### PR TITLE
Use our logging for pycurl messages

### DIFF
--- a/osbs/http.py
+++ b/osbs/http.py
@@ -102,6 +102,8 @@ PYCURL_DEBUG_PREFIX = [
     '}',  # SSL_DATA_OUT
 ]
 
+PYCURL_DEBUG_NOT_STRIPPED = ' !\\n'
+
 
 class Response(object):
     """ let's mock Response object of requests """
@@ -289,8 +291,13 @@ class PycurlAdapter(object):
         try:
             debug_type = PYCURL_DEBUG_PREFIX[debug_type]
         except IndexError:
-            debug_type = '%s' % debug_type
-        logger.debug("pycurl %s: '%s'", debug_type, debug_msg)
+            pass
+        not_stripped = ''
+        if debug_msg.endswith('\n'):
+            debug_msg = debug_msg[:-1]
+        else:
+            not_stripped = PYCURL_DEBUG_NOT_STRIPPED
+        logger.debug("pycurl %s%s: '%s'", debug_type, not_stripped, debug_msg)
 
     def request(self, url, method, data=None, kerberos_auth=False,
                 allow_redirects=True, verify_ssl=True, use_json=False,

--- a/osbs/http.py
+++ b/osbs/http.py
@@ -288,6 +288,22 @@ class PycurlAdapter(object):
         return self._c
 
     def debug_function(self, debug_type, debug_msg):
+        """
+        pycurl's debugfunction callback
+
+        Format pycurl debug messages, prefix it with debug type, strip newlines
+        and log it through python logging module with debug level.
+
+        Messages are prefixed in similar way how curl's TRACE_PLAIN works. See
+        PYCURL_DEBUG_PREFIX for description of prefixes.
+
+        By default all newlines ('\\n') are removed from the debug messages. If
+        new line wasn't found in the message it is prefixed with
+        string PYCURL_DEBUG_NOT_STRIPPED.
+
+        :param debug_type: int, defined by pycurl's API for debugfunction.
+        :param debug_msg: str, defined by pycurl's API for debugfunction.
+        """
         try:
             debug_type = PYCURL_DEBUG_PREFIX[debug_type]
         except IndexError:

--- a/osbs/http.py
+++ b/osbs/http.py
@@ -456,7 +456,7 @@ def pycurl_debug_callback(debug_type, debug_msg):
     try:
         debug_type = PYCURL_DEBUG_PREFIX[debug_type]
     except IndexError:
-        pass
+        debug_type = '#%s' % debug_type
     not_stripped = ''
     if debug_msg.endswith('\n'):
         debug_msg = debug_msg[:-1]


### PR DESCRIPTION
Function is used only if self.verbose is enabled. Debug messages are
prefixed in similar way how curl's TRACE_PLAIN.