### PR TITLE
New API method import_image()

### DIFF
--- a/osbs/api.py
+++ b/osbs/api.py
@@ -315,6 +315,10 @@ class OSBS(object):
         return self.os.set_annotations_on_build(build_id, annotations, namespace=namespace)
 
     @osbsapi
+    def import_image(self, name, namespace=DEFAULT_NAMESPACE):
+        return self.os.import_image(name, namespace=namespace)
+
+    @osbsapi
     def get_token(self):
         return self.os.get_oauth_token()
 

--- a/osbs/cli/main.py
+++ b/osbs/cli/main.py
@@ -182,6 +182,10 @@ def cmd_watch_build(args, osbs):
         print_json_nicely(build_response.json)
 
 
+def cmd_import_image(args, osbs):
+    osbs.import_image(args.NAME[0])
+
+
 def cmd_get_token(args, osbs):  # pylint: disable=W0613
     token = osbs.get_token()
     print(token)
@@ -238,6 +242,10 @@ def cli():
     cancel_build_parser = subparsers.add_parser('cancel-build', help='cancel build specified by ID')
     cancel_build_parser.add_argument("BUILD_ID", help="build ID", nargs=1)
     cancel_build_parser.set_defaults(func=cmd_cancel_build)
+
+    import_image_parser = subparsers.add_parser('import-image', help='import tags for ImageStream')
+    import_image_parser.add_argument("NAME", help="ImageStream name", nargs=1)
+    import_image_parser.set_defaults(func=cmd_import_image)
 
     get_token_parser = subparsers.add_parser('get-token', help='get authentication token')
     get_token_parser.set_defaults(func=cmd_get_token)

--- a/osbs/constants.py
+++ b/osbs/constants.py
@@ -25,6 +25,13 @@ BUILD_FAILED_STATES = ["failed", "error", "cancelled"]  # meaning no image produ
 BUILD_SUCCEEDED_STATES = ["complete"]
 BUILD_PENDING_STATES = ["pending", "new"]
 BUILD_RUNNING_STATES = ["running"]
+
+# Watch response types
+WATCH_ADDED = 'added'
+WATCH_DELETED = 'deleted'
+WATCH_MODIFIED = 'modified'
+WATCH_ERROR = 'error'
+
 # https://github.com/openshift/origin/blob/master/pkg/build/api/types.go
 # type BuildStatus string
 DEFAULT_NAMESPACE = "default"


### PR DESCRIPTION
This new API method tells OpenShift to fetch new ImageStream tags for a repo being tracked in an external registry.