### PR TITLE
[do not merge] Try harder when getting http error response body

### DIFF
--- a/osbs/http.py
+++ b/osbs/http.py
@@ -181,7 +181,7 @@ class Response(object):
                 url = getattr(self.curl, "url", None)
             else:
                 url = None
-            message = self._get_received_data()
+            message = self.content or self._get_received_data()
             raise OsbsNetworkException(url, message, self.status_code)
 
     def _check_curl_errors(self):


### PR DESCRIPTION
This fixes showing http error response body in the particular case of #164. I hope I didn't break something else.

@TomasTomecek - The code in http.py is rather tangled. What do you think about getting rid of the curl-requests emulation layer? I think we're not able to use requests anymore anyway.