### PR TITLE
read config lazily

### DIFF
--- a/osbs/conf.py
+++ b/osbs/conf.py
@@ -7,6 +7,9 @@ of the BSD license. See the LICENSE file for details.
 """
 from __future__ import print_function, absolute_import, unicode_literals
 
+import logging
+import os
+
 try:
     # py2
     import ConfigParser as configparser
@@ -18,6 +21,9 @@ except ImportError:
 
 from osbs.constants import DEFAULT_CONFIGURATION_FILE, DEFAULT_CONFIGURATION_SECTION, GENERAL_CONFIGURATION_SECTION
 from osbs.exceptions import OsbsException
+
+
+logger = logging.getLogger(__name__)
 
 
 class Configuration(object):
@@ -43,14 +49,11 @@ class Configuration(object):
         :param kwargs: keyword arguments, which have highest priority: key is cli argument name
         """
         self.scp = configparser.SafeConfigParser()
-        try:
+        if conf_file and os.path.isfile(conf_file) and os.access(conf_file, os.R_OK):
             self.scp.read(conf_file)
-        except (IOError, TypeError):
-            pass
-        else:
             if not self.scp.has_section(conf_section):
-                raise OsbsException("Specified section '%s' not found in '%s'" %
-                                    (conf_section, conf_file))
+                logger.warning("Specified section '%s' not found in '%s'",
+                               conf_section, conf_file)
         self.conf_section = conf_section
         self.args = cli_args
         self.kwargs = kwargs

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -19,9 +19,8 @@ logger = logging.getLogger("osbs.tests")
 
 
 def test_missing_config():
-    with pytest.raises(OsbsException):
-        os_conf = Configuration(conf_file="/nonexistent/path",
-                                conf_section="default")
+    os_conf = Configuration(conf_file="/nonexistent/path",
+                            conf_section="default")
 
 def test_no_config():
     os_conf = Configuration(conf_file=None,
@@ -31,9 +30,8 @@ def test_no_config():
 
 def test_missing_section():
     with NamedTemporaryFile() as f:
-        with pytest.raises(OsbsException):
-            os_conf = Configuration(conf_file=f.name,
-                                    conf_section="missing")
+        os_conf = Configuration(conf_file=f.name,
+                                conf_section="missing")
 
 def test_no_build_type():
     with NamedTemporaryFile(mode='w+') as f:


### PR DESCRIPTION
So we don't have
```
2015-07-30 11:24:20,991 - osbs - ERROR - Configuration error: Specified section 'default' not found in '/etc/osbs.conf'
```
all over the place