### PR TITLE
Refactor http module

### DIFF
--- a/osbs/cli/main.py
+++ b/osbs/cli/main.py
@@ -18,7 +18,7 @@ from osbs import set_logging
 from osbs.api import OSBS
 from osbs.conf import Configuration
 from osbs.constants import DEFAULT_CONFIGURATION_FILE, DEFAULT_CONFIGURATION_SECTION
-from osbs.exceptions import OsbsNetworkException, OsbsException, OsbsAuthException
+from osbs.exceptions import OsbsNetworkException, OsbsException, OsbsAuthException, OsbsResponseException
 
 
 logger = logging.getLogger('osbs')
@@ -395,6 +395,16 @@ def main():
         else:
             logger.error("Authentication failure: %s",
                          ex.message)
+            return -1
+    except OsbsResponseException as ex:
+        if is_verbose:
+            raise
+        else:
+            if isinstance(ex.json, dict) and 'message' in ex.json:
+                msg = ex.json['message']
+            else:
+                msg = ex.message
+            logger.error("Server returned error %s: %s", ex.status_code, msg)
             return -1
     except Exception as ex:  # pylint: disable=broad-except
         if is_verbose:

--- a/osbs/exceptions.py
+++ b/osbs/exceptions.py
@@ -48,6 +48,7 @@ class OsbsResponseException(OsbsException):
 
 
 class OsbsNetworkException(OsbsException):
+    """ cURL returned an error """
     def __init__(self, url, message, status_code, *args, **kwargs):
         super(OsbsNetworkException, self).__init__("(%s) %s" % (status_code,
                                                                 message),

--- a/osbs/exceptions.py
+++ b/osbs/exceptions.py
@@ -10,6 +10,7 @@ Exceptions raised by OSBS
 """
 from __future__ import print_function, absolute_import, unicode_literals
 
+import json
 from traceback import format_tb
 
 
@@ -45,6 +46,13 @@ class OsbsResponseException(OsbsException):
     def __init__(self, message, status_code, *args, **kwargs):
         super(OsbsResponseException, self).__init__(message, *args, **kwargs)
         self.status_code = status_code
+
+        # try decoding openshift Status object
+        # https://docs.openshift.org/latest/rest_api/openshift_v1.html#v1-status
+        try:
+            self.json = json.loads(message)
+        except ValueError:
+            self.json = None
 
 
 class OsbsNetworkException(OsbsException):

--- a/osbs/http.py
+++ b/osbs/http.py
@@ -8,7 +8,7 @@ of the BSD license. See the LICENSE file for details.
 
 abstraction on top of http api calls
 
-use pycurl (can handle chunked response properly), fallback to requests
+use pycurl (can handle chunked response properly)
 
 chunked implementation for pycurl taken from:
   http://stackoverflow.com/a/21809888/909579
@@ -19,47 +19,25 @@ from __future__ import print_function, absolute_import, unicode_literals
 import re
 import sys
 import json
+import time
 import logging
 import email.parser
-from osbs.exceptions import OsbsException, OsbsNetworkException
+
+import pycurl
+
+from osbs.exceptions import OsbsException, OsbsNetworkException, OsbsResponseException
 
 try:
     # py2
     import httplib
-    from urllib2 import HTTPError
     from StringIO import StringIO as BytesIO
 except ImportError:
     # py3
     import http.client as httplib
-    from urllib.error import HTTPError
     from io import BytesIO
 
 
 logger = logging.getLogger(__name__)
-
-# requests_imported = False
-# pycurl_imported = False
-
-# prefered http lib is pycurl, since it understands chunked responses and kerberos
-import pycurl
-pycurl_imported = True
-
-# FIXME: fix compat abstraction between requests and pycurl
-#        so core doesn't have to care about chosen http lib
-
-# try:
-#     import pycurl
-# except ImportError:
-#     try:
-#         import requests
-#     except ImportError:
-#         print("Neither requests, nor pycurl are available.")
-#         sys.exit(1)
-#     else:
-#         requests_imported = True
-# else:
-#     pycurl_imported = True
-
 
 SELECT_TIMEOUT = 9999
 PYCURL_NETWORK_CODES = [pycurl.E_BAD_CONTENT_ENCODING,
@@ -94,141 +72,217 @@ PYCURL_NETWORK_CODES = [pycurl.E_BAD_CONTENT_ENCODING,
 PYCURL_NETWORK_CODES = [x for x in PYCURL_NETWORK_CODES if x is not None]
 
 
-class Response(object):
-    """ let's mock Response object of requests """
+def parse_headers(all_headers):
+    # headers_buffer contains headers from all responses - even without FOLLOWLOCATION there
+    # might be multiple sets of headers due to 401 Unauthorized. We only care about the last
+    # response.
+    try:
+        raw_headers = all_headers.split("\r\n\r\n")[-2]
+    except IndexError:
+        logger.warning('Incorrectly terminated http headers')
+        raw_headers = all_headers
 
-    def __init__(self, status_code=0, content=b'', curl=None, raw_headers=None):
-        self.status_code = status_code
-        self.content = content
-        self.curl = curl
-        self.curl_multi = getattr(self.curl, "curl_multi", None)
-        self.response_buffer = getattr(self.curl, "response", None)
-        self._raw_headers = raw_headers
-        self._headers = None
+    logger.debug("raw headers: " + repr(raw_headers))
+    encoded_raw_headers = raw_headers.encode('iso-8859-1')
+    try:
+        # py 2
+        # seekable has to be 0, otherwise it won't parse anything
+        m = httplib.HTTPMessage(BytesIO(encoded_raw_headers), seekable=0)
+        m.readheaders()
+        return m.dict
+    except TypeError as ex:
+        # py 3
+        if ex.args[0] == "__init__() got an unexpected keyword argument 'seekable'":
+            parser = email.parser.Parser()
+            m = parser.parsestr(encoded_raw_headers)
+            return dict(m.items())
+        else:
+            raise
 
-    @property
-    def raw_headers(self):
-        """
-        Headers of request (str)
-        """
-        return self._raw_headers
 
-    @raw_headers.setter
-    def raw_headers(self, raw_headers):
-        self._raw_headers = raw_headers
+class HttpSession(object):
+    def __init__(self, verbose=False):
+        self.verbose = verbose
 
-    @property
-    def headers(self):
-        if self._headers is None:
-            logger.debug("raw headers: " + repr(self.raw_headers))
-            encoded_raw_headers = self.raw_headers.encode('iso-8859-1')
-            headers_buffer = BytesIO(encoded_raw_headers)
+    def get(self, url, **kwargs):
+        return self.request(url, "get", **kwargs)
+
+    def post(self, url, **kwargs):
+        return self.request(url, "post", **kwargs)
+
+    def put(self, url, **kwargs):
+        return self.request(url, "put", **kwargs)
+
+    def delete(self, url, **kwargs):
+        return self.request(url, "delete", **kwargs)
+
+    def request(self, url, *args, **kwargs):
+        try:
+            stream = HttpStream(url, *args, verbose=self.verbose, **kwargs)
+            if kwargs.get('stream', False):
+                return stream
+
+            with stream as s:
+                # joining at once is much faster than doing += in a loop
+                all_chunks = list(s.iter_chunks())
+                content = ''.join(all_chunks)
+                return HttpResponse(s.status_code, s.headers, content)
+        except pycurl.error as ex:
+            code = ex.args[0]
             try:
-                # py 2
-                # seekable has to be 0, otherwise it won't parse anything
-                m = httplib.HTTPMessage(headers_buffer, seekable=0)
-                m.readheaders()
-                self._headers = m.dict
-            except TypeError as ex:
-                # py 3
-                if ex.args[0] == "__init__() got an unexpected keyword argument 'seekable'":
-                    parser = email.parser.Parser()
-                    m = parser.parsestr(encoded_raw_headers)
-                    self._headers = dict(m.items())
-                else:
-                    raise
-        return self._headers
+                message = ex.args[1]
+            except IndexError:
+                # happened on rhel 6
+                message = ""
+            if code in PYCURL_NETWORK_CODES:
+                raise OsbsNetworkException(url, message, code, *ex.args[2:],
+                                           cause=ex,
+                                           traceback=sys.exc_info()[2])
 
-    @property
-    def encoding(self):
-        encoding = None
-        if 'content-type' in self.headers:
-            content_type = self.headers['content-type'].lower()
-            match = re.search(r'charset=(\S+)', content_type)
-            if match:
-                encoding = match.group(1)
-        if encoding is None:
-            encoding = 'utf-8'  # assume utf-8
+            raise OsbsException(cause=ex, traceback=sys.exc_info()[2])
 
-        return encoding
 
-    def json(self, check=True):
-        if check:
-            try:
-                self._check_status_code()
-            except HTTPError:
-                logger.exception("Original content with failed response: %s",
-                                 self.content)
-                raise
-        return json.loads(self.content.decode(self.encoding))
+class HttpStream(object):
+    """
+    Handle on HTTP response that is mostly useful for reading the server response incrementally when
+    Transfer-Encoding: chunked is used.
+
+    Users of this class should explicitly free the curl resources associated with it. The preferred
+    way is to use it as a context manager which ensures that it is closed when exception is raised
+    in the middle of reading the stream. Because it doesn't fit into our current API, the class also
+    tries to free the resources when it finishes reading the http stream and also when it's garbage
+    collected.
+    """
+
+    def __init__(self, url, method, data=None, kerberos_auth=False,
+                 allow_redirects=True, verify_ssl=True, use_json=False,
+                 headers=None, stream=False, username=None, password=None, verbose=False):
+        self.finished = False  # have we read all data?
+        self.closed = False    # have we destroyed curl resources?
+
+        self.status_code = 0
+        self.headers = None
+        self.response_buffer = BytesIO()
+        self.headers_buffer = BytesIO()
+
+        self.url = url
+        headers = headers or {}
+        method = method.lower()
+
+        self.c = pycurl.Curl()
+        self.curl_multi = pycurl.CurlMulti()
+
+        if method == 'post':
+            self.c.setopt(pycurl.POST, 1)
+            headers["Expect"] = ""  # openshift can't handle Expect
+        elif method == 'get':
+            self.c.setopt(pycurl.HTTPGET, 1)
+        elif method == 'put':
+            # self.c.setopt(pycurl.PUT, 1)
+            self.c.setopt(pycurl.CUSTOMREQUEST, b"PUT")
+            headers["Expect"] = ""
+        elif method == 'delete':
+            self.c.setopt(pycurl.CUSTOMREQUEST, b"DELETE")
+        else:
+            raise RuntimeError("Unsupported method '%s' for curl call!" % method)
+
+        self.c.setopt(pycurl.COOKIEFILE, b'')
+        self.c.setopt(pycurl.URL, str(url))
+        self.c.setopt(pycurl.WRITEFUNCTION, self.response_buffer.write)
+        self.c.setopt(pycurl.HEADERFUNCTION, self.headers_buffer.write)
+        self.c.setopt(pycurl.SSL_VERIFYPEER, 1 if verify_ssl else 0)
+        self.c.setopt(pycurl.SSL_VERIFYHOST, 2 if verify_ssl else 0)
+        self.c.setopt(pycurl.VERBOSE, 1 if verbose else 0)
+        if username and password:
+            self.c.setopt(pycurl.USERPWD, b"%s:%s" % (username, password))
+
+        if data:
+            # curl sets the method to post if one sets any POSTFIELDS (even '')
+            self.c.setopt(pycurl.POSTFIELDS, data)
+
+        if use_json:
+            headers['Content-Type'] = b'application/json'
+
+        if allow_redirects:
+            self.c.setopt(pycurl.FOLLOWLOCATION, 1)
+
+        if kerberos_auth:
+            self.c.setopt(pycurl.HTTPAUTH, pycurl.HTTPAUTH_GSSNEGOTIATE)
+            self.c.setopt(pycurl.USERPWD, b':')
+
+        if stream:
+            headers['Cache-Control'] = b'no-cache'
+
+        if headers:
+            header_list = []
+            for header_key, header_value in headers.items():
+                header_list.append(str("%s: %s" % (header_key, header_value)))
+            self.c.setopt(pycurl.HTTPHEADER, header_list)
+
+        self.curl_multi.add_handle(self.c)
+
+        # Send request and read all headers. We have all headers once we receive some data or once
+        # the response ends.
+        # NOTE: HTTP response in chunked encoding can contain additional headers ("trailers") in the
+        # last chunk. This is not handled here.
+        while not (self.finished or self._any_data_received()):
+            self._select()
+            self._perform()
+
+        all_headers = self.headers_buffer.getvalue().decode("ascii", 'replace')  # py 2.{6,7} compat
+        self.headers = parse_headers(all_headers)
+        self.status_code = self.c.getinfo(pycurl.HTTP_CODE)
+
+    def _perform(self):
+        while True:
+            ret, num_handles = self.curl_multi.perform()
+            if ret != pycurl.E_CALL_MULTI_PERFORM:
+                # see curl_multi_perform manpage
+                break
+
+        num_q, ok_list, err_list = self.curl_multi.info_read()
+        if num_q != 0:
+            logger.warning("CurlMulti.info_read() has %s remaining messages", num_q)
+
+        if err_list:
+            err_obj = err_list[0]
+            raise OsbsNetworkException(self.url, err_obj[2], err_obj[1])
+
+        self.finished = (num_handles == 0)
+
+    def _select(self):
+        sel = self.curl_multi.select(SELECT_TIMEOUT)
+        if sel == -1:
+            raise OsbsException("CurlMulti.select() timed out")
+        elif sel == 0:
+            # sel==0 means curl_multi_fdset returned -1
+            # manual page suggests sleeping >100ms when this happens:(
+            time.sleep(0.1)
 
     def _any_data_received(self):
         return self.response_buffer.tell() != 0
 
     def _get_received_data(self):
-        if self.response_buffer is None:
-            return ""
-        result = self.response_buffer.getvalue()
+        result = self.response_buffer.getvalue().decode(self.encoding)
         self.response_buffer.truncate(0)
         self.response_buffer.seek(0)
         return result
 
-    def _check_status_code(self):
-        if self.status_code == 0:
-            self.status_code = self.curl.getinfo(pycurl.HTTP_CODE)
-        if self.status_code not in (0, httplib.OK, httplib.CREATED):
-            if self.curl:
-                url = getattr(self.curl, "url", None)
-            else:
-                url = None
-            message = self._get_received_data()
-            raise OsbsNetworkException(url, message, self.status_code)
-
-    def _check_curl_errors(self):
-        for f in self.curl_multi.info_read()[2]:
-            raise pycurl.error(*f[1:])
-
-    def _iter_chunks(self):
+    def iter_chunks(self):
         while True:
-            remaining = self._perform_on_curl()
+            self._perform()
             if self._any_data_received():
-                self._check_status_code()
                 yield self._get_received_data()
-            if remaining == 0:
-                logger.debug("no more handles, quiting curl multi")
+            if self.finished:
                 break
-            sel = self.curl_multi.select(SELECT_TIMEOUT)
-            if sel == -1:
-                raise RuntimeError("error during select")
-        self._check_status_code()
-        self._check_curl_errors()
-        self.close_multi()
+            self._select()
 
-    def _perform_on_curl(self):
-        ret, num_handles = self.curl_multi.perform()
-        if ret == pycurl.E_CALL_MULTI_PERFORM:
-            # on RHEL 6, pycurl is raising this multiple times -- no idea what that means
-            # so, let's log it and ignore it
-            logger.debug("curl multi returned pycurl.E_CALL_MULTI_PERFORM -- "
-                         "this might be an error; or not")
-        return num_handles
+        logger.debug("end of the stream")
+        self.close()
 
     def iter_lines(self):
-        try:
-            chunks = self._iter_chunks()
-            return self._split_lines_from_chunks(chunks)
-        except pycurl.error as ex:
-            code = ex.args[0]
-            message = ex.args[1]
-            if code in PYCURL_NETWORK_CODES:
-                raise OsbsNetworkException("<?>", message, code, *ex.args[2:])
-
-            raise OsbsException(cause=ex, traceback=sys.exc_info()[2])
-        except HTTPError as ex:
-            raise OsbsNetworkException(ex.geturl(), ex.message, ex.code,
-                                       cause=ex, traceback=sys.exc_info()[2])
-        except Exception as ex:
-            raise OsbsException(cause=ex, traceback=sys.exc_info()[2])
+        chunks = self.iter_chunks()
+        return self._split_lines_from_chunks(chunks)
 
     @staticmethod
     def _split_lines_from_chunks(chunks):
@@ -252,184 +306,45 @@ class Response(object):
         if pending is not None:
             yield pending
 
-    def close_multi(self):
-        logger.debug("closing curl multi: %s", id(self.curl_multi))
-        if self.curl_multi is None:
-            logger.warning("curl_multi object is not specified")
-            return
-        # returns (0, [<pycurl.Curl object at 0x27eb9e0>], [])
-        read_info = self.curl_multi.info_read()
-        num_handles = len(read_info[1])
-        logger.debug("%d handles in curl_multi object", num_handles)
-        if num_handles > 0:
-            self.curl_multi.remove_handle(self.curl)
-            self.curl_multi.close()
-
-
-class PycurlAdapter(object):
-    """
-    curl will cache http session
-    """
-
-    def __init__(self, verbose=None):
-        self._c = None
-        self.url = None
-        self.response = BytesIO()
-        self.response_headers = BytesIO()
-        self.verbose = verbose
-
     @property
-    def c(self):
-        if self._c is None:
-            self._c = pycurl.Curl()
-        return self._c
+    def encoding(self):
+        encoding = None
+        if 'content-type' in self.headers:
+            content_type = self.headers['content-type'].lower()
+            match = re.search(r'charset=(\S+)', content_type)
+            if match:
+                encoding = match.group(1)
+        if encoding is None:
+            encoding = 'utf-8'  # assume utf-8
 
-    def request(self, url, method, data=None, kerberos_auth=False,
-                allow_redirects=True, verify_ssl=True, use_json=False,
-                headers=None, stream=False, username=None, password=None):
-        # FIXME: workaround for pycurl bug
-        # self.c.reset()
-        self._c = pycurl.Curl()
+        return encoding
 
-        self.url = url
-        headers = headers or {}
-        method = method.lower()
-
-        if method == 'post':
-            self.c.setopt(pycurl.POST, 1)
-            headers["Expect"] = ""  # openshift can't handle Expect
-        elif method == 'get':
-            self.c.setopt(pycurl.HTTPGET, 1)
-        elif method == 'put':
-            # self.c.setopt(pycurl.PUT, 1)
-            self.c.setopt(pycurl.CUSTOMREQUEST, b"PUT")
-            headers["Expect"] = ""
-        elif method == 'delete':
-            self.c.setopt(pycurl.CUSTOMREQUEST, b"DELETE")
-        else:
-            raise RuntimeError("Unsupported method '%s' for curl call!" % method)
-
-        self.c.setopt(pycurl.COOKIEFILE, b'')
-        self.c.setopt(pycurl.URL, str(url))
-        self.c.setopt(pycurl.WRITEFUNCTION, self.response.write)
-        self.c.setopt(pycurl.HEADERFUNCTION, self.response_headers.write)
-        self.c.setopt(pycurl.SSL_VERIFYPEER, 1 if verify_ssl else 0)
-        self.c.setopt(pycurl.SSL_VERIFYHOST, 2 if verify_ssl else 0)
-        self.c.setopt(pycurl.VERBOSE, 1 if self.verbose else 0)
-        if username and password:
-            self.c.setopt(pycurl.USERPWD, b"%s:%s" % (username, password))
-
-        if data:
-            # curl sets the method to post if one sets any POSTFIELDS (even '')
-            self.c.setopt(pycurl.POSTFIELDS, data)
-
-        if use_json:
-            headers['Content-Type'] = b'application/json'
-
-        if allow_redirects:
-            self.c.setopt(pycurl.FOLLOWLOCATION, 1)
-
-        if kerberos_auth:
-            self.c.setopt(pycurl.HTTPAUTH, pycurl.HTTPAUTH_GSSNEGOTIATE)
-            self.c.setopt(pycurl.USERPWD, b':')
-
-        if stream:
-            headers['Cache-Control'] = b'no-cache'
-            #self.curl.setopt(pycurl.CONNECTTIMEOUT, 5)
-
-        if headers:
-            header_list = []
-            for header_key, header_value in headers.items():
-                header_list.append(str("%s: %s" % (header_key, header_value)))
-            self.c.setopt(pycurl.HTTPHEADER, header_list)
-
-        response = Response()
-        if stream:
-            curl_multi = pycurl.CurlMulti()
-            curl_multi.add_handle(self.c)
-            while response.status_code == 0:
-                sel = curl_multi.select(SELECT_TIMEOUT)  # returns number
-                if sel == -1:
-                    raise OsbsException("error during select")
-                ret, _ = curl_multi.perform()
-                if ret == pycurl.E_CALL_MULTI_PERFORM:
-                    # on RHEL 6, pycurl is raising this multiple times -- no idea what that means
-                    # so, let's log it and ignore it
-                    logger.warning("curl multi returned pycurl.E_CALL_MULTI_PERFORM -- "
-                                   "this might be an error; or not")
-                response.status_code = self.c.getinfo(pycurl.HTTP_CODE)
-            response.content = self.response.getvalue()
-
-            # self.response_headers contains headers from all responses - even
-            # without FOLLOWLOCATION there might be multiple sets of headers
-            # due to 401 Unauthorized. We only care about the last response.
-            allheaders = self.response_headers.getvalue().decode("ascii", 'replace')  # py 2.{6,7} compat
-            response.raw_headers = allheaders.split("\r\n\r\n")[-2]
-
-            response.curl = self.c
-            response.curl_multi = curl_multi
-            response.response_buffer = self.response
-        else:
-            self.c.perform()
-            response.status_code = self.c.getinfo(pycurl.HTTP_CODE)
-            response.content = self.response.getvalue()
-
-            # self.response_headers contains headers from all responses - even
-            # without FOLLOWLOCATION there might be multiple sets of headers
-            # due to 401 Unauthorized. We only care about the last response.
-            allheaders = self.response_headers.getvalue().decode("ascii", 'replace')  # py 2.{6,7} compat
-            try:
-                response.raw_headers = allheaders.split("\r\n\r\n")[-2]
-            except IndexError:
-                logger.warning('Incorrectly terminated http headers')
-                response.raw_headers = allheaders
-
-            # clear buffer
-            self.response.truncate(0)
-            self.response_headers.truncate(0)
-            # FIXME: don't close when we start reusing connection!
+    def close(self):
+        if not self.closed:
+            logger.debug("cleaning up")
+            self.curl_multi.remove_handle(self.c)
             self.c.close()
-        return response
+            self.curl_multi.close()
+        self.closed = True
 
-    def _do_request(self, url, method, **kwargs):
-        try:
-            return self.request(url, method, **kwargs)
-        except pycurl.error as ex:
-            code = ex.args[0]
-            try:
-                message = ex.args[1]
-            except IndexError:
-                # happened on rhel 6
-                message = ""
-            if code in PYCURL_NETWORK_CODES:
-                raise OsbsNetworkException(url, message, code, *ex.args[2:],
-                                           cause=ex,
-                                           traceback=sys.exc_info()[2])
+    def __del__(self):
+        self.close()
 
-            raise OsbsException(cause=ex, traceback=sys.exc_info()[2])
-        except HTTPError as ex:
-            raise OsbsNetworkException(ex.geturl(), ex.message, ex.code,
-                                       cause=ex, traceback=sys.exc_info()[2])
-        except Exception as ex:
-            raise OsbsException(cause=ex, traceback=sys.exc_info()[2])
+    def __enter__(self):
+        return self
 
-    def get(self, url, **kwargs):
-        return self._do_request(url, "get", **kwargs)
-
-    def post(self, url, **kwargs):
-        return self._do_request(url, "post", **kwargs)
-
-    def put(self, url, **kwargs):
-        return self._do_request(url, "put", **kwargs)
-
-    def delete(self, url, **kwargs):
-        return self._do_request(url, "delete", **kwargs)
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()
 
 
-def get_http_session(verbose=None):
-    if pycurl_imported:
-        return PycurlAdapter(verbose=verbose)
-    #elif requests_imported:
-    #    return requests.Session()
-    else:
-        raise OsbsException("no http library imported")
+class HttpResponse(object):
+    def __init__(self, status_code, headers, content):
+        self.status_code = status_code
+        self.headers = headers
+        self.content = content
+
+    def json(self, check=True):
+        if check and self.status_code not in (0, httplib.OK, httplib.CREATED):
+            raise OsbsResponseException(self.content, self.status_code)
+
+        return json.loads(self.content)

--- a/tests/httpbin_test.py
+++ b/tests/httpbin_test.py
@@ -18,20 +18,20 @@ logger = logging.getLogger("osbs.tests")
 def s():
     return HttpSession(verbose=True)
 
-@pytest.mark.skipif(sys.version_info[0] >= 3,
-                    reason="known not to work on Python 3 (#74)")
 def test_single_multi_secure_without_redirs(s):
     response_single = s.get("https://httpbin.org/get")
     logger.debug(response_single.headers)
     logger.debug(response_single.content)
+    assert len(response_single.headers) > 2
+    assert response_single.headers['content-type'] == 'application/json'
     response_multi = s.get("https://httpbin.org/stream/3", stream=True)
     with response_multi as r:
         for line in r.iter_lines():
             logger.debug(line)
+    assert len(response_multi.headers) > 2
+    assert response_multi.headers['content-type'] == 'application/json'
 
 
-@pytest.mark.skipif(sys.version_info[0] >= 3,
-                    reason="known not to work on Python 3 (#74)")
 def test_single_multi_without_redirs(s):
     response_single = s.get("http://httpbin.org/get")
     logger.debug(response_single.headers)
@@ -42,8 +42,6 @@ def test_single_multi_without_redirs(s):
             logger.debug(line)
 
 
-@pytest.mark.skipif(sys.version_info[0] >= 3,
-                    reason="known not to work on Python 3 (#74)")
 def test_single_multi_secure(s):
     response_single = s.get("https://httpbin.org/get", allow_redirects=False)
     logger.debug(response_single.headers)
@@ -54,8 +52,6 @@ def test_single_multi_secure(s):
             logger.debug(line)
 
 
-@pytest.mark.skipif(sys.version_info[0] >= 3,
-                    reason="known not to work on Python 3 (#74)")
 def test_single_multi(s):
     response_single = s.get("http://httpbin.org/get", allow_redirects=False)
     logger.debug(response_single.headers)
@@ -66,8 +62,6 @@ def test_single_multi(s):
             logger.debug(line)
 
 
-@pytest.mark.skipif(sys.version_info[0] >= 3,
-                    reason="known not to work on Python 3 (#74)")
 def test_multi_multi(s):
     response = s.get("http://httpbin.org/stream/3", stream=True)
     logger.debug(response.headers)
@@ -81,8 +75,6 @@ def test_multi_multi(s):
             logger.debug(line)
 
 
-@pytest.mark.skipif(sys.version_info[0] >= 3,
-                    reason="known not to work on Python 3 (#74)")
 def test_single_multi_multi(s):
     response_single = s.get("http://httpbin.org/basic-auth/user/pwd", username="user", password="pwd")
     logger.debug(response_single.headers)
@@ -99,8 +91,6 @@ def test_single_multi_multi(s):
             logger.debug(line)
 
 
-@pytest.mark.skipif(sys.version_info[0] >= 3,
-                    reason="known not to work on Python 3 (#74)")
 def test_multi_single(s):
     response_multi = s.get("http://httpbin.org/stream/3", stream=True)
     logger.debug(response_multi.headers)
@@ -112,15 +102,11 @@ def test_multi_single(s):
     logger.debug(response_single.content)
 
 
-@pytest.mark.skipif(sys.version_info[0] >= 3,
-                    reason="known not to work on Python 3 (#74)")
 def test_utf8_encoding(s):
     response_multi = s.get("http://httpbin.org/encoding/utf8")
     logger.debug(response_multi.headers)
     logger.debug(response_multi.content)
 
-@pytest.mark.skipif(sys.version_info[0] >= 3,
-                    reason="known not to work on Python 3 (#74)")
 def test_raise(s):
     with pytest.raises(RuntimeError):
         with s.get("http://httpbin.org/stream/3", stream=True) as s:

--- a/tests/httpbin_test.py
+++ b/tests/httpbin_test.py
@@ -10,103 +10,103 @@ import sys
 import logging
 import pytest
 
-from osbs.http import get_http_session
+from osbs.http import HttpSession
 
 logger = logging.getLogger("osbs.tests")
 
+@pytest.fixture
+def s():
+    return HttpSession(verbose=True)
 
 @pytest.mark.skipif(sys.version_info[0] >= 3,
                     reason="known not to work on Python 3 (#74)")
-def test_single_multi_secure_without_redirs():
-    s = get_http_session(verbose=True)
+def test_single_multi_secure_without_redirs(s):
     response_single = s.get("https://httpbin.org/get")
     logger.debug(response_single.headers)
     logger.debug(response_single.content)
     response_multi = s.get("https://httpbin.org/stream/3", stream=True)
-    for line in response_multi.iter_lines():
-        logger.debug(line)
+    with response_multi as r:
+        for line in r.iter_lines():
+            logger.debug(line)
 
 
 @pytest.mark.skipif(sys.version_info[0] >= 3,
                     reason="known not to work on Python 3 (#74)")
-def test_single_multi_without_redirs():
-    s = get_http_session(verbose=True)
+def test_single_multi_without_redirs(s):
     response_single = s.get("http://httpbin.org/get")
     logger.debug(response_single.headers)
     logger.debug(response_single.content)
     response_multi = s.get("http://httpbin.org/stream/3", stream=True)
-    for line in response_multi.iter_lines():
-        logger.debug(line)
+    with response_multi as r:
+        for line in r.iter_lines():
+            logger.debug(line)
 
 
 @pytest.mark.skipif(sys.version_info[0] >= 3,
                     reason="known not to work on Python 3 (#74)")
-def test_single_multi_secure():
-    s = get_http_session(verbose=True)
+def test_single_multi_secure(s):
     response_single = s.get("https://httpbin.org/get", allow_redirects=False)
     logger.debug(response_single.headers)
     logger.debug(response_single.content)
     response_multi = s.get("https://httpbin.org/stream/3", stream=True, allow_redirects=False)
-    for line in response_multi.iter_lines():
-        logger.debug(line)
+    with response_multi as r:
+        for line in r.iter_lines():
+            logger.debug(line)
 
 
 @pytest.mark.skipif(sys.version_info[0] >= 3,
                     reason="known not to work on Python 3 (#74)")
-def test_single_multi():
-    s = get_http_session(verbose=True)
+def test_single_multi(s):
     response_single = s.get("http://httpbin.org/get", allow_redirects=False)
     logger.debug(response_single.headers)
     logger.debug(response_single.content)
     response_multi = s.get("http://httpbin.org/stream/3", stream=True, allow_redirects=False)
-    for line in response_multi.iter_lines():
-        logger.debug(line)
+    with response_multi as r:
+        for line in r.iter_lines():
+            logger.debug(line)
 
 
 @pytest.mark.skipif(sys.version_info[0] >= 3,
                     reason="known not to work on Python 3 (#74)")
-def test_multi_multi():
-    s = get_http_session(verbose=True)
+def test_multi_multi(s):
     response = s.get("http://httpbin.org/stream/3", stream=True)
     logger.debug(response.headers)
-    logger.debug(response.content)
-    for line in response.iter_lines():
-        logger.debug(line)
+    with response as r:
+        for line in r.iter_lines():
+            logger.debug(line)
     response = s.get("http://httpbin.org/stream/3", stream=True)
     logger.debug(response.headers)
-    logger.debug(response.content)
-    for line in response.iter_lines():
-        logger.debug(line)
+    with response as r:
+        for line in r.iter_lines():
+            logger.debug(line)
 
 
 @pytest.mark.skipif(sys.version_info[0] >= 3,
                     reason="known not to work on Python 3 (#74)")
-def test_single_multi_multi():
-    s = get_http_session(verbose=True)
+def test_single_multi_multi(s):
     response_single = s.get("http://httpbin.org/basic-auth/user/pwd", username="user", password="pwd")
     logger.debug(response_single.headers)
     logger.debug(response_single.content)
     response = s.get("http://httpbin.org/stream/3", stream=True)
     logger.debug(response.headers)
-    logger.debug(response.content)
-    for line in response.iter_lines():
-        logger.debug(line)
+    with response as r:
+        for line in r.iter_lines():
+            logger.debug(line)
     response = s.get("http://httpbin.org/stream/5", stream=True)
     logger.debug(response.headers)
-    logger.debug(response.content)
-    for line in response.iter_lines():
-        logger.debug(line)
+    with response as r:
+        for line in r.iter_lines():
+            logger.debug(line)
 
 
 @pytest.mark.skipif(sys.version_info[0] >= 3,
                     reason="known not to work on Python 3 (#74)")
-def test_multi_single():
-    s = get_http_session(verbose=True)
+def test_multi_single(s):
     response_multi = s.get("http://httpbin.org/stream/3", stream=True)
     logger.debug(response_multi.headers)
-    logger.debug(response_multi.content)
-    for line in response_multi.iter_lines():
-        logger.debug(line)
+    with response_multi as r:
+        for line in r.iter_lines():
+            logger.debug(line)
     response_single = s.get("http://httpbin.org/get")
     logger.debug(response_single.headers)
     logger.debug(response_single.content)
@@ -114,8 +114,15 @@ def test_multi_single():
 
 @pytest.mark.skipif(sys.version_info[0] >= 3,
                     reason="known not to work on Python 3 (#74)")
-def test_utf8_encoding():
-    s = get_http_session(verbose=True)
+def test_utf8_encoding(s):
     response_multi = s.get("http://httpbin.org/encoding/utf8")
     logger.debug(response_multi.headers)
     logger.debug(response_multi.content)
+
+@pytest.mark.skipif(sys.version_info[0] >= 3,
+                    reason="known not to work on Python 3 (#74)")
+def test_raise(s):
+    with pytest.raises(RuntimeError):
+        with s.get("http://httpbin.org/stream/3", stream=True) as s:
+            raise RuntimeError("hi")
+    assert s.closed

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -948,8 +948,6 @@ def test_build_logs_api_from_docker(osbs, decode_docker_logs):
     assert logs.split('\n')[0].find("Step ") != -1
 
 
-@pytest.mark.skipif(sys.version_info[0] >= 3,
-                    reason="known not to work on Python 3 (#74)")
 def test_parse_headers():
     conn = Connection("0.5.4")
     rm = ResponseMapping("0.5.4", lookup=conn.get_definition_for)

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -29,8 +29,8 @@ from osbs.constants import BUILD_FINISHED_STATES
 from osbs.constants import SIMPLE_BUILD_TYPE, PROD_BUILD_TYPE, PROD_WITHOUT_KOJI_BUILD_TYPE
 from osbs.constants import PROD_WITH_SECRET_BUILD_TYPE
 from osbs.exceptions import OsbsValidationException
-from osbs.http import Response
 from osbs import utils
+from osbs.http import HttpResponse, parse_headers
 from tests.constants import TEST_BUILD, TEST_BUILD_CONFIG, TEST_LABEL, TEST_LABEL_VALUE
 from tests.constants import TEST_GIT_URI, TEST_GIT_REF, TEST_GIT_BRANCH, TEST_USER
 from tests.constants import TEST_COMPONENT, TEST_TARGET, TEST_ARCH
@@ -910,13 +910,13 @@ def test_get_build_request_api(osbs):
 def test_set_labels_on_build_api(osbs):
     labels = {'label1': 'value1', 'label2': 'value2'}
     response = osbs.set_labels_on_build(TEST_BUILD, labels)
-    assert isinstance(response, Response)
+    assert isinstance(response, HttpResponse)
 
 
 def test_set_annotations_on_build_api(osbs):
     annotations = {'ann1': 'value1', 'ann2': 'value2'}
     response = osbs.set_annotations_on_build(TEST_BUILD, annotations)
-    assert isinstance(response, Response)
+    assert isinstance(response, HttpResponse)
 
 
 def test_get_token_api(osbs):
@@ -929,8 +929,8 @@ def test_get_user_api(osbs):
 
 def test_build_logs_api(osbs):
     logs = osbs.get_build_logs(TEST_BUILD)
-    assert isinstance(logs, tuple(list(six.string_types) + [bytes]))
-    assert logs == b"line 1"
+    assert isinstance(logs, six.string_types)
+    assert logs == "line 1"
 
 
 def test_build_logs_api_follow(osbs):
@@ -958,11 +958,11 @@ def test_parse_headers():
     file_name = value["get"]["file"]
     raw_headers = rm.get_response_content(file_name)
 
-    r = Response(raw_headers=raw_headers)
+    headers = parse_headers(raw_headers)
 
-    assert r.headers is not None
-    assert len(r.headers.items()) > 0
-    assert r.headers["location"]
+    assert headers is not None
+    assert len(headers.items()) > 0
+    assert headers["location"]
 
 
 def test_build_id_param_shorten_id():


### PR DESCRIPTION
Blocking and streaming http responses now live in a separate classes.  The blocking response is implemented using the streaming response. Each streaming response has its own curl and curl_multi handle.

The streaming response has to be explicitly closed. The preferred way is to use it as a context manager which ensures that it is closed when exception is raised in the middle of reading the stream. Because it doesn't fit into our current API, the class also tries to free the curl resources when it finishes reading the http stream and also when it's gargabe collected.
