### PR TITLE
Temporarily disable build triggers

### DIFF
--- a/inputs/prod.json
+++ b/inputs/prod.json
@@ -8,17 +8,6 @@
     }
   },
   "spec": {
-    "triggers": [
-      {
-        "type": "ImageChange",
-        "imageChange": {
-          "from": {
-            "kind": "ImageStreamTag",
-            "name": "{{BASE_IMAGE_STREAM}}"
-          }
-        }
-      }
-    ],
     "source": {
       "type": "Git",
       "git": {

--- a/inputs/simple.json
+++ b/inputs/simple.json
@@ -8,17 +8,6 @@
     }
   },
   "spec": {
-    "triggers": [
-      {
-        "type": "ImageChange",
-        "imageChange": {
-          "from": {
-            "kind": "ImageStreamTag",
-            "name": "{{BASE_IMAGE_STREAM}}"
-          }
-        }
-      }
-    ],
     "source": {
       "type": "Git",
       "git": {

--- a/osbs/build/build_request.py
+++ b/osbs/build/build_request.py
@@ -167,8 +167,9 @@ class CommonBuild(BuildRequest):
 
         tag_with_registry = self.spec.registry_uri.value + "/" + self.spec.image_tag.value
         self.template['spec']['output']['to']['name'] = tag_with_registry
-        self.template['spec']['triggers'][0]['imageChange']['from']['name'] = \
-            self.spec.base_image.value
+        if 'triggers' in self.template['spec']:
+            self.template['spec']['triggers']\
+                [0]['imageChange']['from']['name'] = self.spec.base_image.value
 
         if (self.spec.yum_repourls.value is not None and
                 self.dj.dock_json_has_plugin_conf('prebuild_plugins', "add_yum_repo_by_url")):

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -282,8 +282,8 @@ def test_render_simple_request():
     build_json = build_request.render()
 
     assert build_json["metadata"]["name"] == "%s-%s" % (TEST_COMPONENT, TEST_GIT_REF)
-    assert build_json["spec"]["triggers"][0]["imageChange"]["from"]["name"] == \
-        os.path.join(kwargs["registry_uri"], kwargs["base_image"])
+    #assert build_json["spec"]["triggers"][0]["imageChange"]["from"]["name"] == \
+    #    os.path.join(kwargs["registry_uri"], kwargs["base_image"])
     assert build_json["spec"]["source"]["git"]["uri"] == "http://git/"
     assert build_json["spec"]["source"]["git"]["ref"] == "master"
     assert build_json["spec"]["output"]["to"]["name"].startswith(
@@ -334,8 +334,8 @@ def test_render_prod_request_with_repo():
     build_json = build_request.render()
 
     assert build_json["metadata"]["name"] == "%s-%s" % (TEST_COMPONENT, TEST_GIT_REF)
-    assert build_json["spec"]["triggers"][0]["imageChange"]["from"]["name"] == \
-        os.path.join(kwargs["registry_uri"], kwargs["base_image"])
+    #assert build_json["spec"]["triggers"][0]["imageChange"]["from"]["name"] == \
+    #    os.path.join(kwargs["registry_uri"], kwargs["base_image"])
     assert build_json["spec"]["source"]["git"]["uri"] == "http://git/"
     assert build_json["spec"]["source"]["git"]["ref"] == "master"
     assert build_json["spec"]["output"]["to"]["name"].startswith(
@@ -406,8 +406,8 @@ def test_render_prod_request():
     build_json = build_request.render()
 
     assert build_json["metadata"]["name"] == "%s-%s" % (TEST_COMPONENT, TEST_GIT_REF)
-    assert build_json["spec"]["triggers"][0]["imageChange"]["from"]["name"] == \
-        os.path.join(kwargs["registry_uri"], kwargs["base_image"])
+    #assert build_json["spec"]["triggers"][0]["imageChange"]["from"]["name"] == \
+    #    os.path.join(kwargs["registry_uri"], kwargs["base_image"])
     assert build_json["spec"]["source"]["git"]["uri"] == "http://git/"
     assert build_json["spec"]["source"]["git"]["ref"] == "master"
     assert build_json["spec"]["output"]["to"]["name"].startswith(
@@ -475,8 +475,8 @@ def test_render_prod_without_koji_request():
     build_json = build_request.render()
 
     assert build_json["metadata"]["name"] == "%s-%s" % (TEST_COMPONENT, TEST_GIT_REF)
-    assert build_json["spec"]["triggers"][0]["imageChange"]["from"]["name"] == \
-        os.path.join(kwargs["registry_uri"], kwargs["base_image"])
+    #assert build_json["spec"]["triggers"][0]["imageChange"]["from"]["name"] == \
+    #    os.path.join(kwargs["registry_uri"], kwargs["base_image"])
     assert build_json["spec"]["source"]["git"]["uri"] == "http://git/"
     assert build_json["spec"]["source"]["git"]["ref"] == "master"
     assert build_json["spec"]["output"]["to"]["name"].startswith(


### PR DESCRIPTION
This is for several reasons:

 * currently Origin does not understand triggers from named ImageStreamTags
 * additional plugins will need to be enabled for rebuild functionality
 * the triggering ImageStreamTag is not set correctly at the moment (#192)

Note that `CommonBuild.render()` has been changed so that it only sets the trigger From field if there is a trigger to set, and condition should remain even when triggers are enabled as some BuildConfigs will be created without triggers.