### PR TITLE
Imagestream naming

### DIFF
--- a/inputs/prod_inner.json
+++ b/inputs/prod_inner.json
@@ -89,6 +89,15 @@
         "image_id": "BUILT_IMAGE_ID"
       },
       "name": "all_rpm_packages"
+    },
+    {
+      "args": {
+        "imagestream": "{{IMAGESTREAM}}",
+        "docker_image_repo": "{{DOCKER_IMAGE_REPO}}",
+        "url": "{{OPENSHIFT_URI}}",
+        "verify_ssl": false
+      },
+      "name": "import_image"
     }
   ],
   "exit_plugins": [

--- a/inputs/simple_inner.json
+++ b/inputs/simple_inner.json
@@ -1,15 +1,6 @@
 {
   "prebuild_plugins": [
     {
-      "args": {
-        "label_key": "is_autorebuild",
-        "label_value": "true",
-        "url": "{{OPENSHIFT_URI}}",
-        "verify_ssl": false
-      },
-      "name": "check_and_set_rebuild"
-    },
-    {
       "name": "pull_base_image",
       "args": {
         "parent_registry": "{{REGISTRY_URI}}",
@@ -29,15 +20,6 @@
         "image_id": "BUILT_IMAGE_ID"
       },
       "name": "all_rpm_packages"
-    },
-    {
-      "args": {
-        "imagestream": "{{IMAGESTREAM}}",
-        "docker_image_repo": "{{DOCKER_IMAGE_REPO}}",
-        "url": "{{OPENSHIFT_URI}}",
-        "verify_ssl": false
-      },
-      "name": "import_image"
     }
   ],
   "exit_plugins": [

--- a/inputs/simple_inner.json
+++ b/inputs/simple_inner.json
@@ -29,6 +29,15 @@
         "image_id": "BUILT_IMAGE_ID"
       },
       "name": "all_rpm_packages"
+    },
+    {
+      "args": {
+        "imagestream": "{{IMAGESTREAM}}",
+        "docker_image_repo": "{{DOCKER_IMAGE_REPO}}",
+        "url": "{{OPENSHIFT_URI}}",
+        "verify_ssl": false
+      },
+      "name": "import_image"
     }
   ],
   "exit_plugins": [

--- a/osbs/api.py
+++ b/osbs/api.py
@@ -171,7 +171,7 @@ class OSBS(object):
     @osbsapi
     def create_prod_build(self, git_uri, git_ref, git_branch, user, component, target,
                           architecture, yum_repourls=None, namespace=DEFAULT_NAMESPACE, **kwargs):
-        base_image = utils.get_base_image(git_uri, git_ref)
+        df_parser = utils.get_df_parser(git_uri, git_ref)
         build_request = self.get_build_request(PROD_BUILD_TYPE)
         build_request.set_params(
             git_uri=git_uri,
@@ -179,7 +179,8 @@ class OSBS(object):
             git_branch=git_branch,
             user=user,
             component=component,
-            base_image=base_image,
+            base_image=df_parser.baseimage,
+            name_label=df_parser.labels['Name'],
             registry_uri=self.build_conf.get_registry_uri(),
             openshift_uri=self.os_conf.get_openshift_base_uri(),
             kojiroot=self.build_conf.get_kojiroot(),
@@ -203,7 +204,7 @@ class OSBS(object):
     def create_prod_with_secret_build(self, git_uri, git_ref, git_branch, user, component,
                                       target, architecture, yum_repourls=None,
                                       namespace=DEFAULT_NAMESPACE, **kwargs):
-        base_image = utils.get_base_image(git_uri, git_ref)
+        df_parser = utils.get_df_parser(git_uri, git_ref)
         build_request = self.get_build_request(PROD_WITH_SECRET_BUILD_TYPE)
         build_request.set_params(
             git_uri=git_uri,
@@ -211,7 +212,8 @@ class OSBS(object):
             git_branch=git_branch,
             user=user,
             component=component,
-            base_image=base_image,
+            base_image=df_parser.baseimage,
+            name_label=df_parser.labels['Name'],
             registry_uri=self.build_conf.get_registry_uri(),
             openshift_uri=self.os_conf.get_openshift_base_uri(),
             kojiroot=self.build_conf.get_kojiroot(),
@@ -239,7 +241,7 @@ class OSBS(object):
     def create_prod_without_koji_build(self, git_uri, git_ref, git_branch, user, component,
                                        architecture, yum_repourls=None,
                                        namespace=DEFAULT_NAMESPACE, **kwargs):
-        base_image = utils.get_base_image(git_uri, git_ref)
+        df_parser = utils.get_df_parser(git_uri, git_ref)
         build_request = self.get_build_request(PROD_BUILD_TYPE)
         build_request.set_params(
             git_uri=git_uri,
@@ -247,7 +249,8 @@ class OSBS(object):
             git_branch=git_branch,
             user=user,
             component=component,
-            base_image=base_image,
+            base_image=df_parser.baseimage,
+            name_label=df_parser.labels['Name'],
             registry_uri=self.build_conf.get_registry_uri(),
             openshift_uri=self.os_conf.get_openshift_base_uri(),
             sources_command=self.build_conf.get_sources_command(),
@@ -266,7 +269,7 @@ class OSBS(object):
     @osbsapi
     def create_simple_build(self, git_uri, git_ref, git_branch, user, component, yum_repourls=None,
                             namespace=DEFAULT_NAMESPACE, **kwargs):
-        base_image = utils.get_base_image(git_uri, git_ref)
+        df_parser = utils.get_df_parser(git_uri, git_ref)
         build_request = self.get_build_request(SIMPLE_BUILD_TYPE)
         build_request.set_params(
             git_uri=git_uri,
@@ -274,7 +277,8 @@ class OSBS(object):
             git_branch=git_branch,
             user=user,
             component=component,
-            base_image=base_image,
+            base_image=df_parser.baseimage,
+            name_label=df_parser.labels['Name'],
             registry_uri=self.build_conf.get_registry_uri(),
             openshift_uri=self.os_conf.get_openshift_base_uri(),
             yum_repourls=yum_repourls,

--- a/osbs/build/build_request.py
+++ b/osbs/build/build_request.py
@@ -192,6 +192,9 @@ class CommonBuild(BuildRequest):
                                       self.spec.imagestream_url.value)
             self.dj.dock_json_set_arg('postbuild_plugins', 'import_image', 'url',
                                       self.spec.openshift_uri.value)
+            if self.spec.use_auth.value is not None:
+                self.dj.dock_json_set_arg('postbuild_plugins', 'import_image', 'use_auth',
+                                          self.spec.use_auth.value)
 
     def validate_input(self):
         self.spec.validate()

--- a/osbs/build/build_request.py
+++ b/osbs/build/build_request.py
@@ -169,7 +169,7 @@ class CommonBuild(BuildRequest):
         self.template['spec']['output']['to']['name'] = tag_with_registry
         if 'triggers' in self.template['spec']:
             self.template['spec']['triggers']\
-                [0]['imageChange']['from']['name'] = self.spec.base_image.value
+                [0]['imageChange']['from']['name'] = self.spec.trigger_imagestream_name.value
 
         if (self.spec.yum_repourls.value is not None and
                 self.dj.dock_json_has_plugin_conf('prebuild_plugins', "add_yum_repo_by_url")):
@@ -184,6 +184,14 @@ class CommonBuild(BuildRequest):
                 # For compatibility with older osbs.conf files
                 self.dj.dock_json_set_arg('postbuild_plugins', "store_metadata_in_osv3",
                                           "use_auth", self.spec.use_auth.value)
+
+        if self.dj.dock_json_has_plugin_conf('postbuild_plugins', 'import_image'):
+            self.dj.dock_json_set_arg('postbuild_plugins', 'import_image', 'imagestream',
+                                      self.spec.imagestream_name.value)
+            self.dj.dock_json_set_arg('postbuild_plugins', 'import_image', 'docker_image_repo',
+                                      self.spec.imagestream_url.value)
+            self.dj.dock_json_set_arg('postbuild_plugins', 'import_image', 'url',
+                                      self.spec.openshift_uri.value)
 
     def validate_input(self):
         self.spec.validate()

--- a/osbs/build/spec.py
+++ b/osbs/build/spec.py
@@ -147,9 +147,10 @@ class CommonSpec(BuildTypeSpec):
             raise OsbsValidationException("yum_repourls must be a list")
         self.yum_repourls.value = yum_repourls or []
         self.use_auth.value = use_auth
-        self.name.value = '%s-%s' % (self.component.value, self.git_branch.value)
+        self.name.value = name_label.replace('/', '-')
         self.trigger_imagestream_name.value = get_imagestream_name_from_image(base_image)
-        self.imagestream_name.value = name_label.replace('/', '-')
+        # imagestream and buildconfig have precisely the same name
+        self.imagestream_name.value = self.name.value
         self.imagestream_url.value = os.path.join(self.registry_uri.value, name_label)
 
 

--- a/osbs/build/spec.py
+++ b/osbs/build/spec.py
@@ -16,6 +16,7 @@ import os
 import re
 from osbs.constants import DEFAULT_GIT_REF
 from osbs.exceptions import OsbsValidationException
+from osbs.utils import get_imagestream_name_from_image
 
 
 logger = logging.getLogger(__name__)
@@ -110,7 +111,9 @@ class CommonSpec(BuildTypeSpec):
     git_branch = BuildParam('git_branch')
     user = UserParam()
     component = BuildParam('component')
-    base_image = BuildParam('base_image')
+    trigger_imagestream_name = BuildParam('trigger_imagestream_name')
+    imagestream_name = BuildParam('imagestream_name')
+    imagestream_url = BuildParam('imagestream_url')
     registry_uri = BuildParam('registry_uri')
     openshift_uri = BuildParam('openshift_uri')
     name = BuildIDParam()
@@ -128,8 +131,8 @@ class CommonSpec(BuildTypeSpec):
         ]
 
     def set_params(self, git_uri=None, git_ref=None, git_branch=None, registry_uri=None, user=None,
-                   component=None, base_image=None, openshift_uri=None, yum_repourls=None,
-                   use_auth=None, **kwargs):
+                   component=None, base_image=None, name_label=None, openshift_uri=None,
+                   yum_repourls=None, use_auth=None, **kwargs):
         self.git_uri.value = git_uri
         self.git_ref.value = git_ref
         self.git_branch.value = git_branch
@@ -145,7 +148,9 @@ class CommonSpec(BuildTypeSpec):
         self.yum_repourls.value = yum_repourls or []
         self.use_auth.value = use_auth
         self.name.value = '%s-%s' % (self.component.value, self.git_branch.value)
-        self.base_image.value = os.path.join(registry_uri, base_image)
+        self.trigger_imagestream_name.value = get_imagestream_name_from_image(base_image)
+        self.imagestream_name.value = name_label.replace('/', '-')
+        self.imagestream_url.value = os.path.join(self.registry_uri.value, name_label)
 
 
 class ProdSpec(CommonSpec):

--- a/osbs/utils.py
+++ b/osbs/utils.py
@@ -61,4 +61,4 @@ def get_imagestream_name_from_image(image):
     if ':' in ret:
         ret = ret[:ret.index(':')]
 
-    return ret
+    return ret.replace('/', '-')

--- a/osbs/utils.py
+++ b/osbs/utils.py
@@ -43,12 +43,22 @@ def checkout_git_repo(uri, commit):
     return tmpdir
 
 
-def get_base_image_from_dir(repo_dir):
-    df_path = os.path.join(repo_dir, 'Dockerfile')
-    df = DockerfileParser(df_path)
-    return df.baseimage
-
-
-def get_base_image(git_uri, git_ref):
+def get_df_parser(git_uri, git_ref):
     code_dir = checkout_git_repo(git_uri, git_ref)
-    return get_base_image_from_dir(code_dir)
+    return DockerfileParser(os.path.join(code_dir, 'Dockerfile'))
+
+
+def get_imagestream_name_from_image(image):
+    # this duplicates some logic with atomic_reactor.util.ImageName,
+    # but I don't think it's worth it to depend on AR just for this
+    ret = image
+    parts = image.split('/', 2)
+    if len(parts) == 2:
+        if '.' in parts[0] or ':' in parts[0]:
+            ret = parts[1]
+    elif len(parts) == 3:
+        ret = '%s/%s' % (parts[1], parts[2])
+    if ':' in ret:
+        ret = ret[:ret.index(':')]
+
+    return ret

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -8,7 +8,7 @@ of the BSD license. See the LICENSE file for details.
 from __future__ import absolute_import, unicode_literals
 
 TEST_BUILD = "test-build-123"
-TEST_BUILD_CONFIG = "test-build-config-123"
+TEST_BUILD_CONFIG = "fedora23-something"
 TEST_GIT_URI = "git://hostname/path"
 TEST_GIT_REF = "master"
 TEST_USER = "user"
@@ -18,4 +18,3 @@ TEST_ARCH = "x86_64"
 TEST_BUILD_POD = "build-test-build-123"
 TEST_LABEL = "test-label"
 TEST_LABEL_VALUE = "sample-value"
-

--- a/tests/fake_api.py
+++ b/tests/fake_api.py
@@ -16,7 +16,7 @@ from osbs.core import Openshift
 from osbs.http import Response
 from osbs.conf import Configuration
 from osbs.api import OSBS
-from tests.constants import TEST_BUILD, TEST_COMPONENT, TEST_GIT_REF
+from tests.constants import TEST_BUILD, TEST_COMPONENT, TEST_GIT_REF, TEST_BUILD_CONFIG
 from tempfile import NamedTemporaryFile
 
 try:
@@ -98,20 +98,19 @@ DEFINITION = {
             "file": "created_build_config_test-build-config-123.json",
         }
     },
-    "/osapi/v1beta3/namespaces/default/buildconfigs/%s-%s/instantiate" % \
-        (TEST_COMPONENT, TEST_GIT_REF): {
+    "/osapi/v1beta3/namespaces/default/buildconfigs/%s/instantiate" % TEST_BUILD_CONFIG: {
         "post": {
             "file": "instantiated_test-build-config-123.json",
         }
     },
     # use both version with ending slash and without it
-    "/osapi/v1beta3/namespaces/default/buildconfigs/%s-%s" % (TEST_COMPONENT, TEST_GIT_REF): {
+    "/osapi/v1beta3/namespaces/default/buildconfigs/%s" % TEST_BUILD_CONFIG: {
         "get": {
             "custom_callback": buildconfig_not_found,
             "file": "not_found_build-config-component-master.json",
         }
     },
-    "/osapi/v1beta3/namespaces/default/buildconfigs/%s-%s/" % (TEST_COMPONENT, TEST_GIT_REF): {
+    "/osapi/v1beta3/namespaces/default/buildconfigs/%s/" % TEST_BUILD_CONFIG: {
         "get": {
             "custom_callback": buildconfig_not_found,
             "file": "not_found_build-config-component-master.json",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,11 +13,11 @@ def test_deep_update():
 @pytest.mark.parametrize(('img', 'expected'), [
     ('fedora23', 'fedora23'),
     ('fedora23:sometag', 'fedora23'),
-    ('fedora23/python', 'fedora23/python'),
-    ('fedora23/python:sometag', 'fedora23/python'),
+    ('fedora23/python', 'fedora23-python'),
+    ('fedora23/python:sometag', 'fedora23-python'),
     ('docker.io/fedora23', 'fedora23'),
-    ('docker.io/fedora23/python', 'fedora23/python'),
-    ('docker.io/fedora23/python:sometag', 'fedora23/python'),
+    ('docker.io/fedora23/python', 'fedora23-python'),
+    ('docker.io/fedora23/python:sometag', 'fedora23-python'),
 ])
 def test_get_imagestream_name_from_image(img, expected):
     assert get_imagestream_name_from_image(img) == expected

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,6 @@
-from osbs.utils import deep_update
+import pytest
+
+from osbs.utils import deep_update, get_imagestream_name_from_image
 
 
 def test_deep_update():
@@ -6,3 +8,16 @@ def test_deep_update():
     y = {'b': {'b1': 'newB1', 'b3': 'B3'}, 'c': 'C'}
     deep_update(x, y)
     assert x == {'a': 'A', 'b': {'b1': 'newB1', 'b2': 'B2', 'b3': 'B3'}, 'c': 'C'}
+
+
+@pytest.mark.parametrize(('img', 'expected'), [
+    ('fedora23', 'fedora23'),
+    ('fedora23:sometag', 'fedora23'),
+    ('fedora23/python', 'fedora23/python'),
+    ('fedora23/python:sometag', 'fedora23/python'),
+    ('docker.io/fedora23', 'fedora23'),
+    ('docker.io/fedora23/python', 'fedora23/python'),
+    ('docker.io/fedora23/python:sometag', 'fedora23/python'),
+])
+def test_get_imagestream_name_from_image(img, expected):
+    assert get_imagestream_name_from_image(img) == expected

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -239,6 +239,7 @@ def test_render_simple_request_incorrect_postbuild(tmpdir):
         'user': "john-foo",
         'component': "component",
         'base_image': 'fedora:latest',
+        'name_label': 'fedora/resultingimage',
         'registry_uri': "registry.example.com",
         'openshift_uri': "http://openshift/",
     }
@@ -275,6 +276,7 @@ def test_render_simple_request():
         'user': "john-foo",
         'component': TEST_COMPONENT,
         'base_image': 'fedora:latest',
+        'name_label': 'fedora/resultingimage',
         'registry_uri': "http://registry.example.com:5000",
         'openshift_uri': "http://openshift/",
     }
@@ -318,6 +320,7 @@ def test_render_prod_request_with_repo():
         'user': "john-foo",
         'component': TEST_COMPONENT,
         'base_image': 'fedora:latest',
+        'name_label': 'fedora/resultingimage',
         'registry_uri': "registry.example.com",
         'openshift_uri': "http://openshift/",
         'koji_target': "koji-target",
@@ -391,6 +394,7 @@ def test_render_prod_request():
         'user': "john-foo",
         'component': TEST_COMPONENT,
         'base_image': 'fedora:latest',
+        'name_label': 'fedora/resultingimage',
         'registry_uri': "registry.example.com",
         'openshift_uri': "http://openshift/",
         'koji_target': "koji-target",
@@ -463,6 +467,7 @@ def test_render_prod_without_koji_request():
         'user': "john-foo",
         'component': TEST_COMPONENT,
         'base_image': 'fedora:latest',
+        'name_label': 'fedora/resultingimage',
         'registry_uri': "registry.example.com",
         'openshift_uri': "http://openshift/",
         'sources_command': "make",
@@ -532,6 +537,7 @@ def test_render_prod_with_secret_request():
         'user': "john-foo",
         'component': TEST_COMPONENT,
         'base_image': 'fedora:latest',
+        'name_label': 'fedora/resultingimage',
         'registry_uri': "",
         'pulp_registry': "registry.example.com",
         'nfs_server_path': "server:path",
@@ -580,6 +586,7 @@ def test_render_with_yum_repourls():
         'user': "john-foo",
         'component': TEST_COMPONENT,
         'base_image': 'fedora:latest',
+        'name_label': 'fedora/resultingimage',
         'registry_uri': "registry.example.com",
         'openshift_uri': "http://openshift/",
         'koji_target': "koji-target",
@@ -648,6 +655,7 @@ def test_render_prod_with_pulp_no_auth():
         'user': "john-foo",
         'component': TEST_COMPONENT,
         'base_image': 'fedora:latest',
+        'name_label': 'fedora/resultingimage',
         'registry_uri': "registry.example.com",
         'openshift_uri': "http://openshift/",
         'sources_command': "make",
@@ -696,8 +704,11 @@ def test_list_builds_api(osbs):
 
 def test_create_prod_build(osbs):
     # TODO: test situation when a buildconfig already exists
-    flexmock(utils).should_receive('get_base_image').\
-        with_args(TEST_GIT_URI, TEST_GIT_REF).and_return('fedora23/python')
+    class MockParser(object):
+        labels = {'Name': 'fedora23/something'}
+        baseimage = 'fedora23/python'
+    flexmock(utils).should_receive('get_df_parser').\
+        with_args(TEST_GIT_URI, TEST_GIT_REF).and_return(MockParser())
     response = osbs.create_prod_build(TEST_GIT_URI, TEST_GIT_REF, TEST_GIT_REF, TEST_USER,
                                       TEST_COMPONENT, TEST_TARGET, TEST_ARCH)
     assert isinstance(response, BuildResponse)

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -269,6 +269,7 @@ def test_render_simple_request():
     inputs_path = os.path.join(parent_dir, "inputs")
     bm = BuildManager(inputs_path)
     build_request = bm.get_build_request_by_type("simple")
+    name_label = "fedora/resultingimage"
     kwargs = {
         'git_uri': "http://git/",
         'git_ref': TEST_GIT_REF,
@@ -276,14 +277,14 @@ def test_render_simple_request():
         'user': "john-foo",
         'component': TEST_COMPONENT,
         'base_image': 'fedora:latest',
-        'name_label': 'fedora/resultingimage',
+        'name_label': name_label,
         'registry_uri': "http://registry.example.com:5000",
         'openshift_uri': "http://openshift/",
     }
     build_request.set_params(**kwargs)
     build_json = build_request.render()
 
-    assert build_json["metadata"]["name"] == "%s-%s" % (TEST_COMPONENT, TEST_GIT_REF)
+    assert build_json["metadata"]["name"] == name_label.replace('/', '-')
     #assert build_json["spec"]["triggers"][0]["imageChange"]["from"]["name"] == \
     #    os.path.join(kwargs["registry_uri"], kwargs["base_image"])
     assert build_json["spec"]["source"]["git"]["uri"] == "http://git/"
@@ -312,6 +313,7 @@ def test_render_prod_request_with_repo():
     inputs_path = os.path.join(parent_dir, "inputs")
     bm = BuildManager(inputs_path)
     build_request = bm.get_build_request_by_type(PROD_BUILD_TYPE)
+    name_label = "fedora/resultingimage"
     assert isinstance(build_request, ProductionBuild)
     kwargs = {
         'git_uri': "http://git/",
@@ -320,7 +322,7 @@ def test_render_prod_request_with_repo():
         'user': "john-foo",
         'component': TEST_COMPONENT,
         'base_image': 'fedora:latest',
-        'name_label': 'fedora/resultingimage',
+        'name_label': name_label,
         'registry_uri': "registry.example.com",
         'openshift_uri': "http://openshift/",
         'koji_target': "koji-target",
@@ -336,7 +338,7 @@ def test_render_prod_request_with_repo():
     build_request.set_params(**kwargs)
     build_json = build_request.render()
 
-    assert build_json["metadata"]["name"] == "%s-%s" % (TEST_COMPONENT, TEST_GIT_REF)
+    assert build_json["metadata"]["name"] == name_label.replace('/', '-')
     #assert build_json["spec"]["triggers"][0]["imageChange"]["from"]["name"] == \
     #    os.path.join(kwargs["registry_uri"], kwargs["base_image"])
     assert build_json["spec"]["source"]["git"]["uri"] == "http://git/"
@@ -387,6 +389,7 @@ def test_render_prod_request():
     inputs_path = os.path.join(parent_dir, "inputs")
     bm = BuildManager(inputs_path)
     build_request = bm.get_build_request_by_type(PROD_BUILD_TYPE)
+    name_label = "fedora/resultingimage"
     kwargs = {
         'git_uri': "http://git/",
         'git_ref': TEST_GIT_REF,
@@ -394,7 +397,7 @@ def test_render_prod_request():
         'user': "john-foo",
         'component': TEST_COMPONENT,
         'base_image': 'fedora:latest',
-        'name_label': 'fedora/resultingimage',
+        'name_label': name_label,
         'registry_uri': "registry.example.com",
         'openshift_uri': "http://openshift/",
         'koji_target': "koji-target",
@@ -409,7 +412,7 @@ def test_render_prod_request():
     build_request.set_params(**kwargs)
     build_json = build_request.render()
 
-    assert build_json["metadata"]["name"] == "%s-%s" % (TEST_COMPONENT, TEST_GIT_REF)
+    assert build_json["metadata"]["name"] == name_label.replace('/', '-')
     #assert build_json["spec"]["triggers"][0]["imageChange"]["from"]["name"] == \
     #    os.path.join(kwargs["registry_uri"], kwargs["base_image"])
     assert build_json["spec"]["source"]["git"]["uri"] == "http://git/"
@@ -459,6 +462,7 @@ def test_render_prod_without_koji_request():
     inputs_path = os.path.join(parent_dir, "inputs")
     bm = BuildManager(inputs_path)
     build_request = bm.get_build_request_by_type(PROD_WITHOUT_KOJI_BUILD_TYPE)
+    name_label = "fedora/resultingimage"
     assert isinstance(build_request, ProductionBuild)
     kwargs = {
         'git_uri': "http://git/",
@@ -467,7 +471,7 @@ def test_render_prod_without_koji_request():
         'user': "john-foo",
         'component': TEST_COMPONENT,
         'base_image': 'fedora:latest',
-        'name_label': 'fedora/resultingimage',
+        'name_label': name_label,
         'registry_uri': "registry.example.com",
         'openshift_uri': "http://openshift/",
         'sources_command': "make",
@@ -479,7 +483,7 @@ def test_render_prod_without_koji_request():
     build_request.set_params(**kwargs)
     build_json = build_request.render()
 
-    assert build_json["metadata"]["name"] == "%s-%s" % (TEST_COMPONENT, TEST_GIT_REF)
+    assert build_json["metadata"]["name"] == name_label.replace('/', '-')
     #assert build_json["spec"]["triggers"][0]["imageChange"]["from"]["name"] == \
     #    os.path.join(kwargs["registry_uri"], kwargs["base_image"])
     assert build_json["spec"]["source"]["git"]["uri"] == "http://git/"


### PR DESCRIPTION
This PR makes sure we get three things right:
- `imagestream` argument for `ImportImagePlugin`
- `docker_image_repo` argument for `ImportImagePlugin`
- name of trigger that built image depends on

Also, the second commit fixes minor issue, where openshift url for `check_and_set_rebuild` wasn't previously substituted in `BuildRequest`.