### PR TITLE
[do not merge] Enable rebuild triggers

### DIFF
--- a/inputs/prod.json
+++ b/inputs/prod.json
@@ -8,6 +8,17 @@
     }
   },
   "spec": {
+    "triggers": [
+      {
+        "type": "ImageChange",
+        "imageChange": {
+          "from": {
+            "kind": "ImageStreamTag",
+            "name": "{{BASE_IMAGE_STREAM}}"
+          }
+        }
+      }
+    ],
     "source": {
       "type": "Git",
       "git": {

--- a/tests/fake_api.py
+++ b/tests/fake_api.py
@@ -161,6 +161,7 @@ class Connection(object):
                     # Contains a BuildList with Builds labeled with
                     # buildconfig=fedora23-something, none of which
                     # are running
+                    "custom_callback": self.find_buildconfig_next_time,
                     "file": "builds_list.json"
                 }
             },
@@ -196,7 +197,6 @@ class Connection(object):
             },
         }
 
-
     @staticmethod
     def process_authorize(key, content):
         match = re.findall("[Ll]ocation: (.+)", content.decode("utf-8"))
@@ -217,6 +217,17 @@ class Connection(object):
             }
 
         return custom_func
+
+    def find_buildconfig_next_time(self, key, content):
+        # Next time this API call is made, find a pending build
+        self.DEFINITION[key].update({
+            "get": {
+                "file": "builds_list_fedora23-something_pending.json"
+            }
+        })
+        return {
+            "content": content,
+        }
 
     def get_definition_for(self, key):
         """

--- a/tests/mock_jsons/0.5.4/builds_list_fedora23-something_pending.json
+++ b/tests/mock_jsons/0.5.4/builds_list_fedora23-something_pending.json
@@ -1,0 +1,70 @@
+{
+    "apiVersion": "v1", 
+    "items": [
+        {
+        "apiVersion": "v1", 
+        "kind": "Build", 
+        "metadata": {
+            "creationTimestamp": "2015-08-26T16:18:18Z", 
+            "labels": {
+                "buildconfig": "fedora23-something", 
+                "is_autorebuild": "false"
+            }, 
+            "name": "component-master-1", 
+            "namespace": "default", 
+            "resourceVersion": "488", 
+            "selfLink": "/oapi/v1/namespaces/default/builds/component-master-1", 
+            "uid": "1013cdd6-4c0e-11e5-9c59-52540080e6f8"
+        }, 
+        "spec": {
+            "output": {
+                "to": {
+                    "kind": "DockerImage", 
+                    "name": "localhost:5000/twaugh/component:20150826171818"
+                }
+            }, 
+            "resources": {}, 
+            "source": {
+                "git": {
+                    "ref": "master", 
+                    "uri": "https://github.com/TomasTomecek/docker-hello-world.git"
+                }, 
+                "type": "Git"
+            }, 
+            "strategy": {
+                "customStrategy": {
+                    "env": [
+                        {
+                            "name": "DOCK_PLUGINS", 
+                            "value": "{\"prebuild_plugins\": [{\"args\": {}, \"name\": \"pull_base_image\"}, {\"name\": \"change_from_in_dockerfile\"}, {\"name\": \"dockerfile_content\"}], \"exit_plugins\": [{\"args\": {\"url\": \"https://osbs.localdomain:8443/\", \"verify_ssl\": false, \"use_auth\": false}, \"name\": \"store_metadata_in_osv3\"}, {\"name\": \"remove_built_image\"}], \"postbuild_plugins\": [{\"args\": {\"image_id\": \"BUILT_IMAGE_ID\"}, \"name\": \"all_rpm_packages\"}]}"
+                        }, 
+                        {
+                            "name": "OPENSHIFT_CUSTOM_BUILD_BASE_IMAGE", 
+                            "value": "buildroot:latest"
+                        }
+                    ], 
+                    "exposeDockerSocket": true, 
+                    "from": {
+                        "kind": "DockerImage", 
+                        "name": "buildroot:latest"
+                    }
+                }, 
+                "type": "Custom"
+            }
+        }, 
+        "status": {
+            "config": {
+                "kind": "BuildConfig", 
+                "name": "fedora23-something", 
+                "namespace": "default"
+            }, 
+            "phase": "Pending"
+        }
+    }
+    ], 
+    "kind": "BuildList", 
+    "metadata": {
+        "resourceVersion": "483", 
+        "selfLink": "/oapi/v1/namespaces/default/builds/"
+    }
+}

--- a/tests/mock_jsons/1.0.4/builds_list_fedora23-something_pending.json
+++ b/tests/mock_jsons/1.0.4/builds_list_fedora23-something_pending.json
@@ -1,0 +1,69 @@
+{
+    "apiVersion": "v1", 
+    "items": [
+        {
+            "metadata": {
+                "creationTimestamp": "2015-08-26T16:34:54Z", 
+                "labels": {
+                    "buildconfig": "fedora23-something", 
+                    "is_autorebuild": "false"
+                }, 
+                "name": "fedora23-something-1", 
+                "namespace": "default", 
+                "resourceVersion": "488", 
+                "selfLink": "/oapi/v1/namespaces/default/builds/fedora23-something-1", 
+                "uid": "61da90c2-4c10-11e5-83ec-52540080e6f8"
+            }, 
+            "spec": {
+                "output": {
+                    "to": {
+                        "kind": "DockerImage", 
+                        "name": "localhost:5000/twaugh/component:20150826173454"
+                    }
+                }, 
+                "resources": {}, 
+                "serviceAccount": "builder", 
+                "source": {
+                    "git": {
+                        "ref": "master", 
+                        "uri": "https://github.com/TomasTomecek/docker-hello-world.git"
+                    }, 
+                    "type": "Git"
+                }, 
+                "strategy": {
+                    "customStrategy": {
+                        "env": [
+                            {
+                                "name": "DOCK_PLUGINS", 
+                                "value": "{\"prebuild_plugins\": [{\"args\": {}, \"name\": \"pull_base_image\"}, {\"name\": \"change_from_in_dockerfile\"}, {\"name\": \"dockerfile_content\"}], \"exit_plugins\": [{\"args\": {\"url\": \"https://osbs.localdomain:8443/\", \"verify_ssl\": false, \"use_auth\": false}, \"name\": \"store_metadata_in_osv3\"}, {\"name\": \"remove_built_image\"}], \"postbuild_plugins\": [{\"args\": {\"image_id\": \"BUILT_IMAGE_ID\"}, \"name\": \"all_rpm_packages\"}]}"
+                            }, 
+                            {
+                                "name": "OPENSHIFT_CUSTOM_BUILD_BASE_IMAGE", 
+                                "value": "buildroot:latest"
+                            }
+                        ], 
+                        "exposeDockerSocket": true, 
+                        "from": {
+                            "kind": "DockerImage", 
+                            "name": "buildroot:latest"
+                        }
+                    }, 
+                    "type": "Custom"
+                }
+            }, 
+            "status": {
+                "config": {
+                    "kind": "BuildConfig", 
+                    "name": "fedora23-something", 
+                    "namespace": "default"
+                }, 
+                "phase": "Pending"
+            }
+        }
+    ], 
+    "kind": "BuildList", 
+    "metadata": {
+        "resourceVersion": "494", 
+        "selfLink": "/oapi/v1/namespaces/default/builds/"
+    }
+}


### PR DESCRIPTION
This pull request is for enabling rebuild triggers, and should only be merged once all the plug-ins necessary for them to work are configured.
- [x] `check_and_set_rebuild` plug-in (https://github.com/projectatomic/osbs-client/pull/213)
- [x] `bump_release` plug-in (https://github.com/projectatomic/osbs-client/pull/214)
- [x] `import_image` plug-in (https://github.com/projectatomic/osbs-client/pull/194)
- [x] `sendmail` plugin for failed build notifications (https://github.com/projectatomic/atomic-reactor/pull/282, https://github.com/projectatomic/osbs-client/pull/248)
- [x] `koji_promote` plug-in (https://github.com/projectatomic/atomic-reactor/pull/319, https://github.com/projectatomic/osbs-client/pull/282)
