### PR TITLE
Use compress plugin in prod, change load_squashed_image to load_exported_image

### DIFF
--- a/inputs/prod_inner.json
+++ b/inputs/prod_inner.json
@@ -66,6 +66,13 @@
   ],
   "postbuild_plugins": [
     {
+      "name": "compress",
+      "args": {
+        "load_exported_image": true,
+        "method": "gzip"
+      }
+    },
+    {
       "name": "cp_built_image_to_nfs",
       "args": {
         "nfs_server_path": "{{NFS_SERVER_PATH}}"
@@ -81,7 +88,7 @@
       "name": "pulp_push",
       "args": {
         "pulp_registry_name": "{{PULP_REGISTRY_NAME}}",
-        "load_squashed_image": true
+        "load_exported_image": true
       }
     },
     {


### PR DESCRIPTION
As a side effect, this would mean that the image copied to NFS would also be gzipped (previously it wasn't compressed at all). I'm not sure if this is desirable. I can turn this off by running the `compress` plugin after the uncompressed squashed image gets copied to NFS. @pbabinca @twaugh @TomasTomecek any ideas if this is ok or if it should be switched back?