### PR TITLE
Enable rebuild-related plugins only if there are triggers

### DIFF
--- a/inputs/prod_inner.json
+++ b/inputs/prod_inner.json
@@ -97,6 +97,15 @@
         "image_id": "BUILT_IMAGE_ID"
       },
       "name": "all_rpm_packages"
+    },
+    {
+      "args": {
+        "imagestream": "{{IMAGESTREAM}}",
+        "docker_image_repo": "{{DOCKER_IMAGE_REPO}}",
+        "url": "{{OPENSHIFT_URI}}",
+        "verify_ssl": false
+      },
+      "name": "import_image"
     }
   ],
   "exit_plugins": [

--- a/osbs/build/build_request.py
+++ b/osbs/build/build_request.py
@@ -256,11 +256,14 @@ class ProductionBuild(CommonBuild):
                                       "url", self.spec.openshift_uri.value)
 
         # If there are no triggers set, there is no point in running
-        # the import_image plugin.
+        # the check_and_set_rebuild or import_image plugins.
         triggers = self.template['spec'].get('triggers', [])
         if len(triggers) == 0:
-            logger.info("removing import_image from request because there are no triggers")
-            self.dj.remove_plugin("postbuild_plugins", "import_image")
+            for when, which in [("prebuild_plugins", "check_and_set_rebuild"),
+                                ("postbuild_plugins", "import_image")]:
+                logger.info("removing %s from request because there are no triggers",
+                            which)
+                self.dj.remove_plugin(when, which)
 
         # if there is yum repo specified, don't pick stuff from koji
         if self.spec.yum_repourls.value:

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -355,6 +355,8 @@ def test_render_prod_request_with_repo():
     assert plugins_json is not None
     plugins = json.loads(plugins_json)
 
+    with pytest.raises(NoSuchPluginException):
+        assert get_plugin(plugins, "prebuild_plugins", "check_and_set_rebuild")
     assert plugin_value_get(plugins, "prebuild_plugins", "distgit_fetch_artefacts", "args", "command") == "make"
     assert plugin_value_get(plugins, "prebuild_plugins", "pull_base_image", "args", "parent_registry") == \
            "registry.example.com"
@@ -366,6 +368,8 @@ def test_render_prod_request_with_repo():
         assert get_plugin(plugins, "postbuild_plugins", "cp_built_image_to_nfs")
     with pytest.raises(NoSuchPluginException):
         assert get_plugin(plugins, "postbuild_plugins", "pulp_push")
+    with pytest.raises(NoSuchPluginException):
+        assert get_plugin(plugins, "postbuild_plugins", "import_image")
     assert 'sourceSecret' not in build_json["spec"]["source"]
     assert 'sourceSecretName' not in build_json["spec"]["source"]
     plugin_value_get(plugins, "prebuild_plugins", "add_yum_repo_by_url", "args", "repourls") == \
@@ -428,6 +432,8 @@ def test_render_prod_request():
     assert plugins_json is not None
     plugins = json.loads(plugins_json)
 
+    with pytest.raises(NoSuchPluginException):
+        assert get_plugin(plugins, "prebuild_plugins", "check_and_set_rebuild")
     assert plugin_value_get(plugins, "prebuild_plugins", "distgit_fetch_artefacts", "args", "command") == "make"
     assert plugin_value_get(plugins, "prebuild_plugins", "pull_base_image", "args", "parent_registry") == \
         "registry.example.com"
@@ -440,6 +446,8 @@ def test_render_prod_request():
         assert get_plugin(plugins, "postbuild_plugins", "cp_built_image_to_nfs")
     with pytest.raises(NoSuchPluginException):
         assert get_plugin(plugins, "postbuild_plugins", "pulp_push")
+    with pytest.raises(NoSuchPluginException):
+        assert get_plugin(plugins, "postbuild_plugins", "import_image")
     assert 'sourceSecret' not in build_json["spec"]["source"]
     assert 'sourceSecretName' not in build_json["spec"]["source"]
 
@@ -498,6 +506,8 @@ def test_render_prod_without_koji_request():
     assert plugins_json is not None
     plugins = json.loads(plugins_json)
 
+    with pytest.raises(NoSuchPluginException):
+        assert get_plugin(plugins, "prebuild_plugins", "check_and_set_rebuild")
     assert plugin_value_get(plugins, "prebuild_plugins", "distgit_fetch_artefacts", "args", "command") == "make"
     assert plugin_value_get(plugins, "prebuild_plugins", "pull_base_image", "args", "parent_registry") == \
         "registry.example.com"
@@ -510,6 +520,8 @@ def test_render_prod_without_koji_request():
         assert get_plugin(plugins, "postbuild_plugins", "cp_built_image_to_nfs")
     with pytest.raises(NoSuchPluginException):
         assert get_plugin(plugins, "postbuild_plugins", "pulp_push")
+    with pytest.raises(NoSuchPluginException):
+        assert get_plugin(plugins, "postbuild_plugins", "import_image")
     assert 'sourceSecret' not in build_json["spec"]["source"]
     assert 'sourceSecretName' not in build_json["spec"]["source"]
 
@@ -568,9 +580,13 @@ def test_render_prod_with_secret_request():
     assert plugins_json is not None
     plugins = json.loads(plugins_json)
 
+    with pytest.raises(NoSuchPluginException):
+        assert get_plugin(plugins, "prebuild_plugins", "check_and_set_rebuild")
     assert get_plugin(plugins, "prebuild_plugins", "koji")
     assert get_plugin(plugins, "postbuild_plugins", "pulp_push")
     assert get_plugin(plugins, "postbuild_plugins", "cp_built_image_to_nfs")
+    with pytest.raises(NoSuchPluginException):
+        assert get_plugin(plugins, "postbuild_plugins", "import_image")
 
 
 def test_render_with_yum_repourls():
@@ -631,11 +647,15 @@ def test_render_with_yum_repourls():
     assert 'http://example.com/repo2.repo' in repourls
 
     with pytest.raises(NoSuchPluginException):
+        assert get_plugin(plugins, "prebuild_plugins", "check_and_set_rebuild")
+    with pytest.raises(NoSuchPluginException):
         assert get_plugin(plugins, "prebuild_plugins", "koji")
     with pytest.raises(NoSuchPluginException):
         assert get_plugin(plugins, "postbuild_plugins", "cp_built_image_to_nfs")
     with pytest.raises(NoSuchPluginException):
         assert get_plugin(plugins, "postbuild_plugins", "pulp_push")
+    with pytest.raises(NoSuchPluginException):
+        assert get_plugin(plugins, "postbuild_plugins", "import_image")
 
 
 def test_render_prod_with_pulp_no_auth():
@@ -736,6 +756,10 @@ def test_render_prod_request_with_trigger(tmpdir):
             break
 
     plugins = json.loads(plugins_json)
+    assert get_plugin(plugins, "prebuild_plugins", "check_and_set_rebuild")
+    assert plugin_value_get(plugins, "prebuild_plugins",
+                            "check_and_set_rebuild", "args",
+                            "url") == kwargs["openshift_uri"]
     assert get_plugin(plugins, "postbuild_plugins", "import_image")
     assert plugin_value_get(plugins,
                             "postbuild_plugins", "import_image", "args",


### PR DESCRIPTION
This pull request is for adding the `check_and_set_rebuild` and `import_image` plugins only if at least one trigger is specified. It also adds a test case so we can test both with-triggers and without-triggers.