### PR TITLE
Fake API: framework changes to allow responses to change over time

### DIFF
--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -34,7 +34,7 @@ from osbs import utils
 from tests.constants import TEST_BUILD, TEST_LABEL, TEST_LABEL_VALUE
 from tests.constants import TEST_GIT_URI, TEST_GIT_REF, TEST_GIT_BRANCH, TEST_USER
 from tests.constants import TEST_COMPONENT, TEST_TARGET, TEST_ARCH
-from tests.fake_api import ResponseMapping, get_definition_for
+from tests.fake_api import ResponseMapping, Connection
 
 
 logger = logging.getLogger("osbs.tests")
@@ -951,9 +951,11 @@ def test_build_logs_api_from_docker(osbs, decode_docker_logs):
 @pytest.mark.skipif(sys.version_info[0] >= 3,
                     reason="known not to work on Python 3 (#74)")
 def test_parse_headers():
-    rm = ResponseMapping("0.5.4")
+    conn = Connection("0.5.4")
+    rm = ResponseMapping("0.5.4", lookup=conn.get_definition_for)
 
-    file_name = get_definition_for("/oauth/authorize")["get"]["file"]
+    key, value = conn.get_definition_for("/oauth/authorize")
+    file_name = value["get"]["file"]
     raw_headers = rm.get_response_content(file_name)
 
     r = Response(raw_headers=raw_headers)


### PR DESCRIPTION
The URL to response map has been moved into the `Connection` object, as well as the custom callbacks referenced by it and the lookup function, `get_definition_for()`.

This lookup function now also returns the key in the response map, allowing a custom callback to modify the response for that URL the next time it is requested.

This work prepares the way for https://github.com/projectatomic/osbs-client/pull/202.