### PR TITLE
Set correct BuildConfig names and imageChange ImageStreamTags

### DIFF
--- a/osbs/build/build_request.py
+++ b/osbs/build/build_request.py
@@ -185,7 +185,7 @@ class CommonBuild(BuildRequest):
         self.template['spec']['output']['to']['name'] = tag_with_registry
         if 'triggers' in self.template['spec']:
             self.template['spec']['triggers']\
-                [0]['imageChange']['from']['name'] = self.spec.trigger_imagestream_name.value
+                [0]['imageChange']['from']['name'] = self.spec.trigger_imagestreamtag.value
 
         if (self.spec.yum_repourls.value is not None and
                 self.dj.dock_json_has_plugin_conf('prebuild_plugins', "add_yum_repo_by_url")):

--- a/osbs/build/spec.py
+++ b/osbs/build/spec.py
@@ -16,7 +16,8 @@ import os
 import re
 from osbs.constants import DEFAULT_GIT_REF
 from osbs.exceptions import OsbsValidationException
-from osbs.utils import get_imagestreamtag_from_image
+from osbs.utils import (get_imagestreamtag_from_image,
+                        git_repo_humanish_part_from_uri)
 
 
 logger = logging.getLogger(__name__)
@@ -147,10 +148,11 @@ class CommonSpec(BuildTypeSpec):
             raise OsbsValidationException("yum_repourls must be a list")
         self.yum_repourls.value = yum_repourls or []
         self.use_auth.value = use_auth
-        self.name.value = name_label.replace('/', '-')
+        repo = git_repo_humanish_part_from_uri(git_uri)
+        self.name.value = "{repo}-{branch}".format(repo=repo,
+                                                   branch=git_branch)
         self.trigger_imagestreamtag.value = get_imagestreamtag_from_image(base_image)
-        # imagestream and buildconfig have precisely the same name
-        self.imagestream_name.value = self.name.value
+        self.imagestream_name.value = name_label.replace('/', '-')
         self.imagestream_url.value = os.path.join(self.registry_uri.value, name_label)
 
 

--- a/osbs/build/spec.py
+++ b/osbs/build/spec.py
@@ -16,7 +16,7 @@ import os
 import re
 from osbs.constants import DEFAULT_GIT_REF
 from osbs.exceptions import OsbsValidationException
-from osbs.utils import get_imagestream_name_from_image
+from osbs.utils import get_imagestreamtag_from_image
 
 
 logger = logging.getLogger(__name__)
@@ -111,7 +111,7 @@ class CommonSpec(BuildTypeSpec):
     git_branch = BuildParam('git_branch')
     user = UserParam()
     component = BuildParam('component')
-    trigger_imagestream_name = BuildParam('trigger_imagestream_name')
+    trigger_imagestreamtag = BuildParam('trigger_imagestreamtag')
     imagestream_name = BuildParam('imagestream_name')
     imagestream_url = BuildParam('imagestream_url')
     registry_uri = BuildParam('registry_uri')
@@ -148,7 +148,7 @@ class CommonSpec(BuildTypeSpec):
         self.yum_repourls.value = yum_repourls or []
         self.use_auth.value = use_auth
         self.name.value = name_label.replace('/', '-')
-        self.trigger_imagestream_name.value = get_imagestream_name_from_image(base_image)
+        self.trigger_imagestreamtag.value = get_imagestreamtag_from_image(base_image)
         # imagestream and buildconfig have precisely the same name
         self.imagestream_name.value = self.name.value
         self.imagestream_url.value = os.path.join(self.registry_uri.value, name_label)

--- a/osbs/utils.py
+++ b/osbs/utils.py
@@ -55,6 +55,16 @@ def get_df_parser(git_uri, git_ref, git_branch):
     return DockerfileParser(os.path.join(code_dir, 'Dockerfile'))
 
 
+def git_repo_humanish_part_from_uri(git_uri):
+    git_uri = git_uri.rstrip('/')
+    if git_uri.endswith("/.git"):
+        git_uri = git_uri[:-5]
+    elif git_uri.endswith(".git"):
+        git_uri = git_uri[:-4]
+
+    return os.path.basename(git_uri)
+
+
 def get_imagestream_name_from_image(image):
     # this duplicates some logic with atomic_reactor.util.ImageName,
     # but I don't think it's worth it to depend on AR just for this

--- a/osbs/utils.py
+++ b/osbs/utils.py
@@ -65,17 +65,26 @@ def git_repo_humanish_part_from_uri(git_uri):
     return os.path.basename(git_uri)
 
 
-def get_imagestream_name_from_image(image):
+def get_imagestreamtag_from_image(image):
+    """
+    return ImageStreamTag, give a FROM value
+
+    :param image: str, the FROM value from the Dockerfile
+    :return: str, ImageStreamTag
+    """
+
     # this duplicates some logic with atomic_reactor.util.ImageName,
     # but I don't think it's worth it to depend on AR just for this
+
     ret = image
+
+    # Remove the registry part
     parts = image.split('/', 2)
     if len(parts) == 2:
         if '.' in parts[0] or ':' in parts[0]:
             ret = parts[1]
     elif len(parts) == 3:
         ret = '%s/%s' % (parts[1], parts[2])
-    if ':' in ret:
-        ret = ret[:ret.index(':')]
 
+    # ImageStream names cannot contain '/'
     return ret.replace('/', '-')

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -8,7 +8,7 @@ of the BSD license. See the LICENSE file for details.
 from __future__ import absolute_import, unicode_literals
 
 TEST_BUILD = "test-build-123"
-TEST_BUILD_CONFIG = "fedora23-something"
+TEST_BUILD_CONFIG = "path-master"
 TEST_GIT_URI = "git://hostname/path"
 TEST_GIT_REF = "01234567"
 TEST_GIT_BRANCH = "master"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -16,6 +16,7 @@ def test_deep_update():
     ('http://git.example.com/git/repo.git/', 'repo'),
     ('http://git.example.com/git/repo.git', 'repo'),
     ('http://git.example.com/git/repo/.git', 'repo'),
+    ('git://hostname/path', 'path'),
 ])
 def test_git_repo_humanish_part_from_uri(uri, humanish):
     assert git_repo_humanish_part_from_uri(uri) == humanish

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,8 @@
 import pytest
 
-from osbs.utils import deep_update, get_imagestream_name_from_image
+from osbs.utils import (deep_update,
+                        get_imagestream_name_from_image,
+                        git_repo_humanish_part_from_uri)
 
 
 def test_deep_update():
@@ -8,6 +10,15 @@ def test_deep_update():
     y = {'b': {'b1': 'newB1', 'b3': 'B3'}, 'c': 'C'}
     deep_update(x, y)
     assert x == {'a': 'A', 'b': {'b1': 'newB1', 'b2': 'B2', 'b3': 'B3'}, 'c': 'C'}
+
+
+@pytest.mark.parametrize(('uri', 'humanish'), [
+    ('http://git.example.com/git/repo.git/', 'repo'),
+    ('http://git.example.com/git/repo.git', 'repo'),
+    ('http://git.example.com/git/repo/.git', 'repo'),
+])
+def test_git_repo_humanish_part_from_uri(uri, humanish):
+    assert git_repo_humanish_part_from_uri(uri) == humanish
 
 
 @pytest.mark.parametrize(('img', 'expected'), [

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,7 @@
 import pytest
 
 from osbs.utils import (deep_update,
-                        get_imagestream_name_from_image,
+                        get_imagestreamtag_from_image,
                         git_repo_humanish_part_from_uri)
 
 
@@ -23,12 +23,12 @@ def test_git_repo_humanish_part_from_uri(uri, humanish):
 
 @pytest.mark.parametrize(('img', 'expected'), [
     ('fedora23', 'fedora23'),
-    ('fedora23:sometag', 'fedora23'),
+    ('fedora23:sometag', 'fedora23:sometag'),
     ('fedora23/python', 'fedora23-python'),
-    ('fedora23/python:sometag', 'fedora23-python'),
+    ('fedora23/python:sometag', 'fedora23-python:sometag'),
     ('docker.io/fedora23', 'fedora23'),
     ('docker.io/fedora23/python', 'fedora23-python'),
-    ('docker.io/fedora23/python:sometag', 'fedora23-python'),
+    ('docker.io/fedora23/python:sometag', 'fedora23-python:sometag'),
 ])
-def test_get_imagestream_name_from_image(img, expected):
-    assert get_imagestream_name_from_image(img) == expected
+def test_get_imagestreamtag_from_image(img, expected):
+    assert get_imagestreamtag_from_image(img) == expected

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -31,7 +31,7 @@ from osbs.constants import PROD_WITH_SECRET_BUILD_TYPE
 from osbs.exceptions import OsbsValidationException
 from osbs.http import Response
 from osbs import utils
-from tests.constants import TEST_BUILD, TEST_LABEL, TEST_LABEL_VALUE
+from tests.constants import TEST_BUILD, TEST_BUILD_CONFIG, TEST_LABEL, TEST_LABEL_VALUE
 from tests.constants import TEST_GIT_URI, TEST_GIT_REF, TEST_GIT_BRANCH, TEST_USER
 from tests.constants import TEST_COMPONENT, TEST_TARGET, TEST_ARCH
 from tests.fake_api import ResponseMapping, get_definition_for
@@ -249,7 +249,7 @@ def test_render_simple_request_incorrect_postbuild(tmpdir):
     bm = BuildManager(str(tmpdir))
     build_request = bm.get_build_request_by_type("simple")
     kwargs = {
-        'git_uri': "http://git/",
+        'git_uri': TEST_GIT_URI,
         'git_ref': TEST_GIT_REF,
         'user': "john-foo",
         'component': "component",
@@ -286,7 +286,7 @@ def test_render_simple_request():
     build_request = bm.get_build_request_by_type("simple")
     name_label = "fedora/resultingimage"
     kwargs = {
-        'git_uri': "http://git/",
+        'git_uri': TEST_GIT_URI,
         'git_ref': TEST_GIT_REF,
         'git_branch': TEST_GIT_BRANCH,
         'user': "john-foo",
@@ -299,9 +299,9 @@ def test_render_simple_request():
     build_request.set_params(**kwargs)
     build_json = build_request.render()
 
-    assert build_json["metadata"]["name"] == name_label.replace('/', '-')
+    assert build_json["metadata"]["name"] == TEST_BUILD_CONFIG
     assert "triggers" not in build_json["spec"]
-    assert build_json["spec"]["source"]["git"]["uri"] == "http://git/"
+    assert build_json["spec"]["source"]["git"]["uri"] == TEST_GIT_URI
     assert build_json["spec"]["source"]["git"]["ref"] == TEST_GIT_REF
     assert build_json["spec"]["output"]["to"]["name"].startswith(
         "registry.example.com:5000/john-foo/component:"
@@ -330,7 +330,7 @@ def test_render_prod_request_with_repo():
     name_label = "fedora/resultingimage"
     assert isinstance(build_request, ProductionBuild)
     kwargs = {
-        'git_uri': "http://git/",
+        'git_uri': TEST_GIT_URI,
         'git_ref': TEST_GIT_REF,
         'git_branch': TEST_GIT_BRANCH,
         'user': "john-foo",
@@ -352,9 +352,9 @@ def test_render_prod_request_with_repo():
     build_request.set_params(**kwargs)
     build_json = build_request.render()
 
-    assert build_json["metadata"]["name"] == name_label.replace('/', '-')
+    assert build_json["metadata"]["name"] == TEST_BUILD_CONFIG
     assert "triggers" not in build_json["spec"]
-    assert build_json["spec"]["source"]["git"]["uri"] == "http://git/"
+    assert build_json["spec"]["source"]["git"]["uri"] == TEST_GIT_URI
     assert build_json["spec"]["source"]["git"]["ref"] == TEST_GIT_REF
     assert build_json["spec"]["output"]["to"]["name"].startswith(
         "registry.example.com/john-foo/component:"
@@ -410,7 +410,7 @@ def test_render_prod_request():
     build_request = bm.get_build_request_by_type(PROD_BUILD_TYPE)
     name_label = "fedora/resultingimage"
     kwargs = {
-        'git_uri': "http://git/",
+        'git_uri': TEST_GIT_URI,
         'git_ref': TEST_GIT_REF,
         'git_branch': TEST_GIT_BRANCH,
         'user': "john-foo",
@@ -431,9 +431,9 @@ def test_render_prod_request():
     build_request.set_params(**kwargs)
     build_json = build_request.render()
 
-    assert build_json["metadata"]["name"] == name_label.replace('/', '-')
+    assert build_json["metadata"]["name"] == TEST_BUILD_CONFIG
     assert "triggers" not in build_json["spec"]
-    assert build_json["spec"]["source"]["git"]["uri"] == "http://git/"
+    assert build_json["spec"]["source"]["git"]["uri"] == TEST_GIT_URI
     assert build_json["spec"]["source"]["git"]["ref"] == TEST_GIT_REF
     assert build_json["spec"]["output"]["to"]["name"].startswith(
         "registry.example.com/john-foo/component:"
@@ -489,7 +489,7 @@ def test_render_prod_without_koji_request():
     name_label = "fedora/resultingimage"
     assert isinstance(build_request, ProductionBuild)
     kwargs = {
-        'git_uri': "http://git/",
+        'git_uri': TEST_GIT_URI,
         'git_ref': TEST_GIT_REF,
         'git_branch': TEST_GIT_BRANCH,
         'user': "john-foo",
@@ -507,9 +507,9 @@ def test_render_prod_without_koji_request():
     build_request.set_params(**kwargs)
     build_json = build_request.render()
 
-    assert build_json["metadata"]["name"] == name_label.replace('/', '-')
+    assert build_json["metadata"]["name"] == TEST_BUILD_CONFIG
     assert "triggers" not in build_json["spec"]
-    assert build_json["spec"]["source"]["git"]["uri"] == "http://git/"
+    assert build_json["spec"]["source"]["git"]["uri"] == TEST_GIT_URI
     assert build_json["spec"]["source"]["git"]["ref"] == TEST_GIT_REF
     assert build_json["spec"]["output"]["to"]["name"].startswith(
         "registry.example.com/john-foo/component:"
@@ -564,7 +564,7 @@ def test_render_prod_with_secret_request():
     build_request = bm.get_build_request_by_type(PROD_WITH_SECRET_BUILD_TYPE)
     assert isinstance(build_request, ProductionBuild)
     kwargs = {
-        'git_uri': "http://git/",
+        'git_uri': TEST_GIT_URI,
         'git_ref': TEST_GIT_REF,
         'git_branch': TEST_GIT_BRANCH,
         'user': "john-foo",
@@ -619,7 +619,7 @@ def test_render_with_yum_repourls():
     inputs_path = os.path.join(parent_dir, "inputs")
     bm = BuildManager(inputs_path)
     kwargs = {
-        'git_uri': "http://git/",
+        'git_uri': TEST_GIT_URI,
         'git_ref': TEST_GIT_REF,
         'git_branch': TEST_GIT_BRANCH,
         'user': "john-foo",
@@ -694,7 +694,7 @@ def test_render_prod_with_pulp_no_auth():
     bm = BuildManager(inputs_path)
     build_request = bm.get_build_request_by_type(PROD_BUILD_TYPE)
     kwargs = {
-        'git_uri': "http://git/",
+        'git_uri': TEST_GIT_URI,
         'git_ref': TEST_GIT_REF,
         'git_branch': TEST_GIT_BRANCH,
         'user': "john-foo",
@@ -752,7 +752,7 @@ def test_render_prod_request_with_trigger(tmpdir):
     name_label = "fedora/resultingimage"
     push_url = "ssh://{username}git.example.com/git/{component}.git"
     kwargs = {
-        'git_uri': "http://git/",
+        'git_uri': TEST_GIT_URI,
         'git_ref': TEST_GIT_REF,
         'git_branch': TEST_GIT_REF,
         'user': "john-foo",

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -774,7 +774,7 @@ def test_render_prod_request_with_trigger(tmpdir):
 
     assert "triggers" in build_json["spec"]
     assert build_json["spec"]["triggers"][0]\
-        ["imageChange"]["from"]["name"] == 'fedora'
+        ["imageChange"]["from"]["name"] == 'fedora:latest'
 
     strategy = build_json['spec']['strategy']['customStrategy']['env']
     plugins_json = None


### PR DESCRIPTION
Some `FROM` directives may want to specify a particular version of an image, i.e. the part after ':' in the tag name. To accommodate this, the BuildConfig names need to be more specific -- to allow more than one branch to have triggers at a time -- and the ImageStreamTag names used in triggers need to include the whole tag name (still excluding the registry part).

Fixes #217.