### PR TITLE
Use dateutil to parse ISO8601 timestamps with Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ install:
   - "pip install -r requirements.txt"
   - "pip install -r tests/requirements.txt"
   - "pip install pytest-cov coveralls"
+  - "if [[ ${TRAVIS_PYTHON_VERSION%.*} -gt 2 ]]; then pip install -r requirements-py3.txt; fi"
 # command to run tests
 script: py.test -vv tests --cov osbs
 # run in a docker container

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 include LICENSE
 include README.md
 include requirements.txt
+include requirements-py3.txt
 recursive-include inputs *
 recursive-include tests *.py
 include tests/requirements.txt

--- a/osbs-client.spec
+++ b/osbs-client.spec
@@ -67,6 +67,7 @@ Group:          Development/Tools
 License:        BSD
 Requires:       python3-dockerfile-parse
 Requires:       python3-pycurl
+Requires:       python3-dateutil
 Requires:       python3-setuptools
 Requires:       krb5-workstation
 #Requires:       python3-requests

--- a/requirements-py3.txt
+++ b/requirements-py3.txt
@@ -1,0 +1,1 @@
+python-dateutil

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ of the BSD license. See the LICENSE file for details.
 """
 
 import re
+import sys
 
 from setuptools import setup, find_packages
 
@@ -31,6 +32,8 @@ def _get_requirements(path):
 
 def _install_requirements():
     requirements = _get_requirements('requirements.txt')
+    if sys.version_info[0] >= 3:
+        requirements += _get_requirements('requirements-py3.txt')
     return requirements
 
 setup(


### PR DESCRIPTION
Provides robustness against changes in timestamp format.

Unfortunately I couldn't find a way to get this working with Python 2.6.