### PR TITLE
Use secrets array with Origin 1.0.6 (fixes #234)

### DIFF
--- a/docs/configuration_file.md
+++ b/docs/configuration_file.md
@@ -27,6 +27,8 @@ Some options are also mandatory.
 
 * `verbose` (*optional*, `boolean`) — enable verbose logging
 
+* `openshift_required_version` (*optional*, `string`) — required version to run against (adjusts build template as appropriate)
+
 ### instance options
 
 * `openshift_uri` (**mandatory**, `string`) — root URL where openshift master API server is listening (e.g. `localhost:8443`)
@@ -81,7 +83,7 @@ Some options are also mandatory.
 
 * `use_auth` (*optional*, `boolean`) — by default, osbs-client is trying to authenticate against OpenShift master to get OAuth token; you may disable the process with this option
 
-* `source_secret` (*optional*, `string`) — name of [kubernetes secret](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/design/secrets.md) to use for pulp plugin
+* `pulp_secret` (*optional*, `string`) — name of [kubernetes secret](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/design/secrets.md) to use for pulp plugin
 
 * `nfs_server_path` (*optional*, `string`) — NFS server and path to use for storing built image (it is passed to `mount` command)
 

--- a/docs/secret.md
+++ b/docs/secret.md
@@ -1,4 +1,4 @@
-# Using a Source Secret
+# Using Kubernetes Secrets
 
 The `prod` build type allows you to provide some secret content to the build using [Kubernetes Secret Volumes](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/secrets.md).
 
@@ -6,7 +6,7 @@ This is useful when the build workflow requires keys, certificates, etc, which s
 
 The way it works is that a special resource, of type 'Secret', is manually created on the host. This resource is persistent and contains the secret data in the form of keys and base64-encoded values.
 
-Then, when a build container is created, a secret volume is created by OpenShift from that resource and mounted within the container at `$SOURCE_SECRET_PATH`. The secret values can then be accessed as files.
+Then, when a build container is created, a secret volume is created by OpenShift from that resource and mounted within the container at a specified path. The secret values can then be accessed as files.
 
 
 ## Creating the resource
@@ -21,7 +21,7 @@ secrets/mysecret
 
 You also have to allow the build pod service account to [access the secret](https://docs.openshift.org/latest/dev_guide/service_accounts.html#managing-allowed-secrets).
 ```
-$ oc secrets add serviceaccount/default secrets/mysecret --for=mount
+$ oc secrets add serviceaccount/builder secrets/mysecret --for=mount
 ```
 
 ### OpenShift < 0.6.1
@@ -53,11 +53,11 @@ In your OSBS build instance configuration, use the following values:
 
 ```
 build_type = prod
-source_secret = mysecret
+pulp_secret = mysecret
 ```
 
-The `source_secret` name must match the resource name specified in the JSON.
+The `pulp_secret` name must match the resource name specified in the JSON.
 
 ## Fetching the secrets within the build root
 
-In your `dock` plugin which needs the secret values, fetch the location of the Secret Volume mount from the environment variable `SOURCE_SECRET_PATH`. The files in that directory will match the keys from the secret resource's data (`key` and `cert`, from the JSON shown above).
+In your `atomic-reactor` plugin which needs the secret values, provide a configuration parameter to specify the location of the Secret Volume mount. The files in that directory will match the keys from the secret resource's data (`key` and `cert`, from the JSON shown above).

--- a/inputs/prod.json
+++ b/inputs/prod.json
@@ -35,7 +35,8 @@
         "env": [{
           "name": "DOCK_PLUGINS",
           "value": "TBD"
-        }]
+        }],
+        "secrets": []
       }
     }
   }

--- a/osbs/api.py
+++ b/osbs/api.py
@@ -136,6 +136,7 @@ class OSBS(object):
         :param namespace: str, place/context where the build should be executed
         :return: instance of build.build_response.BuildResponse
         """
+        build_request.set_openshift_required_version(self.os_conf.get_openshift_required_version())
         build = build_request.render()
         response = self.os.create_build(json.dumps(build), namespace=namespace)
         build_response = BuildResponse(response)
@@ -252,7 +253,7 @@ class OSBS(object):
             build_host=self.build_conf.get_build_host(),
             authoritative_registry=self.build_conf.get_authoritative_registry(),
             yum_repourls=yum_repourls,
-            source_secret=self.build_conf.get_source_secret(),
+            pulp_secret=self.build_conf.get_pulp_secret(),
             use_auth=self.build_conf.get_use_auth(),
             pulp_registry=self.os_conf.get_pulp_registry(),
             nfs_server_path=self.os_conf.get_nfs_server_path(),
@@ -260,6 +261,7 @@ class OSBS(object):
             git_push_url=self.build_conf.get_git_push_url(),
             git_push_username=self.build_conf.get_git_push_username(),
         )
+        build_request.set_openshift_required_version(self.os_conf.get_openshift_required_version())
         response = self._create_build_config_and_build(build_request, namespace)
         build_response = BuildResponse(response)
         logger.debug(build_response.json)
@@ -295,6 +297,7 @@ class OSBS(object):
             yum_repourls=yum_repourls,
             use_auth=self.build_conf.get_use_auth(),
         )
+        build_request.set_openshift_required_version(self.os_conf.get_openshift_required_version())
         response = self._create_build_config_and_build(build_request, namespace)
         build_response = BuildResponse(response)
         logger.debug(build_response.json)

--- a/osbs/build/spec.py
+++ b/osbs/build/spec.py
@@ -159,7 +159,7 @@ class ProdSpec(CommonSpec):
     kojiroot = BuildParam("kojiroot", allow_none=True)
     kojihub = BuildParam("kojihub", allow_none=True)
     image_tag = BuildParam("image_tag")
-    source_secret = BuildParam("source_secret", allow_none=True)
+    pulp_secret = BuildParam("pulp_secret", allow_none=True)
     pulp_registry = BuildParam("pulp_registry", allow_none=True)
     nfs_server_path = BuildParam("nfs_server_path", allow_none=True)
     nfs_dest_dir = BuildParam("nfs_dest_dir", allow_none=True)
@@ -177,7 +177,7 @@ class ProdSpec(CommonSpec):
             self.koji_target,
             self.kojiroot,
             self.kojihub,
-            self.source_secret,
+            self.pulp_secret,
             self.pulp_registry,
             self.nfs_server_path,
             self.git_push_url,
@@ -187,7 +187,8 @@ class ProdSpec(CommonSpec):
     def set_params(self, sources_command=None, architecture=None, vendor=None,
                    build_host=None, authoritative_registry=None,
                    koji_target=None, kojiroot=None, kojihub=None,
-                   source_secret=None, pulp_registry=None, nfs_server_path=None,
+                   source_secret=None, # compatibility name for pulp_secret
+                   pulp_secret=None, pulp_registry=None, nfs_server_path=None,
                    nfs_dest_dir=None, git_branch=None, base_image=None,
                    name_label=None, git_push_url=None, git_push_username=None,
                    **kwargs):
@@ -200,7 +201,7 @@ class ProdSpec(CommonSpec):
         self.koji_target.value = koji_target
         self.kojiroot.value = kojiroot
         self.kojihub.value = kojihub
-        self.source_secret.value = source_secret
+        self.pulp_secret.value = pulp_secret or source_secret
         self.pulp_registry.value = pulp_registry
         self.nfs_server_path.value = nfs_server_path
         self.nfs_dest_dir.value = nfs_dest_dir

--- a/osbs/conf.py
+++ b/osbs/conf.py
@@ -102,6 +102,27 @@ class Configuration(object):
         else:
             return value
 
+    def get_openshift_required_version(self):
+        """
+        Get minimum version of openshift we require
+
+        :return: list, ints representing version parts, most significant first
+        """
+        verstring = self._get_value("openshift_required_version",
+                                    GENERAL_CONFIGURATION_SECTION,
+                                    "openshift_required_version",
+                                    can_miss=True)
+        if verstring:
+            try:
+                openshift_required_version = [int(x)
+                                              for x in verstring.split('.')]
+            except ValueError:
+                pass
+
+            return openshift_required_version
+
+        return None
+
     def get_openshift_base_uri(self):
         """
         https://<host>[:<port>]/
@@ -235,9 +256,19 @@ class Configuration(object):
     def get_use_auth(self):
         return self._get_value("use_auth", self.conf_section, "use_auth", can_miss=True, is_bool_val=True)
 
+    def get_pulp_secret(self):
+        secret = self._get_value("pulp_secret", self.conf_section,
+                                 "pulp_secret", can_miss=True)
+        if not secret:
+            secret = self._get_value("source_secret", self.conf_section,
+                                     "pulp_secret", can_miss=True)
+        return secret
+
     def get_source_secret(self):
-        return self._get_value("source_secret", self.conf_section,
-                               "source_secret", can_miss=True)
+        """
+        Compatibility name for get_pulp_secret()
+        """
+        return self.get_pulp_secret()
 
     def get_nfs_server_path(self):
         return self._get_value("nfs_server_path", self.conf_section,

--- a/osbs/constants.py
+++ b/osbs/constants.py
@@ -40,3 +40,6 @@ PROD_BUILD_TYPE = "prod"
 PROD_WITHOUT_KOJI_BUILD_TYPE = "prod-without-koji"
 PROD_WITH_SECRET_BUILD_TYPE = "prod-with-secret"
 SIMPLE_BUILD_TYPE = "simple"
+
+# Where will secrets be mounted?
+SECRETS_PATH = "/var/run/secrets/atomic-reactor"

--- a/tests/fake_api.py
+++ b/tests/fake_api.py
@@ -250,6 +250,33 @@ use_auth = false
     return osbs
 
 
+@pytest.fixture
+def osbs106(openshift):
+    with NamedTemporaryFile(mode="wt") as fp:
+        fp.write("""
+[general]
+build_json_dir = {build_json_dir}
+openshift_required_version = 1.0.6
+[default]
+openshift_uri = /
+registry_uri = registry.example.com
+sources_command = fedpkg sources
+vendor = Example, Inc.
+build_host = localhost
+authoritative_registry = registry.example.com
+koji_root = http://koji.example.com/kojiroot
+koji_hub = http://koji.example.com/kojihub
+build_type = simple
+use_auth = false
+""".format (build_json_dir="inputs"))
+        fp.flush()
+        dummy_config = Configuration(fp.name)
+        osbs = OSBS(dummy_config, dummy_config)
+
+    osbs.os = openshift
+    return osbs
+
+
 class ResponseMapping(object):
     def __init__(self, version, lookup):
         self.version = version

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -19,7 +19,7 @@ from osbs import utils
 
 from tests.constants import (TEST_ARCH, TEST_BUILD, TEST_COMPONENT, TEST_GIT_BRANCH, TEST_GIT_REF,
                              TEST_GIT_URI, TEST_TARGET, TEST_USER)
-from tests.fake_api import openshift, osbs
+from tests.fake_api import openshift, osbs, osbs106
 
 
 class TestOSBS(object):
@@ -47,6 +47,23 @@ class TestOSBS(object):
                                           TEST_GIT_BRANCH, TEST_USER,
                                           TEST_COMPONENT, TEST_TARGET, TEST_ARCH)
         assert isinstance(response, BuildResponse)
+
+    def test_create_prod_build_set_required_version(self, osbs106):
+        class MockParser(object):
+            labels = {'Name': 'fedora23/something'}
+            baseimage = 'fedora23/python'
+        (flexmock(utils)
+            .should_receive('get_df_parser')
+            .with_args(TEST_GIT_URI, TEST_GIT_REF, TEST_GIT_BRANCH)
+            .and_return(MockParser()))
+        (flexmock(BuildRequest)
+            .should_receive('set_openshift_required_version')
+            .with_args([1, 0, 6])
+            .once())
+        response = osbs106.create_prod_build(TEST_GIT_URI, TEST_GIT_REF,
+                                             TEST_GIT_BRANCH, TEST_USER,
+                                             TEST_COMPONENT, TEST_TARGET,
+                                             TEST_ARCH)
 
     def test_create_prod_with_secret_build(self, osbs):
         # TODO: test situation when a buildconfig already exists


### PR DESCRIPTION
New configuration parameter `openshift_required_version`.
When this is 1.0.6 or later, use the `secrets` array to give pulp its secret.
Otherwise, use the `sourceSecret`.
Rename `source_secret` build parameter to `pulp_secret` but retain compatibility.