### PR TITLE
New API method get_pod_for_build() (fixes #238)

### DIFF
--- a/osbs/build/__init__.py
+++ b/osbs/build/__init__.py
@@ -8,3 +8,4 @@ of the BSD license. See the LICENSE file for details.
 from __future__ import absolute_import
 
 from .build_response import BuildResponse
+from .pod_response import PodResponse

--- a/osbs/build/pod_response.py
+++ b/osbs/build/pod_response.py
@@ -1,0 +1,53 @@
+"""
+Copyright (c) 2015 Red Hat, Inc
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+"""
+from __future__ import print_function, absolute_import, unicode_literals
+
+import json
+import logging
+
+from osbs.utils import graceful_chain_get
+
+
+logger = logging.getLogger(__name__)
+
+
+class PodResponse(object):
+    """
+    Wrapper for JSON describing build pod
+    """
+
+    def __init__(self, pod):
+        """
+        :param request: http.Request
+        """
+        self._json = pod
+
+    @property
+    def json(self):
+        return self._json
+
+    def get_container_image_ids(self):
+        """
+        Find the image IDs the containers use.
+
+        :return: dict, image tag to docker ID
+        """
+
+        statuses = graceful_chain_get(self.json, "status", "containerStatuses")
+        if statuses is None:
+            return {}
+
+        def remove_prefix(image_id, prefix):
+            if image_id.startswith(prefix):
+                return image_id[len(prefix):]
+
+            return image_id
+
+        return dict([(status['image'], remove_prefix(status['imageID'],
+                                                     'docker://'))
+                     for status in statuses])

--- a/osbs/cli/main.py
+++ b/osbs/cli/main.py
@@ -217,6 +217,19 @@ def cmd_get_user(args, osbs):
         print("Name: \"%s\"\nFull Name: \"%s\"" % (name, full_name))
 
 
+def cmd_get_build_image_id(args, osbs):
+    pod = osbs.get_pod_for_build(args.BUILD_ID[0], namespace=args.namespace)
+    if args.output == 'json':
+        json_output = pod.get_container_image_ids()
+        print_json_nicely(json_output)
+    elif args.output == 'text':
+        format_str = "{tag:18} {image:64}"
+        print(format_str.format(tag='TAG', image='IMAGE ID'), file=sys.stderr)
+        image_ids = pod.get_container_image_ids()
+        for name, image_id in image_ids.items():
+            print(format_str.format(tag=name, image=image_id))
+
+
 def str_on_2_unicode_on_3(s):
     """
     argparse is way too awesome when doing repr() on choices when printing usage
@@ -319,6 +332,12 @@ def cli():
     build_parser.add_argument("--storage-limit", action='store', required=False,
                               help="storage limit")
     build_parser.set_defaults(func=cmd_build)
+
+    get_build_image_id = subparsers.add_parser(str_on_2_unicode_on_3('get-build-image-id'),
+                                                help='get build container image ID',
+                                                description='get build container images for a build in a namespace')
+    get_build_image_id.add_argument("BUILD_ID", help="build ID", nargs=1)
+    get_build_image_id.set_defaults(func=cmd_get_build_image_id)
 
     parser.add_argument("--openshift-uri", action='store', metavar="URL",
                         help="openshift URL to remote API")

--- a/osbs/conf.py
+++ b/osbs/conf.py
@@ -115,15 +115,28 @@ class Configuration(object):
         # This is not configurable.
         return "v1"
 
+    def _get_api_uri(self, keyword):
+        base_uri = self.get_openshift_base_uri()
+        version = self.get_openshift_api_version()
+        return urljoin(base_uri,
+                       "/{keyword}/{version}/".format(keyword=keyword,
+                                                      version=version))
+
+    def get_k8s_api_uri(self):
+        """
+        https://<host>[:<port>]/api/<API version>/
+
+        :return: str
+        """
+        return self._get_api_uri('api')
+
     def get_openshift_api_uri(self):
         """
         https://<host>[:<port>]/oapi/<API version>/
 
         :return: str
         """
-        base_uri = self.get_openshift_base_uri()
-        version = self.get_openshift_api_version()
-        return urljoin(base_uri, "/oapi/{version}/".format(version=version))
+        return self._get_api_uri('oapi')
 
     def get_openshift_oauth_api_uri(self):
         """

--- a/tests/mock_jsons/0.5.4/pods.json
+++ b/tests/mock_jsons/0.5.4/pods.json
@@ -1,0 +1,144 @@
+{
+    "apiVersion": "v1",
+    "items": [
+        {
+            "metadata": {
+                "annotations": {
+                    "openshift.io/build.name": "build-20150820173208-1",
+                    "openshift.io/scc": "privileged"
+                },
+                "creationTimestamp": "2015-09-02T14:34:50Z",
+                "labels": {
+                    "openshift.io/build.name": "build-20150820173208-1"
+                },
+                "name": "build-20150820173208-1-build",
+                "namespace": "default",
+                "resourceVersion": "982",
+                "selfLink": "/api/v1/namespaces/default/pods/build-20150820173208-1-build",
+                "uid": "c4904f51-517f-11e5-88ed-52540080e6f8"
+            },
+            "spec": {
+                "containers": [
+                    {
+                        "env": [
+                            {
+                                "name": "BUILD",
+                                "value": "{\"kind\":\"Build\",\"apiVersion\":\"v1\",...}"
+                            },
+                            {
+                                "name": "SOURCE_REPOSITORY",
+                                "value": "https://github.com/TomasTomecek/docker-hello-world.git"
+                            },
+                            {
+                                "name": "DOCK_PLUGINS",
+                                "value": "{\"prebuild_plugins\": [{\"args\": {}, \"name\": \"pull_base_image\"}, {\"name\": \"change_from_in_dockerfile\"}, {\"name\": \"dockerfile_content\"}], \"exit_plugins\": [{\"args\": {\"url\": \"https://osbs.localdomain:8443/\", \"verify_ssl\": false, \"use_auth\": false}, \"name\": \"store_metadata_in_osv3\"}, {\"name\": \"remove_built_image\"}], \"postbuild_plugins\": [{\"args\": {\"image_id\": \"BUILT_IMAGE_ID\"}, \"name\": \"all_rpm_packages\"}]}"
+                            },
+                            {
+                                "name": "OPENSHIFT_CUSTOM_BUILD_BASE_IMAGE",
+                                "value": "buildroot:latest"
+                            },
+                            {
+                                "name": "DOCKER_SOCKET",
+                                "value": "/var/run/docker.sock"
+                            },
+                            {
+                                "name": "SOURCE_URI",
+                                "value": "https://github.com/TomasTomecek/docker-hello-world.git"
+                            },
+                            {
+                                "name": "SOURCE_REF",
+                                "value": "master"
+                            },
+                            {
+                                "name": "OUTPUT_REGISTRY"
+                            },
+                            {
+                                "name": "OUTPUT_IMAGE",
+                                "value": "twaugh/component:20150820174104"
+                            }
+                        ],
+                        "image": "buildroot:latest",
+                        "imagePullPolicy": "IfNotPresent",
+                        "name": "custom-build",
+                        "resources": {},
+                        "securityContext": {
+                            "privileged": true
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/var/run/docker.sock",
+                                "name": "docker-socket"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "builder-token-p62zo",
+                                "readOnly": true
+                            }
+                        ]
+                    }
+                ],
+                "dnsPolicy": "ClusterFirst",
+                "host": "osbs.localdomain",
+                "imagePullSecrets": [
+                    {
+                        "name": "builder-dockercfg-7zusx"
+                    }
+                ],
+                "nodeName": "osbs.localdomain",
+                "restartPolicy": "Never",
+                "serviceAccount": "builder",
+                "serviceAccountName": "builder",
+                "volumes": [
+                    {
+                        "hostPath": {
+                            "path": "/var/run/docker.sock"
+                        },
+                        "name": "docker-socket"
+                    },
+                    {
+                        "name": "builder-token-p62zo",
+                        "secret": {
+                            "secretName": "builder-token-p62zo"
+                        }
+                    }
+                ]
+            },
+            "status": {
+                "conditions": [
+                    {
+                        "status": "False",
+                        "type": "Ready"
+                    }
+                ],
+                "containerStatuses": [
+                    {
+                        "containerID": "docker://d9e6dee11d7acf361f44572d839a5108034693bc902eb2d490b0b2e6f1b6d45e",
+                        "image": "buildroot:latest",
+                        "imageID": "docker://8daf4790420f666bea3bfe56d1df720d9bc03e0a85de6278eab5f13a4641b509",
+                        "lastState": {},
+                        "name": "custom-build",
+                        "ready": false,
+                        "restartCount": 0,
+                        "state": {
+                            "terminated": {
+                                "containerID": "docker://d9e6dee11d7acf361f44572d839a5108034693bc902eb2d490b0b2e6f1b6d45e",
+                                "exitCode": 1,
+                                "finishedAt": "2015-09-02T14:35:26Z",
+                                "startedAt": "2015-09-02T14:34:51Z"
+                            }
+                        }
+                    }
+                ],
+                "hostIP": "192.168.124.195",
+                "phase": "Failed",
+                "startTime": "2015-09-02T14:34:50Z"
+            }
+        }
+    ],
+    "kind": "PodList",
+    "metadata": {
+        "resourceVersion": "1970",
+        "selfLink": "/api/v1/namespaces/default/pods/"
+    }
+}

--- a/tests/mock_jsons/1.0.4/pods.json
+++ b/tests/mock_jsons/1.0.4/pods.json
@@ -1,0 +1,144 @@
+{
+    "apiVersion": "v1",
+    "items": [
+        {
+            "metadata": {
+                "annotations": {
+                    "openshift.io/build.name": "build-20150820173208-1",
+                    "openshift.io/scc": "privileged"
+                },
+                "creationTimestamp": "2015-09-02T14:34:50Z",
+                "labels": {
+                    "openshift.io/build.name": "build-20150820173208-1"
+                },
+                "name": "build-20150820173208-1-build",
+                "namespace": "default",
+                "resourceVersion": "982",
+                "selfLink": "/api/v1/namespaces/default/pods/build-20150820173208-1-build",
+                "uid": "c4904f51-517f-11e5-88ed-52540080e6f8"
+            },
+            "spec": {
+                "containers": [
+                    {
+                        "env": [
+                            {
+                                "name": "BUILD",
+                                "value": "{\"kind\":\"Build\",\"apiVersion\":\"v1\",...}"
+                            },
+                            {
+                                "name": "SOURCE_REPOSITORY",
+                                "value": "https://github.com/TomasTomecek/docker-hello-world.git"
+                            },
+                            {
+                                "name": "DOCK_PLUGINS",
+                                "value": "{\"prebuild_plugins\": [{\"args\": {}, \"name\": \"pull_base_image\"}, {\"name\": \"change_from_in_dockerfile\"}, {\"name\": \"dockerfile_content\"}], \"exit_plugins\": [{\"args\": {\"url\": \"https://osbs.localdomain:8443/\", \"verify_ssl\": false, \"use_auth\": false}, \"name\": \"store_metadata_in_osv3\"}, {\"name\": \"remove_built_image\"}], \"postbuild_plugins\": [{\"args\": {\"image_id\": \"BUILT_IMAGE_ID\"}, \"name\": \"all_rpm_packages\"}]}"
+                            },
+                            {
+                                "name": "OPENSHIFT_CUSTOM_BUILD_BASE_IMAGE",
+                                "value": "buildroot:latest"
+                            },
+                            {
+                                "name": "DOCKER_SOCKET",
+                                "value": "/var/run/docker.sock"
+                            },
+                            {
+                                "name": "SOURCE_URI",
+                                "value": "https://github.com/TomasTomecek/docker-hello-world.git"
+                            },
+                            {
+                                "name": "SOURCE_REF",
+                                "value": "master"
+                            },
+                            {
+                                "name": "OUTPUT_REGISTRY"
+                            },
+                            {
+                                "name": "OUTPUT_IMAGE",
+                                "value": "twaugh/component:20150820174104"
+                            }
+                        ],
+                        "image": "buildroot:latest",
+                        "imagePullPolicy": "IfNotPresent",
+                        "name": "custom-build",
+                        "resources": {},
+                        "securityContext": {
+                            "privileged": true
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/var/run/docker.sock",
+                                "name": "docker-socket"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "builder-token-p62zo",
+                                "readOnly": true
+                            }
+                        ]
+                    }
+                ],
+                "dnsPolicy": "ClusterFirst",
+                "host": "osbs.localdomain",
+                "imagePullSecrets": [
+                    {
+                        "name": "builder-dockercfg-7zusx"
+                    }
+                ],
+                "nodeName": "osbs.localdomain",
+                "restartPolicy": "Never",
+                "serviceAccount": "builder",
+                "serviceAccountName": "builder",
+                "volumes": [
+                    {
+                        "hostPath": {
+                            "path": "/var/run/docker.sock"
+                        },
+                        "name": "docker-socket"
+                    },
+                    {
+                        "name": "builder-token-p62zo",
+                        "secret": {
+                            "secretName": "builder-token-p62zo"
+                        }
+                    }
+                ]
+            },
+            "status": {
+                "conditions": [
+                    {
+                        "status": "False",
+                        "type": "Ready"
+                    }
+                ],
+                "containerStatuses": [
+                    {
+                        "containerID": "docker://d9e6dee11d7acf361f44572d839a5108034693bc902eb2d490b0b2e6f1b6d45e",
+                        "image": "buildroot:latest",
+                        "imageID": "docker://8daf4790420f666bea3bfe56d1df720d9bc03e0a85de6278eab5f13a4641b509",
+                        "lastState": {},
+                        "name": "custom-build",
+                        "ready": false,
+                        "restartCount": 0,
+                        "state": {
+                            "terminated": {
+                                "containerID": "docker://d9e6dee11d7acf361f44572d839a5108034693bc902eb2d490b0b2e6f1b6d45e",
+                                "exitCode": 1,
+                                "finishedAt": "2015-09-02T14:35:26Z",
+                                "startedAt": "2015-09-02T14:34:51Z"
+                            }
+                        }
+                    }
+                ],
+                "hostIP": "192.168.124.195",
+                "phase": "Failed",
+                "startTime": "2015-09-02T14:34:50Z"
+            }
+        }
+    ],
+    "kind": "PodList",
+    "metadata": {
+        "resourceVersion": "1970",
+        "selfLink": "/api/v1/namespaces/default/pods/"
+    }
+}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -14,6 +14,7 @@ import six
 from osbs.constants import PROD_BUILD_TYPE, PROD_WITHOUT_KOJI_BUILD_TYPE, SIMPLE_BUILD_TYPE
 from osbs.build.build_request import BuildRequest, SimpleBuild, ProductionBuild
 from osbs.build.build_response import BuildResponse
+from osbs.build.pod_response import PodResponse
 from osbs.http import HttpResponse
 from osbs import utils
 
@@ -33,6 +34,15 @@ class TestOSBS(object):
         # All the timestamps are understood
         for build in response_list:
             assert build.get_time_created_in_seconds() != 0.0
+
+    def test_get_pod_for_build(self, osbs):
+        pod = osbs.get_pod_for_build(TEST_BUILD)
+        assert isinstance(pod, PodResponse)
+        images = pod.get_container_image_ids()
+        assert isinstance(images, dict)
+        assert 'buildroot:latest' in images
+        image_id = images['buildroot:latest']
+        assert not image_id.startswith("docker:")
 
     def test_create_prod_build(self, osbs):
         # TODO: test situation when a buildconfig already exists

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7,6 +7,7 @@ of the BSD license. See the LICENSE file for details.
 """
 import six
 
+from osbs.http import HttpResponse
 from osbs.constants import BUILD_FINISHED_STATES
 
 from tests.constants import TEST_BUILD, TEST_LABEL, TEST_LABEL_VALUE
@@ -22,6 +23,11 @@ class TestOpenshift(object):
         l = openshift.list_builds()
         assert l is not None
         assert bool(l.json())  # is there at least something
+
+    def test_list_pods(self, openshift):
+        response = openshift.list_pods(label="openshift.io/build.name=%s" %
+                                       TEST_BUILD)
+        assert isinstance(response, HttpResponse)
 
     def test_get_oauth_token(self, openshift):
         token = openshift.get_oauth_token()


### PR DESCRIPTION
Querying pods requires a different API endpoint as it is a Kubernetes API rather than specifically Origin, so I've added a new `Openshift` constructor parameter to allow for that.

There is a new `PodResponse` class, which `OSBS.get_pods_for_build()` returns a list of (cf. `list_builds`).

I've added a test case for it, which required some mock JSON. To fetch that, I also added a command line verb for it as well... which ironically has decreased overall test coverage.