### PR TITLE
Fixes for updating BuildConfig

### DIFF
--- a/osbs/core.py
+++ b/osbs/core.py
@@ -199,8 +199,10 @@ class Openshift(object):
 
     def update_build_config(self, build_config_id, build_config_json, namespace=DEFAULT_NAMESPACE):
         url = self._build_url("namespaces/%s/buildconfigs/%s" % (namespace, build_config_id))
-        return self._put(url, data=build_config_json,
-                         headers={"Content-Type": "application/json"})
+        response = self._put(url, data=build_config_json,
+                             headers={"Content-Type": "application/json"})
+        check_response(response)
+        return response
 
     def instantiate_build_config(self, build_config_id, namespace=DEFAULT_NAMESPACE):
         url = self._build_url("namespaces/%s/buildconfigs/%s/instantiate" %

--- a/osbs/utils.py
+++ b/osbs/utils.py
@@ -102,7 +102,13 @@ def get_imagestreamtag_from_image(image):
         ret = '%s/%s' % (parts[1], parts[2])
 
     # ImageStream names cannot contain '/'
-    return ret.replace('/', '-')
+    ret = ret.replace('/', '-')
+
+    # If there is no ':' suffix value, add one
+    if ret.find(':') == -1:
+        ret += ":latest"
+
+    return ret
 
 def get_time_from_rfc3399(rfc3399):
     """

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -36,12 +36,12 @@ def test_git_repo_humanish_part_from_uri(uri, humanish):
 
 
 @pytest.mark.parametrize(('img', 'expected'), [
-    ('fedora23', 'fedora23'),
+    ('fedora23', 'fedora23:latest'),
     ('fedora23:sometag', 'fedora23:sometag'),
-    ('fedora23/python', 'fedora23-python'),
+    ('fedora23/python', 'fedora23-python:latest'),
     ('fedora23/python:sometag', 'fedora23-python:sometag'),
-    ('docker.io/fedora23', 'fedora23'),
-    ('docker.io/fedora23/python', 'fedora23-python'),
+    ('docker.io/fedora23', 'fedora23:latest'),
+    ('docker.io/fedora23/python', 'fedora23-python:latest'),
     ('docker.io/fedora23/python:sometag', 'fedora23-python:sometag'),
 ])
 def test_get_imagestreamtag_from_image(img, expected):


### PR DESCRIPTION
This pull request has fixes for two bugs which combined to cause #241. I was testing against Origin 1.0.5, which perhaps has stricter validation that earlier releases.

The first issue is that we were not checking whether a PUT request for an updated BuildConfig was successful.

The second issue is that `get_imagestreamtag_from_image()` could return an ImageStream-format name (e.g. 'fedora') instead of an ImageStreamTag (eg. 'fedora:latest').

The second issue became apparent once the first was fixed:

```
osbs.exceptions.OsbsResponseException: {
  "kind": "Status",
  "apiVersion": "v1",
  "metadata": {},
  "status": "Failure",
  "message": "BuildConfig \"docker-hello-world-fedora\" is invalid: triggers[0].from.name: invalid value 'fedora', Details: ImageStreamTag object references must be in the form \u003cname\u003e:\u003ctag\u003e",
  "reason": "Invalid",
  "details": {
    "id": "docker-hello-world-rhel-fedora",
    "kind": "BuildConfig",
    "causes": [
      {
        "reason": "FieldValueInvalid",
        "message": "invalid value 'fedora', Details: ImageStreamTag object references must be in the form \u003cname\u003e:\u003ctag\u003e",
        "field": "triggers[0].from.name"
      }
    ]
  },
  "code": 422
}
```
