### PR TITLE
Use service account token inside build pod

### DIFF
--- a/docs/configuration_file.md
+++ b/docs/configuration_file.md
@@ -81,6 +81,8 @@ Some options are also mandatory.
 
 * `use_auth` (*optional*, `boolean`) — by default, osbs-client is trying to authenticate against OpenShift master to get OAuth token; you may disable the process with this option
 
+* `builder_use_auth` (*optional*, `boolean`) — whether atomic-reactor plugins which in turn use osbs-client from within the build pod should try to authenticate against OpenShift master; defaults to `use_auth`
+
 * `source_secret` (*optional*, `string`) — name of [kubernetes secret](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/design/secrets.md) to use for pulp plugin
 
 * `nfs_server_path` (*optional*, `string`) — NFS server and path to use for storing built image (it is passed to `mount` command)

--- a/osbs/api.py
+++ b/osbs/api.py
@@ -253,7 +253,7 @@ class OSBS(object):
             authoritative_registry=self.build_conf.get_authoritative_registry(),
             yum_repourls=yum_repourls,
             source_secret=self.build_conf.get_source_secret(),
-            use_auth=self.build_conf.get_use_auth(),
+            use_auth=self.build_conf.get_builder_use_auth(),
             pulp_registry=self.os_conf.get_pulp_registry(),
             nfs_server_path=self.os_conf.get_nfs_server_path(),
             nfs_dest_dir=self.build_conf.get_nfs_destination_dir(),
@@ -293,7 +293,7 @@ class OSBS(object):
             registry_uri=self.build_conf.get_registry_uri(),
             openshift_uri=self.os_conf.get_openshift_base_uri(),
             yum_repourls=yum_repourls,
-            use_auth=self.build_conf.get_use_auth(),
+            use_auth=self.build_conf.get_builder_use_auth(),
         )
         response = self._create_build_config_and_build(build_request, namespace)
         build_response = BuildResponse(response)

--- a/osbs/conf.py
+++ b/osbs/conf.py
@@ -235,6 +235,12 @@ class Configuration(object):
     def get_use_auth(self):
         return self._get_value("use_auth", self.conf_section, "use_auth", can_miss=True, is_bool_val=True)
 
+    def get_builder_use_auth(self):
+        return self._get_value("builder_use_auth", self.conf_section,
+                               "builder_use_auth", can_miss=True,
+                               default=self.get_use_auth(),
+                               is_bool_val=True)
+
     def get_source_secret(self):
         return self._get_value("source_secret", self.conf_section,
                                "source_secret", can_miss=True)

--- a/osbs/constants.py
+++ b/osbs/constants.py
@@ -40,3 +40,8 @@ PROD_BUILD_TYPE = "prod"
 PROD_WITHOUT_KOJI_BUILD_TYPE = "prod-without-koji"
 PROD_WITH_SECRET_BUILD_TYPE = "prod-with-secret"
 SIMPLE_BUILD_TYPE = "simple"
+
+# How to authenticate from within a pod
+SERVICEACCOUNT_SECRET = "/var/run/secrets/kubernetes.io/serviceaccount"
+SERVICEACCOUNT_TOKEN = "token"
+SERVICEACCOUNT_CACRT = "ca.crt"

--- a/osbs/http.py
+++ b/osbs/http.py
@@ -152,7 +152,7 @@ class HttpStream(object):
     """
 
     def __init__(self, url, method, data=None, kerberos_auth=False,
-                 allow_redirects=True, verify_ssl=True, use_json=False,
+                 allow_redirects=True, verify_ssl=True, ca=None, use_json=False,
                  headers=None, stream=False, username=None, password=None,
                  client_cert=None, client_key=None, verbose=False):
         self.finished = False  # have we read all data?
@@ -192,6 +192,10 @@ class HttpStream(object):
         self.c.setopt(pycurl.DEBUGFUNCTION, self._curl_debug)
         self.c.setopt(pycurl.SSL_VERIFYPEER, 1 if verify_ssl else 0)
         self.c.setopt(pycurl.SSL_VERIFYHOST, 2 if verify_ssl else 0)
+        if ca:
+            logger.info("Setting CAINFO to %r", ca)
+            self.c.setopt(pycurl.CAINFO, ca)
+
         self.c.setopt(pycurl.VERBOSE, 1 if verbose else 0)
         if username and password:
             username = username.encode('utf-8')


### PR DESCRIPTION
This allows authentication to OpenShift from within the build pod, by looking for the `/var/run/secrets/kubernetes.io/serviceaccount` path and using it if available.

It only does so if `use_auth` is not set to `False` and no other authentication credentials have been supplied.

This behaviour can be explicitly enabled or disabled by setting `builder_use_auth = false` in the configuration file.

Why might you explicitly enable it? For instance, if the only authorized users use client certificates (so `use_auth` must be off), the plugins will need to authenticate and the only way they can do so is by enabling `builder_use_auth`.

Why might you explicitly disable it? For instance, if the osbs-client version installed in the buildroot image is older than this pull request merge, plugins will not be able to authenticate without additional authentication credentials.