### PR TITLE
Spell RFC3339 correctly

### DIFF
--- a/osbs/build/build_response.py
+++ b/osbs/build/build_response.py
@@ -10,7 +10,7 @@ from __future__ import print_function, absolute_import, unicode_literals
 import json
 import logging
 
-from osbs.utils import graceful_chain_get, get_time_from_rfc3399
+from osbs.utils import graceful_chain_get, get_time_from_rfc3339
 from osbs.constants import BUILD_FINISHED_STATES, BUILD_RUNNING_STATES, \
     BUILD_SUCCEEDED_STATES, BUILD_FAILED_STATES, BUILD_PENDING_STATES
 
@@ -73,7 +73,7 @@ class BuildResponse(object):
         return graceful_chain_get(self.json, "metadata", "creationTimestamp")
 
     def get_time_created_in_seconds(self):
-        return get_time_from_rfc3399(self.get_time_created())
+        return get_time_from_rfc3339(self.get_time_created())
 
     def get_annotations(self):
         return graceful_chain_get(self.json, "metadata", "annotations")

--- a/osbs/utils.py
+++ b/osbs/utils.py
@@ -118,19 +118,19 @@ def get_imagestreamtag_from_image(image):
 
     return ret
 
-def get_time_from_rfc3399(rfc3399):
+def get_time_from_rfc3339(rfc3339):
     """
-    return time tuple from an RFC 3399-formatted time string
+    return time tuple from an RFC 3339-formatted time string
 
-    :param rfc3399: str, time in RFC 3399 format
+    :param rfc3339: str, time in RFC 3339 format
     :return: float, seconds since the Epoch
     """
 
     try:
-        # Decode the RFC 3399 date with no fractional seconds
+        # Decode the RFC 3339 date with no fractional seconds
         # (the format Origin provides)
-        time_tuple = strptime(rfc3399, '%Y-%m-%dT%H:%M:%SZ')
+        time_tuple = strptime(rfc3339, '%Y-%m-%dT%H:%M:%SZ')
     except ValueError:
-        raise RuntimeError("Time format not understood: %s" % rfc3399)
+        raise RuntimeError("Time format not understood: %s" % rfc3339)
 
     return timegm(time_tuple)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,7 +13,7 @@ import datetime
 from osbs.utils import (deep_update,
                         get_imagestreamtag_from_image,
                         git_repo_humanish_part_from_uri,
-                        get_time_from_rfc3399)
+                        get_time_from_rfc3339)
 from osbs.exceptions import OsbsException
 import osbs.kerberos_ccache
 
@@ -48,23 +48,23 @@ def test_get_imagestreamtag_from_image(img, expected):
     assert get_imagestreamtag_from_image(img) == expected
 
 
-@pytest.mark.parametrize(('rfc3399', 'seconds'), [
+@pytest.mark.parametrize(('rfc3339', 'seconds'), [
     ('2015-08-24T10:41:00Z', 1440412860.0),
 ])
-def test_get_time_from_rfc3399_valid(rfc3399, seconds):
-    assert get_time_from_rfc3399(rfc3399) == seconds
+def test_get_time_from_rfc3339_valid(rfc3339, seconds):
+    assert get_time_from_rfc3339(rfc3339) == seconds
 
 
-@pytest.mark.parametrize('rfc3399', [
+@pytest.mark.parametrize('rfc3339', [
     ('just completely invalid'),
 
-    # The implementation doesn't know enough about RFC 3399 to
+    # The implementation doesn't know enough about RFC 3339 to
     # distinguish between invalid and unsupported
     ('2015-08-24T10:41:00.1Z'),
 ])
-def test_get_time_from_rfc3399_invalid(rfc3399):
+def test_get_time_from_rfc3339_invalid(rfc3339):
     with pytest.raises(RuntimeError):
-        get_time_from_rfc3399(rfc3399)
+        get_time_from_rfc3339(rfc3339)
 
 
 KLIST_TEMPLATE = """


### PR DESCRIPTION
Let's at least spell RFC3339 correctly even if we can't get it working for any timezone but UTC (https://github.com/projectatomic/osbs-client/pull/232).