### PR TITLE
Use pkg_resources.parse_version() for handling version numbers

### DIFF
--- a/osbs/build/build_request.py
+++ b/osbs/build/build_request.py
@@ -10,6 +10,7 @@ from __future__ import print_function, absolute_import, unicode_literals
 import json
 import logging
 import os
+from pkg_resources import parse_version
 
 try:
     # py2
@@ -53,7 +54,7 @@ class BuildRequest(object):
         self._inner_template = None  # dock json
         self._dj = None
         self._resource_limits = None
-        self._openshift_required_version = [0, 5, 4]
+        self._openshift_required_version = parse_version('0.5.4')
 
     def set_params(self, **kwargs):
         """
@@ -216,7 +217,7 @@ class CommonBuild(BuildRequest):
 
         # For Origin 1.0.6 we'll use the 'secrets' array; for earlier
         # versions we'll just use 'sourceSecret'
-        if self._openshift_required_version < [1, 0, 6]:
+        if self._openshift_required_version < parse_version('1.0.6'):
             if 'secrets' in self.template['spec']['strategy']['customStrategy']:
                 del self.template['spec']['strategy']['customStrategy']['secrets']
         else:

--- a/osbs/conf.py
+++ b/osbs/conf.py
@@ -9,6 +9,7 @@ from __future__ import print_function, absolute_import, unicode_literals
 
 import logging
 import os
+from pkg_resources import parse_version
 
 try:
     # py2
@@ -106,14 +107,14 @@ class Configuration(object):
         """
         Get minimum version of openshift we require
 
-        :return: list, ints representing version parts, most significant first
+        :return: None, or else an object instance that allows comparisons
         """
         verstring = self._get_value("openshift_required_version",
                                     GENERAL_CONFIGURATION_SECTION,
                                     "openshift_required_version",
                                     can_miss=True)
         if verstring:
-            return [int(x) for x in verstring.split('.')]
+            return parse_version(verstring)
 
         return None
 

--- a/tests/build/test_build_request.py
+++ b/tests/build/test_build_request.py
@@ -8,6 +8,7 @@ of the BSD license. See the LICENSE file for details.
 import copy
 import json
 import os
+from pkg_resources import parse_version
 import shutil
 
 from osbs.build.build_request import BuildManager, BuildRequest, ProductionBuild
@@ -622,7 +623,7 @@ class TestBuildRequest(object):
         }
 
         # Default required version (0.5.4), implicitly and explicitly
-        for required in (None, [0, 5, 4]):
+        for required in (None, parse_version('0.5.4')):
             build_request = bm.get_build_request_by_type(PROD_BUILD_TYPE)
             if required is not None:
                 build_request.set_openshift_required_version(required)
@@ -656,7 +657,7 @@ class TestBuildRequest(object):
         # Set required version to 1.0.6
 
         build_request = bm.get_build_request_by_type(PROD_BUILD_TYPE)
-        build_request.set_openshift_required_version([1, 0, 6])
+        build_request.set_openshift_required_version(parse_version('1.0.6'))
         build_json = build_request.render()
         # Not using the sourceSecret scheme
         assert 'sourceSecret' not in build_json['spec']['source']

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -8,6 +8,7 @@ of the BSD license. See the LICENSE file for details.
 from types import GeneratorType
 
 from flexmock import flexmock
+from pkg_resources import parse_version
 import pytest
 import six
 
@@ -68,7 +69,7 @@ class TestOSBS(object):
             .and_return(MockParser()))
         (flexmock(BuildRequest)
             .should_receive('set_openshift_required_version')
-            .with_args([1, 0, 6])
+            .with_args(parse_version('1.0.6'))
             .once())
         response = osbs106.create_prod_build(TEST_GIT_URI, TEST_GIT_REF,
                                              TEST_GIT_BRANCH, TEST_USER,


### PR DESCRIPTION
The reason for this PR is to demonstrate a fix for the problem identified in https://github.com/projectatomic/osbs-client/pull/250#discussion_r40073359.

Does it make sense to do it this way?