### PR TITLE
Extract v2 digests from BuildResponse

### DIFF
--- a/osbs/build/build_response.py
+++ b/osbs/build/build_response.py
@@ -161,3 +161,8 @@ class BuildResponse(object):
     def get_base_image_name(self):
         return graceful_chain_get(self.get_annotations_or_labels(),
                                   "base-image-name")
+
+    def get_digests(self):
+        digests_json = graceful_chain_get(self.get_annotations_or_labels(), "digests")
+        if digests_json:
+            return json.loads(digests_json)

--- a/osbs/cli/main.py
+++ b/osbs/cli/main.py
@@ -98,6 +98,16 @@ Unique
             }
             repositories_str = repositories_template.format(**repositories_context)
 
+        digests_list = build.get_digests()
+        if digests_list is not None:
+            try:
+                digests_str = "\n".join(["{registry}/{repository}:{tag} {digest}".format(**dig)
+                                         for dig in digests_list])
+            except (TypeError, KeyError):
+                digests_str = "(invalid value)"
+        else:
+            digests_str = "(unset)"
+
         template = """\
 BUILD ID: {build_id}
 STATUS: {status}
@@ -130,7 +140,11 @@ IMAGE ID
 
 REPOSITORIES
 
-{repositories}"""
+{repositories}
+
+V2 DIGESTS
+
+{digests}"""
         context = {
             "build_id": build.get_build_name(),
             "status": build.status,
@@ -144,6 +158,7 @@ REPOSITORIES
             "base_image": build.get_base_image_name() or '(unset)',
             "base_image_id": build.get_base_image_id() or '(unset)',
             "image_id": build.get_image_id() or '(unset)',
+            "digests": digests_str,
         }
         print(template.format(**context))
 


### PR DESCRIPTION
Related to projectatomic/atomic-reactor#339 / projectatomic/atomic-reactor#352.

Simply returns the list of the JSON objects, like the other methods that return pieces of `BuildResponse`. I can rework it to return list of actual python object that can e.g. return the string that can be used to docker-pull the image by its digest, if desired.