### PR TITLE
Configure pulp_sync plugin

### DIFF
--- a/inputs/prod_inner.json
+++ b/inputs/prod_inner.json
@@ -112,6 +112,14 @@
       }
     },
     {
+      "name": "pulp_sync",
+      "args": {
+        "pulp_registry_name": "{{PULP_REGISTRY_NAME}}",
+        "docker_registry": "{{DOCKER_REGISTRY}}",
+        "dockpulp_loglevel": "INFO"
+      }
+    },
+    {
       "args": {
         "image_id": "BUILT_IMAGE_ID"
       },

--- a/osbs/build/build_request.py
+++ b/osbs/build/build_request.py
@@ -320,16 +320,18 @@ class ProductionBuild(CommonBuild):
     def set_secret_for_plugin(self, plugin, secret):
         if 'secrets' in self.template['spec']['strategy']['customStrategy']:
             # origin 1.0.6 and newer
-            secret_path = os.path.join(SECRETS_PATH, secret)
-            logger.info("Configuring %s secret at %s", secret, secret_path)
-            custom = self.template['spec']['strategy']['customStrategy']
-            custom['secrets'].append({
-                'secretSource': {
-                    'name': secret,
-                },
-                'mountPath': secret_path,
-            })
-            self.dj.dock_json_set_arg(*(plugin + (secret_path,)))
+            if self.dj.dock_json_has_plugin_conf(plugin[0], plugin[1]):
+                secret_path = os.path.join(SECRETS_PATH, secret)
+                logger.info("Configuring %s secret at %s", secret, secret_path)
+                custom = self.template['spec']['strategy']['customStrategy']
+                custom['secrets'].append({
+                    'secretSource': {
+                        'name': secret,
+                    },
+                    'mountPath': secret_path,
+                })
+                self.dj.dock_json_set_arg(*(plugin + (secret_path,)))
+
         elif plugin[1] == 'pulp_push':
             # setting pulp_push secret for origin 1.0.5 and earlier
             #  we only use this way to preserve backwards compat for pulp_push plugin,
@@ -389,7 +391,10 @@ class ProductionBuild(CommonBuild):
         except (KeyError, IndexError):
             tag_and_push_registries = {}
 
-        if 'v1' not in versions:
+        if 'v1' in versions:
+            logger.info("removing v2-only plugin: pulp_sync")
+            self.dj.remove_plugin('postbuild_plugins', 'pulp_sync')
+        else:
             # Remove v1-only plugins
             for phase, name in [('postbuild_plugins', 'compress'),
                                 ('postbuild_plugins', 'cp_built_image_to_nfs'),
@@ -401,10 +406,6 @@ class ProductionBuild(CommonBuild):
             self.remove_tag_and_push_registries(tag_and_push_registries, 'v1')
 
         if 'v2' not in versions:
-            # Remove v2-only plugins
-            logger.info("removing v2-only plugin: sync_pulp")
-            self.dj.remove_plugin('postbuild_plugins', 'sync_pulp')
-
             # remove extra tag_and_push config
             self.remove_tag_and_push_registries(tag_and_push_registries, 'v2')
 
@@ -591,6 +592,43 @@ class ProductionBuild(CommonBuild):
             # If no pulp registry is specified, don't run the pulp plugin
             self.dj.remove_plugin("postbuild_plugins", "pulp_push")
 
+    def render_pulp_sync(self):
+        """
+        If a pulp registry is specified, use the pulp plugin
+        """
+        pulp_registry = self.spec.pulp_registry.value
+        docker_v2_registries = [registry
+                                for registry in self.spec.registry_uris.value
+                                if registry.version == 'v2']
+
+        if (self.dj.dock_json_has_plugin_conf('postbuild_plugins',
+                                              'pulp_sync') and
+                pulp_registry and
+                docker_v2_registries):
+            self.dj.dock_json_set_arg('postbuild_plugins', 'pulp_sync',
+                                      'pulp_registry_name', pulp_registry)
+
+            # First specified v2 registry is the one
+            # we'll tell pulp to sync from
+            docker_registry = docker_v2_registries[0].uri
+            logger.info("using docker v2 registry %s for pulp_sync",
+                        docker_registry)
+
+            self.dj.dock_json_set_arg('postbuild_plugins', 'pulp_sync',
+                                      'docker_registry', docker_registry)
+
+            # Verify we have either a secret or username/password
+            if self.spec.pulp_secret.value is None:
+                conf = self.dj.dock_json_get_plugin_conf('postbuild_plugins',
+                                                         'pulp_sync')
+                args = conf.get('args', {})
+                if 'username' not in args:
+                    raise OsbsValidationException("Pulp registry specified "
+                                                  "but no auth config")
+        else:
+            # If no pulp registry is specified, don't run the pulp plugin
+            self.dj.remove_plugin("postbuild_plugins", "pulp_sync")
+
     def render_import_image(self, use_auth=None):
         """
         Configure the import_image plugin
@@ -635,6 +673,11 @@ class ProductionBuild(CommonBuild):
                            'pulp_secret_path'):
                           self.spec.pulp_secret.value,
 
+                          ('postbuild_plugins',
+                           'pulp_sync',
+                           'pulp_secret_path'):
+                          self.spec.pulp_secret.value,
+
                           ('exit_plugins', 'sendmail', 'pdc_secret_path'):
                           self.spec.pdc_secret.value})
 
@@ -651,6 +694,7 @@ class ProductionBuild(CommonBuild):
         self.render_cp_built_image_to_nfs()
         self.render_import_image(use_auth=use_auth)
         self.render_pulp_push()
+        self.render_pulp_sync()
         self.render_koji_promote(use_auth=use_auth)
         self.render_sendmail()
 

--- a/tests/build/test_build_request.py
+++ b/tests/build/test_build_request.py
@@ -228,6 +228,8 @@ class TestBuildRequest(object):
         with pytest.raises(NoSuchPluginException):
             get_plugin(plugins, "postbuild_plugins", "pulp_push")
         with pytest.raises(NoSuchPluginException):
+            get_plugin(plugins, "postbuild_plugins", "pulp_sync")
+        with pytest.raises(NoSuchPluginException):
             get_plugin(plugins, "postbuild_plugins", "import_image")
         with pytest.raises(NoSuchPluginException):
             get_plugin(plugins, "exit_plugins", "koji_promote")
@@ -314,6 +316,8 @@ class TestBuildRequest(object):
         with pytest.raises(NoSuchPluginException):
             get_plugin(plugins, "postbuild_plugins", "pulp_push")
         with pytest.raises(NoSuchPluginException):
+            get_plugin(plugins, "postbuild_plugins", "pulp_sync")
+        with pytest.raises(NoSuchPluginException):
             get_plugin(plugins, "postbuild_plugins", "import_image")
         with pytest.raises(NoSuchPluginException):
             get_plugin(plugins, "exit_plugins", "koji_promote")
@@ -393,6 +397,8 @@ class TestBuildRequest(object):
         with pytest.raises(NoSuchPluginException):
             get_plugin(plugins, "postbuild_plugins", "pulp_push")
         with pytest.raises(NoSuchPluginException):
+            get_plugin(plugins, "postbuild_plugins", "pulp_sync")
+        with pytest.raises(NoSuchPluginException):
             get_plugin(plugins, "postbuild_plugins", "import_image")
         with pytest.raises(NoSuchPluginException):
             get_plugin(plugins, "exit_plugins", "koji_promote")
@@ -456,6 +462,8 @@ class TestBuildRequest(object):
             get_plugin(plugins, "prebuild_plugins", "bump_release")
         assert get_plugin(plugins, "prebuild_plugins", "koji")
         assert get_plugin(plugins, "postbuild_plugins", "pulp_push")
+        with pytest.raises(NoSuchPluginException):
+            get_plugin(plugins, "postbuild_plugins", "pulp_sync")
         assert get_plugin(plugins, "postbuild_plugins", "cp_built_image_to_nfs")
         with pytest.raises(NoSuchPluginException):
             get_plugin(plugins, "postbuild_plugins", "import_image")
@@ -472,6 +480,7 @@ class TestBuildRequest(object):
         bm = BuildManager(INPUTS_PATH)
         build_request = bm.get_build_request_by_type(PROD_WITH_SECRET_BUILD_TYPE)
         name_label = "fedora/resultingimage"
+        pulp_env = 'dev'
         kwargs = {
             'git_uri': TEST_GIT_URI,
             'git_ref': TEST_GIT_REF,
@@ -482,7 +491,7 @@ class TestBuildRequest(object):
             'name_label': name_label,
             'registry_uris': ["registry1.example.com/v1",  # first is primary
                               "registry2.example.com/v2"],
-            'pulp_registry': "registry.example.com",
+            'pulp_registry': pulp_env,
             'nfs_server_path': "server:path",
             'source_registry_uri': "registry.example.com",
             'openshift_uri': "http://openshift/",
@@ -538,6 +547,8 @@ class TestBuildRequest(object):
                               "cp_built_image_to_nfs")
             assert get_plugin(plugins, "postbuild_plugins",
                               "pulp_push")
+            with pytest.raises(NoSuchPluginException):
+                get_plugin(plugins, "postbuild_plugins", "pulp_sync")
         else:
             with pytest.raises(NoSuchPluginException):
                 get_plugin(plugins, "postbuild_plugins",
@@ -548,6 +559,14 @@ class TestBuildRequest(object):
             with pytest.raises(NoSuchPluginException):
                 get_plugin(plugins, "postbuild_plugins",
                            "pulp_push")
+
+            assert get_plugin(plugins, "postbuild_plugins", "pulp_sync")
+            assert plugin_value_get(plugins, "postbuild_plugins", "pulp_sync",
+                                    "args", "pulp_registry_name") == pulp_env
+            docker_registry = plugin_value_get(plugins, "postbuild_plugins",
+                                               "pulp_sync", "args",
+                                               "docker_registry")
+            assert docker_registry == 'registry2.example.com'
 
     def test_render_with_yum_repourls(self):
         bm = BuildManager(INPUTS_PATH)
@@ -613,6 +632,8 @@ class TestBuildRequest(object):
             get_plugin(plugins, "postbuild_plugins", "cp_built_image_to_nfs")
         with pytest.raises(NoSuchPluginException):
             get_plugin(plugins, "postbuild_plugins", "pulp_push")
+        with pytest.raises(NoSuchPluginException):
+            get_plugin(plugins, "postbuild_plugins", "pulp_sync")
         with pytest.raises(NoSuchPluginException):
             get_plugin(plugins, "postbuild_plugins", "import_image")
         with pytest.raises(NoSuchPluginException):


### PR DESCRIPTION
If we are using v1 we want to use `pulp_push`, otherwise we want `pulp_sync`. Only one of those plugins should be enabled, not both.