### PR TITLE
Add %check section and build also for Python3

### DIFF
--- a/osbs-client.spec
+++ b/osbs-client.spec
@@ -2,6 +2,11 @@
 %global with_python3 1
 %endif
 
+%if 0%{?fedora}
+# rhel/epel has no flexmock, pytest-capturelog
+%global with_check 1
+%endif
+
 %global commit 49ef2c5d631b8a0c5f82a1d9354e6f7271ba5f12
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 # set to 0 to create a normal release
@@ -30,11 +35,28 @@ Requires:       python-osbs-client = %{version}-%{release}
 
 BuildRequires:  python2-devel
 BuildRequires:  python-setuptools
+%if 0%{?with_check}
+BuildRequires:  pytest
+BuildRequires:  python-pytest-capturelog
+BuildRequires:  python-flexmock
+BuildRequires:  python-six
+BuildRequires:  python-dockerfile-parse
+BuildRequires:  python-pycurl
+%endif # with_check
 
 %if 0%{?with_python3}
 BuildRequires:  python3-devel
 BuildRequires:  python3-setuptools
-%endif
+%if 0%{?with_check}
+BuildRequires:  python3-pytest
+BuildRequires:  python3-pytest-capturelog
+BuildRequires:  python3-flexmock
+BuildRequires:  python3-six
+BuildRequires:  python3-dockerfile-parse
+BuildRequires:  python3-pycurl
+%endif # with_check
+%endif # with_python3
+
 
 Provides:       osbs = %{version}-%{release}
 Obsoletes:      osbs < %{osbs_obsolete_vr}
@@ -120,6 +142,16 @@ mv %{buildroot}%{_bindir}/osbs %{buildroot}%{_bindir}/osbs2
 ln -s  %{_bindir}/osbs2 %{buildroot}%{_bindir}/osbs
 
 
+%if 0%{?with_check}
+%check
+%if 0%{?with_python3}
+py.test-3 -vv tests
+%endif # with_python3
+
+py.test-2 -vv tests
+%endif # with_check
+
+
 %files
 %doc README.md
 %{_bindir}/osbs
@@ -153,6 +185,7 @@ ln -s  %{_bindir}/osbs2 %{buildroot}%{_bindir}/osbs
 %changelog
 * Thu Nov 05 2015 Jiri Popelka <jpopelka@redhat.com> - 0.15-2
 - build for Python 3
+- %%check section
 
 * Mon Oct 19 2015 Tomas Tomecek <ttomecek@redhat.com> - 0.15-1
 - new upstream release: 0.15

--- a/osbs-client.spec
+++ b/osbs-client.spec
@@ -1,10 +1,12 @@
-%global with_python3 0
+%if (0%{?fedora} >= 23 || 0%{?rhel} >= 8)
+%global with_python3 1
+%endif
 
 %global commit 49ef2c5d631b8a0c5f82a1d9354e6f7271ba5f12
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 # set to 0 to create a normal release
 %global postrelease 0
-%global release 1
+%global release 2
 
 %global osbs_obsolete_vr 0.14-2
 
@@ -149,6 +151,9 @@ ln -s  %{_bindir}/osbs2 %{buildroot}%{_bindir}/osbs
 %endif # with_python3
 
 %changelog
+* Thu Nov 05 2015 Jiri Popelka <jpopelka@redhat.com> - 0.15-2
+- build for Python 3
+
 * Mon Oct 19 2015 Tomas Tomecek <ttomecek@redhat.com> - 0.15-1
 - new upstream release: 0.15
 

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -13,6 +13,7 @@ import pytest
 
 import osbs.http as osbs_http
 from osbs.http import parse_headers, HttpSession, HttpStream
+from osbs.exceptions import OsbsNetworkException
 
 from tests.fake_api import Connection, ResponseMapping
 
@@ -22,6 +23,15 @@ logger = logging.getLogger(__file__)
 @pytest.fixture
 def s():
     return HttpSession(verbose=True)
+
+
+def has_connection():
+    # In case we run tests in an environment without internet connection.
+    try:
+        HttpStream("https://httpbin.org/get", "get")
+        return True
+    except OsbsNetworkException:
+        return False
 
 
 class TestParseHeaders(object):
@@ -40,6 +50,8 @@ class TestParseHeaders(object):
         assert headers["location"]
 
 
+@pytest.mark.skipif(not has_connection(),
+                    reason="requires internet connection")
 class TestHttpSession(object):
     def test_single_multi_secure_without_redirs(self, s):
         response_single = s.get("https://httpbin.org/get")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -77,6 +77,7 @@ def test_get_time_from_rfc3339_valid(rfc3339, seconds, tz):
 def test_get_time_from_rfc3339_valid_alt_format(rfc3339, seconds, tz):
     os.environ['TZ'] = tz
     tzset()
+    assert get_time_from_rfc3339(rfc3339) == seconds
 
 
 @pytest.mark.parametrize('rfc3339', [


### PR DESCRIPTION
Looks like I turned Python3 builds off in 93d5854 (don't ask me why) and nobody has objected so far.
Let's turn them on again.

It'd also be nice to run tests when building the packages, so here's a `%check` section.
There are however some packages (e.g. `flexmock`) missing on `rhel`/`epel` so we can run the tests on Fedora only.
We also have to skip (if there's no internet connection) tests that try to access `httpbin.org`, because there's no connection in `koji` build environment. Here's example scratch-build [build.log](https://kojipkgs.fedoraproject.org//work/tasks/7898/11717898/build.log)