### PR TITLE
Make git_branch and git_push_url optional

### DIFF
--- a/osbs/api.py
+++ b/osbs/api.py
@@ -249,10 +249,27 @@ class OSBS(object):
         return build
 
     @osbsapi
-    def create_prod_build(self, git_uri, git_ref, git_branch, user, component,
-                          target, architecture=None, yum_repourls=None,
+    def create_prod_build(self, git_uri, git_ref,
+                          git_branch,  # may be None
+                          user, component,
+                          target,      # may be None
+                          architecture=None, yum_repourls=None,
                           namespace=DEFAULT_NAMESPACE, **kwargs):
-        df_parser = utils.get_df_parser(git_uri, git_ref, git_branch)
+        """
+        Create a production build
+
+        :param git_uri: str, URI of git repository
+        :param git_ref: str, reference to commit
+        :param git_branch: str, branch name (may be None)
+        :param user: str, user name
+        :param component: str, component name
+        :param target: str, koji target (may be None)
+        :param architecture: str, build architecture
+        :param yum_repourls: list, URLs for yum repos
+        :param namespace: str, OpenShift namespace
+        :return: BuildResponse instance
+        """
+        df_parser = utils.get_df_parser(git_uri, git_ref, git_branch=git_branch)
         build_request = self.get_build_request(PROD_BUILD_TYPE)
         build_request.set_params(
             git_uri=git_uri,

--- a/osbs/build/build_request.py
+++ b/osbs/build/build_request.py
@@ -698,12 +698,19 @@ class ProductionBuild(CommonBuild):
         self.dj.dock_json_set_arg('prebuild_plugins', "pull_base_image",
                                   "parent_registry", self.spec.source_registry_uri.value)
 
-        # The rebuild trigger requires a git_branch parameter, but that
-        # parameter is optional. If it was not provided, remove the trigger.
-        if not self.spec.git_branch.value:
-            if 'triggers' in self.template['spec']:
-                logger.info("removing triggers as no git_branch specified")
-                del self.template['spec']['triggers']
+        # The rebuild trigger requires git_branch and git_push_url
+        # parameters, but those parameters are optional. If either was
+        # not provided, remove the trigger.
+        remove_triggers = False
+        for param_name in ['git_branch', 'git_push_url']:
+            param = getattr(self.spec, param_name)
+            if not param.value:
+                logger.info("removing triggers as no %s specified", param_name)
+                remove_triggers = True
+                # Continue the loop so we log everything that's missing
+
+        if remove_triggers and 'triggers' in self.template['spec']:
+            del self.template['spec']['triggers']
 
         self.adjust_for_triggers()
 

--- a/osbs/build/build_request.py
+++ b/osbs/build/build_request.py
@@ -698,6 +698,13 @@ class ProductionBuild(CommonBuild):
         self.dj.dock_json_set_arg('prebuild_plugins', "pull_base_image",
                                   "parent_registry", self.spec.source_registry_uri.value)
 
+        # The rebuild trigger requires a git_branch parameter, but that
+        # parameter is optional. If it was not provided, remove the trigger.
+        if not self.spec.git_branch.value:
+            if 'triggers' in self.template['spec']:
+                logger.info("removing triggers as no git_branch specified")
+                del self.template['spec']['triggers']
+
         self.adjust_for_triggers()
 
         # Enable/disable plugins as needed for target registry API versions

--- a/osbs/build/spec.py
+++ b/osbs/build/spec.py
@@ -193,7 +193,7 @@ class CommonSpec(BuildTypeSpec):
 
 
 class ProdSpec(CommonSpec):
-    git_branch = BuildParam('git_branch')
+    git_branch = BuildParam('git_branch', allow_none=True)
     trigger_imagestreamtag = BuildParam('trigger_imagestreamtag')
     imagestream_name = BuildParam('imagestream_name')
     imagestream_url = BuildParam('imagestream_url')
@@ -273,8 +273,9 @@ class ProdSpec(CommonSpec):
         self.git_push_username.value = git_push_username
         self.git_branch.value = git_branch
         repo = git_repo_humanish_part_from_uri(self.git_uri.value)
-        self.name.value = "{repo}-{branch}".format(repo=repo,
-                                                   branch=git_branch)
+        namefmt = "{repo}-{branch}"
+        self.name.value = namefmt.format(repo=repo,
+                                         branch=git_branch or 'unknown')
         self.trigger_imagestreamtag.value = get_imagestreamtag_from_image(base_image)
         self.builder_build_json_dir.value = builder_build_json_dir
         self.imagestream_name.value = name_label.replace('/', '-')

--- a/osbs/utils.py
+++ b/osbs/utils.py
@@ -70,14 +70,19 @@ def buildconfig_update(orig, new, remove_nonexistent_keys=False):
 
 
 @contextlib.contextmanager
-def checkout_git_repo(git_uri, git_ref, git_branch):
+def checkout_git_repo(git_uri, git_ref, git_branch=None):
     tmpdir = tempfile.mkdtemp()
     repo_path = os.path.join(tmpdir, "repo")
     try:
         try:
             # when you clone into an empty directory and cloning process fails
             # git will remove the empty directory (why?!)
-            run_command(['git', 'clone', git_uri, '-b', git_branch, repo_path])
+            args = ['git', 'clone', git_uri]
+            if git_branch:
+                args += ['-b', git_branch]
+
+            args.append(repo_path)
+            run_command(args)
         except OsbsException as ex:
             raise OsbsException("Unable to clone git repo '%s' "
                                 "branch '%s'" % (git_uri, git_branch),
@@ -100,7 +105,7 @@ def looks_like_git_hash(git_ref):
     return all(ch in string.hexdigits for ch in git_ref) and len(git_ref) == 40
 
 
-def get_df_parser(git_uri, git_ref, git_branch):
+def get_df_parser(git_uri, git_ref, git_branch=None):
     with checkout_git_repo(git_uri, git_ref, git_branch) as code_dir:
         dfp = DockerfileParser(os.path.join(code_dir), cache_content=True)
     return dfp

--- a/tests/build/test_build_request.py
+++ b/tests/build/test_build_request.py
@@ -757,29 +757,21 @@ class TestBuildRequest(object):
         with pytest.raises(OsbsValidationException):
             build_request.render()
 
-    @pytest.mark.parametrize('params', [
-        # Wrong way round
-        {
-            'git_ref': TEST_GIT_BRANCH,
-            'git_branch': TEST_GIT_REF,
-            'should_raise': True,
-        },
+    @staticmethod
+    def create_image_change_trigger_json(outdir):
+        """
+        Create JSON templates with an image change trigger added.
 
-        # Right way round
-        {
-            'git_ref': TEST_GIT_REF,
-            'git_branch': TEST_GIT_BRANCH,
-            'should_raise': False,
-        },
-    ])
-    def test_render_prod_request_with_trigger(self, tmpdir, params):
+        :param outdir: str, path to store modified templates
+        """
+
         # Make temporary copies of the JSON files
         for basename in ['prod.json', 'prod_inner.json']:
             shutil.copy(os.path.join(INPUTS_PATH, basename),
-                        os.path.join(str(tmpdir), basename))
+                        os.path.join(outdir, basename))
 
         # Create a build JSON description with an image change trigger
-        with open(os.path.join(str(tmpdir), 'prod.json'), 'r+') as prod_json:
+        with open(os.path.join(outdir, 'prod.json'), 'r+') as prod_json:
             build_json = json.load(prod_json)
 
             # Add the image change trigger
@@ -799,6 +791,23 @@ class TestBuildRequest(object):
             json.dump(build_json, prod_json)
             prod_json.truncate()
 
+    @pytest.mark.parametrize('params', [
+        # Wrong way round
+        {
+            'git_ref': TEST_GIT_BRANCH,
+            'git_branch': TEST_GIT_REF,
+            'should_raise': True,
+        },
+
+        # Right way round
+        {
+            'git_ref': TEST_GIT_REF,
+            'git_branch': TEST_GIT_BRANCH,
+            'should_raise': False,
+        },
+    ])
+    def test_render_prod_request_with_trigger(self, tmpdir, params):
+        self.create_image_change_trigger_json(str(tmpdir))
         bm = BuildManager(str(tmpdir))
         build_request = bm.get_build_request_by_type(PROD_BUILD_TYPE)
         name_label = "fedora/resultingimage"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -52,7 +52,7 @@ class TestOSBS(object):
             baseimage = 'fedora23/python'
         (flexmock(utils)
             .should_receive('get_df_parser')
-            .with_args(TEST_GIT_URI, TEST_GIT_REF, TEST_GIT_BRANCH)
+            .with_args(TEST_GIT_URI, TEST_GIT_REF, git_branch=TEST_GIT_BRANCH)
             .and_return(MockParser()))
         response = osbs.create_prod_build(TEST_GIT_URI, TEST_GIT_REF,
                                           TEST_GIT_BRANCH, TEST_USER,
@@ -65,7 +65,7 @@ class TestOSBS(object):
             baseimage = 'fedora23/python'
         (flexmock(utils)
             .should_receive('get_df_parser')
-            .with_args(TEST_GIT_URI, TEST_GIT_REF, TEST_GIT_BRANCH)
+            .with_args(TEST_GIT_URI, TEST_GIT_REF, git_branch=TEST_GIT_BRANCH)
             .and_return(MockParser()))
         (flexmock(BuildRequest)
             .should_receive('set_openshift_required_version')
@@ -83,7 +83,7 @@ class TestOSBS(object):
             baseimage = 'fedora23/python'
         (flexmock(utils)
             .should_receive('get_df_parser')
-            .with_args(TEST_GIT_URI, TEST_GIT_REF, TEST_GIT_BRANCH)
+            .with_args(TEST_GIT_URI, TEST_GIT_REF, git_branch=TEST_GIT_BRANCH)
             .and_return(MockParser()))
         response = osbs.create_prod_with_secret_build(TEST_GIT_URI, TEST_GIT_REF,
                                                       TEST_GIT_BRANCH, TEST_USER,
@@ -98,7 +98,7 @@ class TestOSBS(object):
             baseimage = 'fedora23/python'
         (flexmock(utils)
             .should_receive('get_df_parser')
-            .with_args(TEST_GIT_URI, TEST_GIT_REF, TEST_GIT_BRANCH)
+            .with_args(TEST_GIT_URI, TEST_GIT_REF, git_branch=TEST_GIT_BRANCH)
             .and_return(MockParser()))
         response = osbs.create_prod_without_koji_build(TEST_GIT_URI, TEST_GIT_REF,
                                                        TEST_GIT_BRANCH, TEST_USER,


### PR DESCRIPTION
The `git_push_url` configuration parameter and `git_branch` parameter to `create_prod_build()` are now both optional.

If either is omitted, rebuild triggers are disabled.