### PR TITLE
pulp_sync requires scheme part of docker registry URI

### DIFF
--- a/osbs/build/build_request.py
+++ b/osbs/build/build_request.py
@@ -11,7 +11,6 @@ import json
 import logging
 import os
 from pkg_resources import parse_version
-import re
 
 try:
     # py2
@@ -698,14 +697,9 @@ class ProductionBuild(CommonBuild):
                                   "command", self.spec.sources_command.value)
 
         # pull_base_image wants a docker URI so strip off the scheme part
-        docker_uri = self.spec.source_registry_uri.value
-        if docker_uri:
-            docker_uri = re.sub(r'^https?://(.*)$',
-                                lambda m: m.groups[0],
-                                docker_uri)
-
-        self.dj.dock_json_set_arg('prebuild_plugins', "pull_base_image",
-                                  "parent_registry", docker_uri)
+        source_registry = self.spec.source_registry_uri.value
+        self.dj.dock_json_set_arg('prebuild_plugins', "pull_base_image", "parent_registry",
+                                  source_registry.docker_uri if source_registry else None)
 
         self.adjust_for_triggers()
 

--- a/osbs/build/spec.py
+++ b/osbs/build/spec.py
@@ -269,7 +269,7 @@ class ProdSpec(CommonSpec):
         self.trigger_imagestreamtag.value = get_imagestreamtag_from_image(base_image)
         self.builder_build_json_dir.value = builder_build_json_dir
         self.imagestream_name.value = name_label.replace('/', '-')
-        primary_registry_uri = self.registry_uris.value[0].uri
+        primary_registry_uri = self.registry_uris.value[0].docker_uri
         self.imagestream_url.value = os.path.join(primary_registry_uri,
                                                   name_label)
         timestamp = datetime.datetime.now().strftime('%Y%m%d%H%M%S')

--- a/tests/build/test_build_request.py
+++ b/tests/build/test_build_request.py
@@ -555,8 +555,12 @@ class TestBuildRequest(object):
             'component': TEST_COMPONENT,
             'base_image': 'fedora:latest',
             'name_label': name_label,
-            'registry_uris': ["registry1.example.com/v1",  # first is primary
-                              "registry2.example.com/v2"],
+            'registry_uris': [
+                # first is primary
+                "http://registry1.example.com:5000/v1",
+
+                "http://registry2.example.com:5000/v2"
+            ],
             'nfs_server_path': "server:path",
             'source_registry_uri': "registry.example.com",
             'openshift_uri': "http://openshift/",
@@ -595,12 +599,15 @@ class TestBuildRequest(object):
         assert plugins_json is not None
         plugins = json.loads(plugins_json)
 
+        # tag_and_push configuration. Must not have the scheme part.
         expected_registries = {
-            "registry2.example.com": {"insecure": True},
+            'registry2.example.com:5000': {'insecure': True},
         }
 
         if 'v1' in registry_api_versions:
-            expected_registries['registry1.example.com'] = {'insecure': True}
+            expected_registries['registry1.example.com:5000'] = {
+                'insecure': True,
+            }
 
         assert plugin_value_get(plugins, "postbuild_plugins", "tag_and_push",
                                 "args", "registries") == expected_registries
@@ -651,7 +658,9 @@ class TestBuildRequest(object):
             docker_registry = plugin_value_get(plugins, "postbuild_plugins",
                                                "pulp_sync", "args",
                                                "docker_registry")
-            assert docker_registry == 'registry2.example.com'
+
+            # pulp_sync config must have the scheme part to satisfy pulp.
+            assert docker_registry == 'http://registry2.example.com:5000'
         else:
             with pytest.raises(NoSuchPluginException):
                 get_plugin(plugins, "postbuild_plugins", "pulp_sync")

--- a/tests/build/test_build_request.py
+++ b/tests/build/test_build_request.py
@@ -820,7 +820,7 @@ class TestBuildRequest(object):
             'component': TEST_COMPONENT,
             'base_image': 'fedora:latest',
             'name_label': name_label,
-            'registry_uri': "registry.example.com",
+            'registry_uri': "http://registry.example.com",
             'openshift_uri': "http://openshift/",
             'builder_openshift_url': "http://openshift/",
             'koji_target': "koji-target",
@@ -871,6 +871,7 @@ class TestBuildRequest(object):
                                 "postbuild_plugins", "import_image", "args",
                                 "imagestream") == name_label.replace('/', '-')
         expected_repo = os.path.join(kwargs["registry_uri"], name_label)
+        expected_repo = expected_repo.replace('http://', '')
         assert plugin_value_get(plugins,
                                 "postbuild_plugins", "import_image", "args",
                                 "docker_image_repo") == expected_repo

--- a/tests/build/test_spec.py
+++ b/tests/build/test_spec.py
@@ -49,5 +49,5 @@ class TestCommonSpec(object):
         spec.set_params(registry_uris=['http://registry.example.com:5000/v2'],
                         user=TEST_USER)
         registry = spec.registry_uris.value[0]
-        assert registry.uri == 'registry.example.com:5000'
+        assert registry.uri == 'http://registry.example.com:5000'
         assert registry.version == 'v2'

--- a/tests/build/test_spec.py
+++ b/tests/build/test_spec.py
@@ -33,6 +33,7 @@ class TestRegistryURIsParam(object):
         p.value = ['registry.example.com:5000']
 
         assert p.value[0].uri == 'registry.example.com:5000'
+        assert p.value[0].docker_uri == 'registry.example.com:5000'
         assert p.value[0].version == 'v1'
 
     def test_registry_uris_param_v2(self):
@@ -40,6 +41,7 @@ class TestRegistryURIsParam(object):
         p.value = ['registry.example.com:5000/v2']
 
         assert p.value[0].uri == 'registry.example.com:5000'
+        assert p.value[0].docker_uri == 'registry.example.com:5000'
         assert p.value[0].version == 'v2'
 
 
@@ -50,4 +52,5 @@ class TestCommonSpec(object):
                         user=TEST_USER)
         registry = spec.registry_uris.value[0]
         assert registry.uri == 'http://registry.example.com:5000'
+        assert registry.docker_uri == 'registry.example.com:5000'
         assert registry.version == 'v2'


### PR DESCRIPTION
Pulp requires the scheme part of the docker registry URI, and so `pulp_sync` needs to be configured with it.

Don't strip out the scheme part when creating build parameters.
Strip out the scheme part for the source registry URI.
Strip out the scheme part for `tag_and_push` configuration.
Strip out the scheme part for `spec.output.to.name`.