### PR TITLE
Revert implicit labels to the old standard

### DIFF
--- a/osbs/build/build_request.py
+++ b/osbs/build/build_request.py
@@ -471,15 +471,15 @@ class ProductionBuild(CommonBuild):
 
     def render_add_labels_in_dockerfile(self):
         implicit_labels = {
-            'vendor': self.spec.vendor.value,
-            'com.redhat.build-host': self.spec.build_host.value,
-            'authoritative-source': self.spec.authoritative_registry.value,
+            'Vendor': self.spec.vendor.value,
+            'Build_Host': self.spec.build_host.value,
+            'Authoritative_Registry': self.spec.authoritative_registry.value,
             'distribution-scope': self.spec.distribution_scope.value,
         }
 
         architecture = self.spec.architecture.value
         if architecture:
-            implicit_labels['architecture'] = architecture
+            implicit_labels['Architecture'] = architecture
 
         self.dj.dock_json_merge_arg('prebuild_plugins',
                                     "add_labels_in_dockerfile",

--- a/tests/build/test_build_request.py
+++ b/tests/build/test_build_request.py
@@ -255,14 +255,14 @@ class TestBuildRequest(object):
                                   "args", "labels")
 
         assert labels is not None
-        assert labels['authoritative-source'] is not None
-        assert labels['com.redhat.build-host'] is not None
-        assert labels['vendor'] is not None
+        assert labels['Authoritative_Registry'] is not None
+        assert labels['Build_Host'] is not None
+        assert labels['Vendor'] is not None
         assert labels['distribution-scope'] is not None
         if architecture:
-            assert labels['architecture'] is not None
+            assert labels['Architecture'] is not None
         else:
-            assert 'architecture' not in labels
+            assert 'Architecture' not in labels
 
     def test_render_prod_request(self):
         bm = BuildManager(INPUTS_PATH)
@@ -353,10 +353,10 @@ class TestBuildRequest(object):
                                   "args", "labels")
 
         assert labels is not None
-        assert labels['architecture'] is not None
-        assert labels['authoritative-source'] is not None
-        assert labels['com.redhat.build-host'] is not None
-        assert labels['vendor'] is not None
+        assert labels['Architecture'] is not None
+        assert labels['Authoritative_Registry'] is not None
+        assert labels['Build_Host'] is not None
+        assert labels['Vendor'] is not None
         assert labels['distribution-scope'] is not None
 
     def test_render_prod_without_koji_request(self):
@@ -441,10 +441,10 @@ class TestBuildRequest(object):
                                   "args", "labels")
 
         assert labels is not None
-        assert labels['architecture'] is not None
-        assert labels['authoritative-source'] is not None
-        assert labels['com.redhat.build-host'] is not None
-        assert labels['vendor'] is not None
+        assert labels['Architecture'] is not None
+        assert labels['Authoritative_Registry'] is not None
+        assert labels['Build_Host'] is not None
+        assert labels['Vendor'] is not None
         assert labels['distribution-scope'] is not None
 
     def test_render_prod_with_secret_request(self):


### PR DESCRIPTION
Partially reverts 36e1bef6c85f685484cc1c07db524555bebfc528. Related to #266.

When new labels were used with old a-r the result was mix of old (provided by a-r/Dockerfile) and new (provided by osbs-client) labels.

During the migration to the new set, we should:
- use the old set in osbs-client
- use the alias feature of atomic-reactor to add new-style alias for the
  old label.
