### PR TITLE
Configure import_image's insecure_registry parameter

### DIFF
--- a/osbs/build/build_request.py
+++ b/osbs/build/build_request.py
@@ -712,6 +712,10 @@ class ProductionBuild(CommonBuild):
                 self.dj.dock_json_set_arg('postbuild_plugins', 'import_image',
                                           'use_auth', use_auth)
 
+            if self.spec.imagestream_insecure_registry.value:
+                self.dj.dock_json_set_arg('postbuild_plugins', 'import_image',
+                                          'insecure_registry', True)
+
     def render(self, validate=True):
         if validate:
             self.spec.validate()


### PR DESCRIPTION
We no longer require a secure registry when creating ImageStreams.

Requires https://github.com/projectatomic/atomic-reactor/pull/386.