### PR TITLE
cli: shorten output of list-builds

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 origin:
   image: "openshift/origin:v1.0.6"
+  container_name: "osbs"
   net: "host"
   privileged: true
   volumes:

--- a/osbs/utils.py
+++ b/osbs/utils.py
@@ -141,6 +141,19 @@ def git_repo_humanish_part_from_uri(git_uri):
     return os.path.basename(git_uri)
 
 
+def strip_registry_from_image(image):
+    # this duplicates some logic with atomic_reactor.util.ImageName,
+    # but I don't think it's worth it to depend on AR just for this
+    ret = image
+    parts = image.split('/', 2)
+    if len(parts) == 2:
+        if '.' in parts[0] or ':' in parts[0]:
+            ret = parts[1]
+    elif len(parts) == 3:
+        ret = '%s/%s' % (parts[1], parts[2])
+    return ret
+
+
 def get_imagestreamtag_from_image(image):
     """
     return ImageStreamTag, give a FROM value
@@ -148,19 +161,10 @@ def get_imagestreamtag_from_image(image):
     :param image: str, the FROM value from the Dockerfile
     :return: str, ImageStreamTag
     """
-
-    # this duplicates some logic with atomic_reactor.util.ImageName,
-    # but I don't think it's worth it to depend on AR just for this
-
     ret = image
 
     # Remove the registry part
-    parts = image.split('/', 2)
-    if len(parts) == 2:
-        if '.' in parts[0] or ':' in parts[0]:
-            ret = parts[1]
-    elif len(parts) == 3:
-        ret = '%s/%s' % (parts[1], parts[2])
+    ret = strip_registry_from_image(image)
 
     # ImageStream names cannot contain '/'
     ret = ret.replace('/', '-')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -15,7 +15,7 @@ from time import tzset
 from osbs.utils import (buildconfig_update,
                         get_imagestreamtag_from_image,
                         git_repo_humanish_part_from_uri,
-                        get_time_from_rfc3339)
+                        get_time_from_rfc3339, strip_registry_from_image)
 from osbs.exceptions import OsbsException
 import osbs.kerberos_ccache
 
@@ -35,6 +35,19 @@ def test_buildconfig_update():
 ])
 def test_git_repo_humanish_part_from_uri(uri, humanish):
     assert git_repo_humanish_part_from_uri(uri) == humanish
+
+
+@pytest.mark.parametrize(('img', 'expected'), [
+    ('fedora23', 'fedora23'),
+    ('fedora23:sometag', 'fedora23:sometag'),
+    ('fedora23/python', 'fedora23/python'),
+    ('fedora23/python:sometag', 'fedora23/python:sometag'),
+    ('docker.io/fedora23', 'fedora23'),
+    ('docker.io/fedora23/python', 'fedora23/python'),
+    ('docker.io/fedora23/python:sometag', 'fedora23/python:sometag'),
+])
+def test_strip_registry_from_image(img, expected):
+    assert strip_registry_from_image(img) == expected
 
 
 @pytest.mark.parametrize(('img', 'expected'), [


### PR DESCRIPTION
Previously:

```
 jboss-kieserver-6-docker-20151130-050421                        | complete | user1/jboss-kieserver-6-docker:this-target-name-is-so-long-it-cant-fit-anywhere-docker-candidate-20151130050421
 jboss-decisionserver-6-docker-20151130-054836                   | complete | user1/jboss-decisionserver-6-docker:this-target-name-is-so-long-it-cant-fit-anywhere-docker-candidate-20151130054836
 openshift-enterprise-node-docker-20151130-115732                | complete | user2/openshift-enterprise-node-docker:long-target-name-docker-candidate-20151130115732
```

Now:

```
 jboss-eap-6-docker-20151130-041010                                                 | complete                    | jboss-eap-6/eap64-openshift:0.0-0
 jboss-kieserver-6-docker-20151130-050421                                           | complete                    | jboss-kieserver-6/kieserver62-openshift:0.0-0
 jboss-decisionserver-6-docker-20151130-054836                                      | complete                    | jboss-decisionserver-6/decisionserver62-openshift:0.0-0
 openshift-enterprise-node-docker-20151130-115732                                   | complete                    | openshift3/node:v3.0.0.0-0
```
