### PR TITLE
Fix authentication for Python 3

### DIFF
--- a/osbs/core.py
+++ b/osbs/core.py
@@ -201,7 +201,7 @@ class Openshift(object):
         fragment = parsed_url.fragment
         logger.debug("fragment is '%s'", fragment)
         parsed_fragment = urlparse.parse_qs(fragment)
-        self.token = parsed_fragment[b'access_token'][0]
+        self.token = parsed_fragment['access_token'][0]
         return self.token
 
     def get_user(self, username="~"):

--- a/tests/fake_api.py
+++ b/tests/fake_api.py
@@ -190,7 +190,7 @@ class Connection(object):
 
     @staticmethod
     def process_authorize(key, content):
-        match = re.findall(b"[Ll]ocation: (.+)", content)
+        match = re.findall("[Ll]ocation: (.+)", content.decode("utf-8"))
         headers = {
             "location": match[0],
         }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -135,7 +135,7 @@ class TestOSBS(object):
         assert isinstance(response, HttpResponse)
 
     def test_get_token_api(self, osbs):
-        assert isinstance(osbs.get_token(), bytes)
+        assert isinstance(osbs.get_token(), six.string_types)
 
     def test_get_user_api(self, osbs):
         assert 'name' in osbs.get_user()['metadata']


### PR DESCRIPTION
Using auth on python 3 resulted in OsbsException: KeyError(b'access_token',)

Essentially reverts f7aafa6 since the headers are unicode/str after the http refactoring in 61f327b.