### PR TITLE
BuildResponse: only accept JSON in constructor

### DIFF
--- a/osbs/build/build_response.py
+++ b/osbs/build/build_response.py
@@ -21,20 +21,12 @@ logger = logging.getLogger(__name__)
 class BuildResponse(object):
     """ class which wraps json from http response from OpenShift """
 
-    def __init__(self, request, build_json=None):
+    def __init__(self, build_json):
         """
-        :param request: http.Request
-        :param build_json: dict
+        :param build_json: dict from JSON of OpenShift Build object
         """
-        self._json = build_json
-        self.request = request
+        self.json = build_json
         self._status = None
-
-    @property
-    def json(self):
-        if self._json is None:
-            self._json = self.request.json()
-        return self._json
 
     @property
     def status(self):

--- a/osbs/core.py
+++ b/osbs/core.py
@@ -227,7 +227,7 @@ class Openshift(object):
 
     def cancel_build(self, build_id, namespace=DEFAULT_NAMESPACE):
         response = self.get_build(build_id, namespace=namespace)
-        br = BuildResponse(response)
+        br = BuildResponse(response.json())
         br.status = BUILD_CANCELLED_STATE
         url = self._build_url("namespaces/%s/builds/%s/" % (namespace, build_id))
         return self._put(url, data=json.dumps(br.json),
@@ -305,7 +305,7 @@ class Openshift(object):
         if follow or wait_if_missing:
             build_json = self.wait_for_build_to_get_scheduled(build_id, namespace=namespace)
 
-        br = BuildResponse(None, build_json=build_json)
+        br = BuildResponse(build_json)
 
         # When build is in new or pending state, openshift responds with 500
         if br.is_pending():


### PR DESCRIPTION
Fixes a bug where two builds were started the first time we created a BuildConfig.

Another thing we could do is to have single argument constructor where the code would detect `HttpResponse`s and automagically call `.json()` on them. I slightly prefer doing it explicitly.