### PR TITLE
osbs-client Require python3-osbs-client when py3 or broken symlink is installed

### DIFF
--- a/osbs-client.spec
+++ b/osbs-client.spec
@@ -46,7 +46,11 @@ Source0:        https://github.com/projectatomic/osbs-client/archive/%{commit}/o
 
 BuildArch:      noarch
 
+%if 0%{?with_python3}
+Requires:       python3-osbs-client = %{version}-%{release}
+%else
 Requires:       python-osbs-client = %{version}-%{release}
+%endif
 
 BuildRequires:  python2-devel
 BuildRequires:  python-setuptools


### PR DESCRIPTION
If there isn't conditional on the Requires for python2 vs python3 version of the backend libs then we are left with a dangling symlink:

```
# dnf install osbs-client
Last metadata expiration check performed 0:20:51 ago on Mon Jan  4 17:12:33 2016.
Dependencies resolved.
=======================================================================================================================
 Package                        Arch          Version                          Repository                         Size
=======================================================================================================================
Installing:
 krb5-workstation               x86_64        1.14-12.fc24                     rawhide                           860 k
 osbs-client                    noarch        0.15-3.git.0.303032f.fc24        maxamillion-atomic-reactor         10 k
 python-dockerfile-parse        noarch        0.0.5-3.fc24                     rawhide                            24 k
 python-osbs-client             noarch        0.15-3.git.0.303032f.fc24        maxamillion-atomic-reactor        103 k
 python-pycurl                  x86_64        7.19.5.3-3.fc24                  rawhide                           186 k

Transaction Summary
=======================================================================================================================
Install  5 Packages

Total download size: 1.2 M
Installed size: 3.8 M
Is this ok [y/N]: y
Downloading Packages:
(1/5): krb5-workstation-1.14-12.fc24.x86_64.rpm                                        4.8 MB/s | 860 kB     00:00
(2/5): osbs-client-0.15-3.git.0.303032f.fc24.noarch.rpm                                 58 kB/s |  10 kB     00:00
(3/5): python-osbs-client-0.15-3.git.0.303032f.fc24.noarch.rpm                         303 kB/s | 103 kB     00:00
(4/5): python-pycurl-7.19.5.3-3.fc24.x86_64.rpm                                        1.1 MB/s | 186 kB     00:00
(5/5): python-dockerfile-parse-0.0.5-3.fc24.noarch.rpm                                 1.3 MB/s |  24 kB     00:00
-----------------------------------------------------------------------------------------------------------------------
Total                                                                                  1.2 MB/s | 1.2 MB     00:00
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Installing  : python-dockerfile-parse-0.0.5-3.fc24.noarch                                                        1/5
  Installing  : python-pycurl-7.19.5.3-3.fc24.x86_64                                                               2/5
  Installing  : krb5-workstation-1.14-12.fc24.x86_64                                                               3/5
  Installing  : python-osbs-client-0.15-3.git.0.303032f.fc24.noarch                                                4/5
  Installing  : osbs-client-0.15-3.git.0.303032f.fc24.noarch                                                       5/5
  Verifying   : osbs-client-0.15-3.git.0.303032f.fc24.noarch                                                       1/5
  Verifying   : python-osbs-client-0.15-3.git.0.303032f.fc24.noarch                                                2/5
  Verifying   : krb5-workstation-1.14-12.fc24.x86_64                                                               3/5
  Verifying   : python-pycurl-7.19.5.3-3.fc24.x86_64                                                               4/5
  Verifying   : python-dockerfile-parse-0.0.5-3.fc24.noarch                                                        5/5

Installed:
  krb5-workstation.x86_64 1.14-12.fc24                   osbs-client.noarch 0.15-3.git.0.303032f.fc24
  python-dockerfile-parse.noarch 0.0.5-3.fc24            python-osbs-client.noarch 0.15-3.git.0.303032f.fc24
  python-pycurl.x86_64 7.19.5.3-3.fc24

Complete!

[root@maxamillion-osbs roles]# ls -l /usr/bin/osbs
lrwxrwxrwx. 1 root root 17 Dec 23 16:27 /usr/bin/osbs -> /usr/bin/osbs-3.5

[root@maxamillion-osbs roles]# ls -l /usr/bin/osbs-3.5
ls: cannot access /usr/bin/osbs-3.5: No such file or directo
```