### PR TITLE
Refactor: don't pass namespace as an argument

### DIFF
--- a/osbs/conf.py
+++ b/osbs/conf.py
@@ -22,7 +22,7 @@ except ImportError:
     from urllib.parse import urljoin
 
 from osbs.constants import (DEFAULT_CONFIGURATION_FILE, DEFAULT_CONFIGURATION_SECTION,
-                            GENERAL_CONFIGURATION_SECTION)
+                            GENERAL_CONFIGURATION_SECTION, DEFAULT_NAMESPACE)
 
 
 logger = logging.getLogger(__name__)
@@ -194,7 +194,8 @@ class Configuration(object):
         return self._get_value("yum_repourls", self.conf_section, "yum_repourls")
 
     def get_namespace(self):
-        return self._get_value("namespace", self.conf_section, "namespace")
+        return self._get_value("namespace", self.conf_section, "namespace",
+                               default=DEFAULT_NAMESPACE)
 
     def get_kojiroot(self):
         return self._get_value("koji_root", self.conf_section, "koji_root")

--- a/osbs/utils.py
+++ b/osbs/utils.py
@@ -195,14 +195,14 @@ def checkout_git_repo(git_uri, git_ref, git_branch=None):
 
 
 @contextlib.contextmanager
-def paused_builds(osbs, namespace):
+def paused_builds(osbs):
     logger.info("pausing builds")
-    osbs.pause_builds(namespace=namespace)
+    osbs.pause_builds()
     try:
         yield osbs
     finally:
         logger.info("resuming builds")
-        osbs.resume_builds(namespace=namespace)
+        osbs.resume_builds()
 
 
 def looks_like_git_hash(git_ref):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -12,8 +12,7 @@ from pkg_resources import parse_version
 import pytest
 import six
 
-from osbs.constants import (PROD_BUILD_TYPE, PROD_WITHOUT_KOJI_BUILD_TYPE,
-                            SIMPLE_BUILD_TYPE, DEFAULT_NAMESPACE)
+from osbs.constants import PROD_BUILD_TYPE, PROD_WITHOUT_KOJI_BUILD_TYPE, SIMPLE_BUILD_TYPE
 from osbs.build.build_request import BuildRequest, SimpleBuild, ProductionBuild
 from osbs.build.build_response import BuildResponse
 from osbs.build.pod_response import PodResponse
@@ -79,8 +78,7 @@ class TestOSBS(object):
                        user=TEST_USER,
                        component=TEST_COMPONENT,
                        target=None,
-                       architecture=TEST_ARCH,
-                       namespace=DEFAULT_NAMESPACE)
+                       architecture=TEST_ARCH)
             .once()
             .and_return(None))
         response = osbs.create_build(git_uri=TEST_GIT_URI,


### PR DESCRIPTION
Passing it as a parameter everywhere clutters the code and serves no
purpose. It is initialized in OSBS constructor and lives as a property of
class Openshift now.

Breaks our Python API in case non-default namespace is used.

Closes #333.

---

* I took the liberty of removing support for listing builds in all namespaces. It wasn't working for some time now. I can make it work if anybody thinks it's useful.
* The `osbsapi` decorator checks if the methods are called with `namespace` kwarg and prints warning if it's the case. This means that we don't break compatibility with API users that use the default namespace. With little bit more work we can probably unbreak it for API users that use other namespace, though I don't think there are any.
* If this PR is merged I'll fix the osbs-client usage in atomic-reactor.