### PR TITLE
Improve performance for `list-builds --running`

### DIFF
--- a/osbs/api.py
+++ b/osbs/api.py
@@ -90,8 +90,15 @@ class OSBS(object):
         return self._bm
 
     @osbsapi
-    def list_builds(self):
-        response = self.os.list_builds()
+    def list_builds(self, field_selector=None):
+        """
+        List builds with matching fields
+
+        :param field_selector: str, field selector for Builds
+        :return: BuildResponse list
+        """
+
+        response = self.os.list_builds(field_selector=field_selector)
         serialized_response = response.json()
         build_list = []
         for build in serialized_response["items"]:

--- a/osbs/cli/main.py
+++ b/osbs/cli/main.py
@@ -22,7 +22,8 @@ from osbs.api import OSBS
 from osbs.cli.render import TablePrinter
 from osbs.conf import Configuration
 from osbs.constants import (DEFAULT_CONFIGURATION_FILE, DEFAULT_CONFIGURATION_SECTION,
-                            CLI_LIST_BUILDS_DEFAULT_COLS, PY3, BACKUP_RESOURCES, DEFAULT_NAMESPACE)
+                            CLI_LIST_BUILDS_DEFAULT_COLS, PY3, BACKUP_RESOURCES, DEFAULT_NAMESPACE,
+                            BUILD_FINISHED_STATES)
 from osbs.exceptions import OsbsNetworkException, OsbsException, OsbsAuthException, OsbsResponseException
 from osbs.cli.capture import setup_json_capture
 from osbs.utils import strip_registry_from_image, paused_builds, TarReader, TarWriter
@@ -35,7 +36,13 @@ def print_json_nicely(decoded_json):
 
 
 def cmd_list_builds(args, osbs):
-    builds = osbs.list_builds()
+    kwargs = {}
+    if args.running:
+        field_selector = ",".join(["status!={status}".format(status=status.capitalize())
+                                   for status in BUILD_FINISHED_STATES])
+        kwargs['field_selector'] = field_selector
+
+    builds = osbs.list_builds(**kwargs)
     if args.output == 'json':
         json_output = []
         for build in builds:

--- a/osbs/core.py
+++ b/osbs/core.py
@@ -344,14 +344,21 @@ class Openshift(object):
             return response.iter_lines()
         return response.content
 
-    def list_builds(self, build_config_id=None):
+    def list_builds(self, build_config_id=None, field_selector=None):
         """
+        List builds matching criteria
 
-        :return:
+        :param build_config_id: str, name of BuildConfig to list builds for
+        :param field_selector: str, field selector for query
+        :return: HttpResponse
         """
         query = {}
+        selector = '{field}={value}'
         if build_config_id is not None:
-            query['labelSelector'] = '%s=%s' % ('buildconfig', build_config_id)
+            query['labelSelector'] = selector.format(field='buildconfig',
+                                                     value=build_config_id)
+        if field_selector is not None:
+            query['fieldSelector'] = field_selector
         url = self._build_url("builds/", **query)
         return self._get(url)
 


### PR DESCRIPTION
Previously, all builds were fetched and then each build's status was examined.

Now, the fieldSelector is set to match status=running in the builds query when the --running option is passed to the CLI tool. This means only running builds will be returned.

API changes:
- OSBS.list_builds() now accepts a 'field_selector' keyword argument

This also brings us closer to an implementation for #252.