### PR TITLE
utils: show URI as a repr for RegistryURI

### DIFF
--- a/osbs/utils.py
+++ b/osbs/utils.py
@@ -57,6 +57,9 @@ class RegistryURI(object):
     def uri(self):
         return self.scheme + self.docker_uri
 
+    def __repr__(self):
+        return self.uri
+
 
 class TarWriter(object):
     def __init__(self, outfile, directory=None):
@@ -301,4 +304,3 @@ def run_command(*popenargs, **kwargs):
             message="Command %s returned %s\n\n%s" % (cmd, retcode, output)
         )
     return output
-


### PR DESCRIPTION
This replaces
```
  osbs.build.spec - DEBUG - registry_uris = '[<osbs.utils.RegistryURI object at 0x7f64c8a44dd0>]'
```
in debug output with proper registry URIs