### PR TITLE
Make it possible to specify buildroot to be used

### DIFF
--- a/inputs/prod.json
+++ b/inputs/prod.json
@@ -29,7 +29,7 @@
       "customStrategy": {
         "from": {
           "kind": "DockerImage",
-          "name": "buildroot:latest"
+          "name": "{{BUILD_IMAGE}}"
         },
         "exposeDockerSocket": true,
         "env": [{

--- a/inputs/simple.json
+++ b/inputs/simple.json
@@ -26,7 +26,7 @@
       "customStrategy": {
         "from": {
           "kind": "DockerImage",
-          "name": "buildroot:latest"
+          "name": "{{BUILD_IMAGE}}"
         },
         "exposeDockerSocket": true,
         "env": [{

--- a/osbs/api.py
+++ b/osbs/api.py
@@ -246,6 +246,7 @@ class OSBS(object):
                           user, component,
                           target,      # may be None
                           architecture=None, yum_repourls=None,
+                          build_image=None,
                           **kwargs):
         """
         Create a production build
@@ -268,6 +269,7 @@ class OSBS(object):
             git_branch=git_branch,
             user=user,
             component=component,
+            build_image=build_image,
             base_image=df_parser.baseimage,
             name_label=df_parser.labels['Name'],
             registry_uris=self.build_conf.get_registry_uris(),
@@ -296,7 +298,6 @@ class OSBS(object):
             git_push_url=self.build_conf.get_git_push_url(),
             git_push_username=self.build_conf.get_git_push_username(),
             builder_build_json_dir=self.build_conf.get_builder_build_json_store(),
-            build_image=self.build_conf.get_build_image(),
         )
         build_request.set_openshift_required_version(self.os_conf.get_openshift_required_version())
         response = self._create_build_config_and_build(build_request)
@@ -317,7 +318,7 @@ class OSBS(object):
 
     @osbsapi
     def create_simple_build(self, git_uri, git_ref, user, component, tag,
-                            yum_repourls=None, **kwargs):
+                            yum_repourls=None, build_image=None, **kwargs):
         build_request = self.get_build_request(SIMPLE_BUILD_TYPE)
         build_request.set_params(
             git_uri=git_uri,
@@ -325,13 +326,13 @@ class OSBS(object):
             user=user,
             component=component,
             tag=tag,
+            build_image=build_image,
             registry_uris=self.build_conf.get_registry_uris(),
             source_registry_uri=self.build_conf.get_source_registry_uri(),
             openshift_uri=self.os_conf.get_openshift_base_uri(),
             builder_openshift_url=self.os_conf.get_builder_openshift_url(),
             yum_repourls=yum_repourls,
             use_auth=self.build_conf.get_builder_use_auth(),
-            build_image=self.build_conf.get_build_image(),
         )
         build_request.set_openshift_required_version(self.os_conf.get_openshift_required_version())
         response = self._create_build_config_and_build(build_request)

--- a/osbs/api.py
+++ b/osbs/api.py
@@ -295,7 +295,8 @@ class OSBS(object):
             nfs_dest_dir=self.build_conf.get_nfs_destination_dir(),
             git_push_url=self.build_conf.get_git_push_url(),
             git_push_username=self.build_conf.get_git_push_username(),
-            builder_build_json_dir=self.build_conf.get_builder_build_json_store()
+            builder_build_json_dir=self.build_conf.get_builder_build_json_store(),
+            build_image=self.build_conf.get_build_image(),
         )
         build_request.set_openshift_required_version(self.os_conf.get_openshift_required_version())
         response = self._create_build_config_and_build(build_request)
@@ -330,6 +331,7 @@ class OSBS(object):
             builder_openshift_url=self.os_conf.get_builder_openshift_url(),
             yum_repourls=yum_repourls,
             use_auth=self.build_conf.get_builder_use_auth(),
+            build_image=self.build_conf.get_build_image(),
         )
         build_request.set_openshift_required_version(self.os_conf.get_openshift_required_version())
         response = self._create_build_config_and_build(build_request)

--- a/osbs/build/build_request.py
+++ b/osbs/build/build_request.py
@@ -283,6 +283,9 @@ class CommonBuild(BuildRequest):
             if 'sourceSecret' in self.template['spec']['source']:
                 del self.template['spec']['source']['sourceSecret']
 
+        self.template['spec']['strategy']['customStrategy']['from']['name'] = \
+            self.spec.build_image.value
+
     def validate_input(self):
         self.spec.validate()
 

--- a/osbs/build/spec.py
+++ b/osbs/build/spec.py
@@ -14,7 +14,7 @@ import logging
 import datetime
 import os
 import re
-from osbs.constants import DEFAULT_GIT_REF
+from osbs.constants import DEFAULT_GIT_REF, DEFAULT_BUILD_IMAGE
 from osbs.exceptions import OsbsValidationException
 from osbs.utils import (get_imagestreamtag_from_image,
                         git_repo_humanish_part_from_uri,
@@ -147,6 +147,7 @@ class CommonSpec(BuildTypeSpec):
     name = BuildIDParam()
     yum_repourls = BuildParam("yum_repourls")
     use_auth = BuildParam("use_auth", allow_none=True)
+    build_image = BuildParam('build_image')
 
     def __init__(self):
         self.required_params = [
@@ -156,13 +157,15 @@ class CommonSpec(BuildTypeSpec):
             self.component,
             self.registry_uris,
             self.openshift_uri,
+            self.build_image,
         ]
 
     def set_params(self, git_uri=None, git_ref=None,
                    registry_uri=None,  # compatibility name for registry_uris
                    registry_uris=None, user=None,
                    component=None, openshift_uri=None, source_registry_uri=None,
-                   yum_repourls=None, use_auth=None, builder_openshift_url=None):
+                   yum_repourls=None, use_auth=None, builder_openshift_url=None,
+                   build_image=None):
         self.git_uri.value = git_uri
         self.git_ref.value = git_ref
         self.user.value = user
@@ -181,6 +184,7 @@ class CommonSpec(BuildTypeSpec):
             raise OsbsValidationException("yum_repourls must be a list")
         self.yum_repourls.value = yum_repourls or []
         self.use_auth.value = use_auth
+        self.build_image.value = build_image or DEFAULT_BUILD_IMAGE
 
 
 class ProdSpec(CommonSpec):

--- a/osbs/cli/main.py
+++ b/osbs/cli/main.py
@@ -201,6 +201,7 @@ def cmd_build(args, osbs):
         target=osbs.build_conf.get_koji_target(),
         architecture=osbs.build_conf.get_architecture(),
         yum_repourls=osbs.build_conf.get_yum_repourls(),
+        build_image=osbs.build_conf.get_build_image(),
     )
     build_id = build.get_build_name()
     # we need to wait for kubelet to schedule the build, otherwise it's 500

--- a/osbs/cli/main.py
+++ b/osbs/cli/main.py
@@ -462,6 +462,8 @@ def cli():
                               help="memory limit")
     build_parser.add_argument("--storage-limit", action='store', required=False,
                               help="storage limit")
+    build_parser.add_argument("--build-image", action='store', required=False,
+                              help="builder image to use")
     build_parser.set_defaults(func=cmd_build)
 
     get_build_image_id = subparsers.add_parser(str_on_2_unicode_on_3('get-build-image-id'),

--- a/osbs/conf.py
+++ b/osbs/conf.py
@@ -349,3 +349,6 @@ class Configuration(object):
 
     def get_git_push_username(self):
         return self._get_value("git_push_username", self.conf_section, "git_push_username")
+
+    def get_build_image(self):
+        return self._get_value("build_image", self.conf_section, "build_image")

--- a/osbs/constants.py
+++ b/osbs/constants.py
@@ -13,6 +13,7 @@ PY3 = sys.version_info[0] >= 3
 
 BUILD_JSON_STORE = "/usr/share/osbs/"
 DEFAULT_GIT_REF = "master"
+DEFAULT_BUILD_IMAGE = "buildroot:latest"
 DEFAULT_CONFIGURATION_FILE = "/etc/osbs.conf"
 DEFAULT_CONFIGURATION_SECTION = "default"
 GENERAL_CONFIGURATION_SECTION = "general"


### PR DESCRIPTION
Closes #356.
I'm not quite sure where to put the default value, whether into *spec.py*, *conf.py*, or both.