### PR TITLE
Configurable secret for koji ssl certs

### DIFF
--- a/docs/configuration_file.md
+++ b/docs/configuration_file.md
@@ -51,6 +51,8 @@ Some options are also mandatory.
 
 * `koji_target` (*optional*, `string`) — name of koji target from which packages should be fetched
 
+* `koji_certs_secret` (*optional*, `string`) — name of [kubernetes secret](https://github.com/kubernetes/kubernetes/blob/master/docs/design/secrets.md) to use for koji authentication
+
 * `sources_command` (*optional*, `string`) — command to use to get dist-git artifacts from lookaside cache (e.g. `fedpkg sources`)
 
 * `username`, `password` (*optional*, `string`) — when OpenShift is hidden behind authentication proxy, you can specify username and password for basic authentication

--- a/osbs/api.py
+++ b/osbs/api.py
@@ -281,6 +281,7 @@ class OSBS(object):
             kojihub=self.build_conf.get_kojihub(),
             sources_command=self.build_conf.get_sources_command(),
             koji_target=target,
+            koji_certs_secret=self.build_conf.get_koji_certs_secret(),
             architecture=architecture,
             vendor=self.build_conf.get_vendor(),
             build_host=self.build_conf.get_build_host(),

--- a/osbs/build/build_request.py
+++ b/osbs/build/build_request.py
@@ -766,7 +766,7 @@ class ProductionBuild(CommonBuild):
                           self.spec.pdc_secret.value,
 
                           ('exit_plugins', 'koji_promote', 'koji_ssl_certs'):
-                          self.spec.koji_certs_secret})
+                          self.spec.koji_certs_secret.value})
 
         if self.spec.pulp_secret.value:
             # Don't push to docker registry, we're using pulp here

--- a/osbs/build/build_request.py
+++ b/osbs/build/build_request.py
@@ -309,6 +309,7 @@ class ProductionBuild(CommonBuild):
         :param koji_target: str, koji tag with packages used to build the image
         :param kojiroot: str, URL from which koji packages are fetched
         :param kojihub: str, URL of the koji hub
+        :param koji_certs_secret: str, resource name of secret that holds the koji certificates
         :param pulp_registry: str, name of pulp registry in dockpulp.conf
         :param nfs_server_path: str, NFS server and path
         :param nfs_dest_dir: str, directory to create on NFS server
@@ -762,7 +763,10 @@ class ProductionBuild(CommonBuild):
                           self.spec.pulp_secret.value,
 
                           ('exit_plugins', 'sendmail', 'pdc_secret_path'):
-                          self.spec.pdc_secret.value})
+                          self.spec.pdc_secret.value,
+
+                          ('exit_plugins', 'koji_promote', 'koji_ssl_certs'):
+                          self.spec.koji_certs_secret})
 
         if self.spec.pulp_secret.value:
             # Don't push to docker registry, we're using pulp here

--- a/osbs/build/spec.py
+++ b/osbs/build/spec.py
@@ -203,6 +203,7 @@ class ProdSpec(CommonSpec):
     koji_target = BuildParam("koji_target", allow_none=True)
     kojiroot = BuildParam("kojiroot", allow_none=True)
     kojihub = BuildParam("kojihub", allow_none=True)
+    koji_certs_secret = BuildParam("koji_certs_secret", allow_none=True)
     image_tag = BuildParam("image_tag")
     pulp_secret = BuildParam("pulp_secret", allow_none=True)
     pulp_registry = BuildParam("pulp_registry", allow_none=True)
@@ -227,6 +228,7 @@ class ProdSpec(CommonSpec):
             self.koji_target,
             self.kojiroot,
             self.kojihub,
+            self.koji_certs_secret,
             self.pulp_secret,
             self.pulp_registry,
             self.pdc_secret,
@@ -239,7 +241,7 @@ class ProdSpec(CommonSpec):
 
     def set_params(self, sources_command=None, architecture=None, vendor=None,
                    build_host=None, authoritative_registry=None, distribution_scope=None,
-                   koji_target=None, kojiroot=None, kojihub=None,
+                   koji_target=None, kojiroot=None, kojihub=None, koji_certs_secret=None,
                    source_secret=None,  # compatibility name for pulp_secret
                    pulp_secret=None, pulp_registry=None, pdc_secret=None, pdc_url=None,
                    smtp_uri=None, nfs_server_path=None,
@@ -258,6 +260,7 @@ class ProdSpec(CommonSpec):
         self.koji_target.value = koji_target
         self.kojiroot.value = kojiroot
         self.kojihub.value = kojihub
+        self.koji_certs_secret = koji_certs_secret
         self.pulp_secret.value = pulp_secret or source_secret
         self.pulp_registry.value = pulp_registry
         self.pdc_secret.value = pdc_secret

--- a/osbs/build/spec.py
+++ b/osbs/build/spec.py
@@ -260,7 +260,7 @@ class ProdSpec(CommonSpec):
         self.koji_target.value = koji_target
         self.kojiroot.value = kojiroot
         self.kojihub.value = kojihub
-        self.koji_certs_secret = koji_certs_secret
+        self.koji_certs_secret.value = koji_certs_secret
         self.pulp_secret.value = pulp_secret or source_secret
         self.pulp_registry.value = pulp_registry
         self.pdc_secret.value = pdc_secret

--- a/osbs/conf.py
+++ b/osbs/conf.py
@@ -206,6 +206,9 @@ class Configuration(object):
     def get_koji_target(self):
         return self._get_value("target", self.conf_section, "target")
 
+    def get_koji_certs_secret(self):
+        return self._get_value("koji_certs_secret", self.conf_section, "koji_certs_secret")
+
     def get_sources_command(self):
         return self._get_value("sources_command", self.conf_section, "sources_command")
 


### PR DESCRIPTION
@maxamillion tested this and it seems to work: http://koji.stg.fedoraproject.org/koji/getfile?taskID=90071405&name=build.log (the auth, at least)
