### PR TITLE
Run compress plugin even for v2-only builds

### DIFF
--- a/osbs/build/build_request.py
+++ b/osbs/build/build_request.py
@@ -432,8 +432,7 @@ class ProductionBuild(CommonBuild):
 
         if 'v1' not in versions:
             # Remove v1-only plugins
-            for phase, name in [('postbuild_plugins', 'compress'),
-                                ('postbuild_plugins', 'pulp_push')]:
+            for phase, name in [('postbuild_plugins', 'pulp_push')]:
                 logger.info("removing v1-only plugin: %s", name)
                 self.dj.remove_plugin(phase, name)
 

--- a/tests/build/test_build_request.py
+++ b/tests/build/test_build_request.py
@@ -662,17 +662,14 @@ class TestBuildRequest(object):
         with pytest.raises(NoSuchPluginException):
             get_plugin(plugins, "postbuild_plugins", "cp_built_image_to_nfs")
 
+        assert get_plugin(plugins, "postbuild_plugins", "compress")
+
         if 'v1' in registry_api_versions:
-            assert get_plugin(plugins, "postbuild_plugins",
-                              "compress")
             assert get_plugin(plugins, "postbuild_plugins",
                               "pulp_push")
             assert plugin_value_get(plugins, "postbuild_plugins", "pulp_push",
                                     "args", "pulp_registry_name") == pulp_env
         else:
-            with pytest.raises(NoSuchPluginException):
-                get_plugin(plugins, "postbuild_plugins",
-                           "compress")
             with pytest.raises(NoSuchPluginException):
                 get_plugin(plugins, "postbuild_plugins",
                            "pulp_push")


### PR DESCRIPTION
We will always use the'save' tarball, even for v2-only builds.