### PR TITLE
Adding build status filter when fetching running builds

### DIFF
--- a/osbs/api.py
+++ b/osbs/api.py
@@ -19,7 +19,7 @@ from .constants import SIMPLE_BUILD_TYPE, PROD_WITHOUT_KOJI_BUILD_TYPE, PROD_WIT
 from osbs.build.build_request import BuildManager
 from osbs.build.build_response import BuildResponse
 from osbs.build.pod_response import PodResponse
-from osbs.constants import PROD_BUILD_TYPE
+from osbs.constants import BUILD_RUNNING_STATES, PROD_BUILD_TYPE
 from osbs.core import Openshift
 from osbs.exceptions import OsbsException, OsbsValidationException
 # import utils in this way, so that we can mock standalone functions with flexmock
@@ -515,8 +515,13 @@ class OSBS(object):
 
         # Now wait for running builds to finish
         while True:
-            builds = self.list_builds()
+            field_selector = ','.join(['status=%s' % status.capitalize()
+                                       for status in BUILD_RUNNING_STATES])
+            builds = self.list_builds(field_selector)
+
+            # Double check builds are actually in running state.
             running_builds = [build for build in builds if build.is_running()]
+
             if not running_builds:
                 break
 

--- a/tests/fake_api.py
+++ b/tests/fake_api.py
@@ -76,6 +76,14 @@ class Connection(object):
                 },
             },
 
+            (OAPI_PREFIX + "namespaces/default/builds?fieldSelector=status%3DRunning",
+             OAPI_PREFIX + "namespaces/default/builds/?fieldSelector=status%3DRunning"): {
+                "get": {
+                    # Contains a list of builds
+                    "file": "builds_list.json",
+                }
+            },
+
             # Some 'builds' requests are with a trailing slash, some without:
             (OAPI_PREFIX + "namespaces/default/builds/%s" % TEST_BUILD,
              OAPI_PREFIX + "namespaces/default/builds/%s/" % TEST_BUILD): {


### PR DESCRIPTION
Verified API call is being made as:
`2016-04-13 09:57:17,948 - osbs.http.out - DEBUG - GET /oapi/v1/namespaces/default/builds/?fieldSelector=status%3DRunning HTTP/1.1`