### PR TITLE
conf: build_host is not required anymore

### DIFF
--- a/osbs/build/spec.py
+++ b/osbs/build/spec.py
@@ -221,7 +221,6 @@ class ProdSpec(CommonSpec):
         self.required_params += [
             self.sources_command,
             self.vendor,
-            self.build_host,
             self.authoritative_registry,
             self.distribution_scope,
             self.registry_api_versions,


### PR DESCRIPTION
Follow-up on e0b77062f9087c12f1ce504fd68104fcae3d4704