### PR TITLE
BuildResponse: don't traceback on errorDetail logs

### DIFF
--- a/osbs/build/build_response.py
+++ b/osbs/build/build_response.py
@@ -110,9 +110,10 @@ class BuildResponse(object):
                 error = decoded_line.get("error", "").strip()
                 if error:
                     output += [error]
-                error_detail = decoded_line.get("errorDetail", "").strip()
-                if error_detail:
-                    output += [error_detail]
+                error_detail = decoded_line.get("errorDetail", {})
+                error_msg = error_detail.get("message", "").strip()
+                if error_msg:
+                    output += [error_msg]
             output += "\n"
             return "\n".join(output)
         else:

--- a/tests/build/test_build_response.py
+++ b/tests/build/test_build_response.py
@@ -1,0 +1,29 @@
+"""
+Copyright (c) 2016 Red Hat, Inc
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+"""
+import json
+from osbs.build.build_response import BuildResponse
+
+class TestBuildResponse(object):
+    def test_get_logs(self):
+        msg = "This is an error message"
+        error = json.dumps({
+            'errorDetail': {
+                'code': 1,
+                'message': msg,
+                'error': msg,
+            },
+        })
+        build_response = BuildResponse({
+            'metadata': {
+                'annotations': {
+                    'logs': error,
+                },
+            },
+        })
+
+        assert msg in build_response.get_logs()


### PR DESCRIPTION
Back-port this fix to 0.18.x.