### PR TITLE
New koji_task_id parameter for create_prod_build()

### DIFF
--- a/osbs/api.py
+++ b/osbs/api.py
@@ -247,6 +247,7 @@ class OSBS(object):
                           user, component,
                           target,      # may be None
                           architecture=None, yum_repourls=None,
+                          koji_task_id=None,
                           **kwargs):
         """
         Create a production build
@@ -259,6 +260,7 @@ class OSBS(object):
         :param target: str, koji target (may be None)
         :param architecture: str, build architecture
         :param yum_repourls: list, URLs for yum repos
+        :param koji_task_id: int, koji task ID requesting build
         :return: BuildResponse instance
         """
         df_parser = utils.get_df_parser(git_uri, git_ref, git_branch=git_branch)
@@ -283,6 +285,7 @@ class OSBS(object):
             sources_command=self.build_conf.get_sources_command(),
             koji_target=target,
             koji_certs_secret=self.build_conf.get_koji_certs_secret(),
+            koji_task_id=koji_task_id,
             architecture=architecture,
             vendor=self.build_conf.get_vendor(),
             build_host=self.build_conf.get_build_host(),

--- a/osbs/build/build_request.py
+++ b/osbs/build/build_request.py
@@ -322,6 +322,7 @@ class ProductionBuild(CommonBuild):
         :param kojiroot: str, URL from which koji packages are fetched
         :param kojihub: str, URL of the koji hub
         :param koji_certs_secret: str, resource name of secret that holds the koji certificates
+        :param koji_task_id: int, Koji Task that created this build config
         :param pulp_registry: str, name of pulp registry in dockpulp.conf
         :param nfs_server_path: str, NFS server and path
         :param nfs_dest_dir: str, directory to create on NFS server
@@ -781,6 +782,11 @@ class ProductionBuild(CommonBuild):
             # but still construct the unique tag
             self.template['spec']['output']['to']['name'] = \
                 self.spec.image_tag.value
+
+        kojitask = self.spec.koji_task_id.value
+        if kojitask is not None:
+            self.template['metadata'].setdefault('labels', {})
+            self.template['metadata']['labels']['kojitask'] = kojitask
 
         use_auth = self.spec.use_auth.value
         self.render_add_labels_in_dockerfile()

--- a/osbs/build/spec.py
+++ b/osbs/build/spec.py
@@ -207,6 +207,7 @@ class ProdSpec(CommonSpec):
     kojiroot = BuildParam("kojiroot", allow_none=True)
     kojihub = BuildParam("kojihub", allow_none=True)
     koji_certs_secret = BuildParam("koji_certs_secret", allow_none=True)
+    koji_task_id = BuildParam("koji_task_id", allow_none=True)
     image_tag = BuildParam("image_tag")
     pulp_secret = BuildParam("pulp_secret", allow_none=True)
     pulp_registry = BuildParam("pulp_registry", allow_none=True)
@@ -244,6 +245,7 @@ class ProdSpec(CommonSpec):
     def set_params(self, sources_command=None, architecture=None, vendor=None,
                    build_host=None, authoritative_registry=None, distribution_scope=None,
                    koji_target=None, kojiroot=None, kojihub=None, koji_certs_secret=None,
+                   koji_task_id=None,
                    source_secret=None,  # compatibility name for pulp_secret
                    pulp_secret=None, pulp_registry=None, pdc_secret=None, pdc_url=None,
                    smtp_uri=None, nfs_server_path=None,
@@ -263,6 +265,7 @@ class ProdSpec(CommonSpec):
         self.kojiroot.value = kojiroot
         self.kojihub.value = kojihub
         self.koji_certs_secret.value = koji_certs_secret
+        self.koji_task_id.value = koji_task_id
         self.pulp_secret.value = pulp_secret or source_secret
         self.pulp_registry.value = pulp_registry
         self.pdc_secret.value = pdc_secret

--- a/tests/build/test_build_request.py
+++ b/tests/build/test_build_request.py
@@ -196,6 +196,7 @@ class TestBuildRequest(object):
         build_host = "our.build.host.example.com"
         authoritative_registry = "registry.example.com"
         distribution_scope = "authoritative-source-only"
+        koji_task_id = 4756
         assert isinstance(build_request, ProductionBuild)
         kwargs = {
             'git_uri': TEST_GIT_URI,
@@ -212,6 +213,7 @@ class TestBuildRequest(object):
             'koji_target': "koji-target",
             'kojiroot': "http://root/",
             'kojihub': "http://hub/",
+            'koji_task_id': koji_task_id,
             'sources_command': "make",
             'architecture': architecture,
             'vendor': vendor,
@@ -228,6 +230,7 @@ class TestBuildRequest(object):
         build_json = build_request.render()
 
         assert build_json["metadata"]["name"] == TEST_BUILD_CONFIG
+        assert build_json["metadata"]["labels"]["kojitask"] == koji_task_id
         assert "triggers" not in build_json["spec"]
         assert build_json["spec"]["source"]["git"]["uri"] == TEST_GIT_URI
         assert build_json["spec"]["source"]["git"]["ref"] == TEST_GIT_REF
@@ -1167,6 +1170,7 @@ class TestBuildRequest(object):
         name_label = "fedora/resultingimage"
         push_url = "ssh://{username}git.example.com/git/{component}.git"
         koji_certs_secret_name = 'foobar'
+        koji_task_id = 1234
         kwargs = {
             'git_uri': TEST_GIT_URI,
             'git_ref': TEST_GIT_REF,
@@ -1182,6 +1186,7 @@ class TestBuildRequest(object):
             'kojiroot': "http://root/",
             'kojihub': "http://hub/",
             'sources_command': "make",
+            'koji_task_id': koji_task_id,
             'architecture': "x86_64",
             'vendor': "Foo Vendor",
             'build_host': "our.build.host.example.com",
@@ -1194,6 +1199,8 @@ class TestBuildRequest(object):
         }
         build_request.set_params(**kwargs)
         build_json = build_request.render()
+
+        assert build_json["metadata"]["labels"]["kojitask"] == koji_task_id
 
         strategy = build_json['spec']['strategy']['customStrategy']['env']
         plugins_json = None


### PR DESCRIPTION
This is stored in the kojitask label of the BuildConfig.