### PR TITLE
Fix backup processing

### DIFF
--- a/osbs/api.py
+++ b/osbs/api.py
@@ -542,13 +542,6 @@ class OSBS(object):
     def _prepare_resource(resource_type, resource):
         utils.graceful_chain_del(resource, 'metadata', 'resourceVersion')
 
-        if resource_type == 'buildconfigs':
-            utils.graceful_chain_del(resource, 'status', 'lastVersion')
-
-            triggers = utils.graceful_chain_get(resource, 'spec', 'triggers') or ()
-            for t in triggers:
-                utils.graceful_chain_del(t, 'imageChange', 'lastTrigerredImageID')
-
     @osbsapi
     def dump_resource(self, resource_type):
         return self.os.dump_resource(resource_type).json()


### PR DESCRIPTION
* Don't drop `status.lastVersion` from buildconfigs as this causes name collisions of newly created builds with restored builds.
* Don't drop `lastTriggeredImageID` because empty value may cause a rebuild from the same base image.

Closes #407.