### PR TITLE
rename kojitask label 'koji-task-id'

### DIFF
--- a/osbs/build/build_request.py
+++ b/osbs/build/build_request.py
@@ -796,10 +796,10 @@ class ProductionBuild(CommonBuild):
             self.template['spec']['output']['to']['name'] = \
                 self.spec.image_tag.value
 
-        kojitask = self.spec.koji_task_id.value
-        if kojitask is not None:
+        koji_task_id = self.spec.koji_task_id.value
+        if koji_task_id is not None:
             self.template['metadata'].setdefault('labels', {})
-            self.template['metadata']['labels']['kojitask'] = kojitask
+            self.template['metadata']['labels']['koji-task-id'] = koji_task_id
 
         use_auth = self.spec.use_auth.value
         self.render_add_labels_in_dockerfile()

--- a/tests/build/test_build_request.py
+++ b/tests/build/test_build_request.py
@@ -246,7 +246,7 @@ class TestBuildRequest(object):
         build_json = build_request.render()
 
         assert build_json["metadata"]["name"] == TEST_BUILD_CONFIG
-        assert build_json["metadata"]["labels"]["kojitask"] == koji_task_id
+        assert build_json["metadata"]["labels"]["koji-task-id"] == koji_task_id
         assert "triggers" not in build_json["spec"]
         assert build_json["spec"]["source"]["git"]["uri"] == TEST_GIT_URI
         assert build_json["spec"]["source"]["git"]["ref"] == TEST_GIT_REF
@@ -1218,7 +1218,7 @@ class TestBuildRequest(object):
         build_request.set_params(**kwargs)
         build_json = build_request.render()
 
-        assert build_json["metadata"]["labels"]["kojitask"] == koji_task_id
+        assert build_json["metadata"]["labels"]["koji-task-id"] == koji_task_id
 
         strategy = build_json['spec']['strategy']['customStrategy']['env']
         plugins_json = None


### PR DESCRIPTION
This is safe right now as it is not yet used.