### PR TITLE
New optional koji_task_id parameter for list_builds.

### DIFF
--- a/osbs/api.py
+++ b/osbs/api.py
@@ -94,15 +94,17 @@ class OSBS(object):
         return self._bm
 
     @osbsapi
-    def list_builds(self, field_selector=None):
+    def list_builds(self, field_selector=None, koji_task_id=None):
         """
         List builds with matching fields
 
         :param field_selector: str, field selector for Builds
+        :param koji_task_id: str, only list builds for Koji Task ID
         :return: BuildResponse list
         """
 
-        response = self.os.list_builds(field_selector=field_selector)
+        response = self.os.list_builds(field_selector=field_selector,
+                                       koji_task_id=koji_task_id)
         serialized_response = response.json()
         build_list = []
         for build in serialized_response["items"]:

--- a/osbs/core.py
+++ b/osbs/core.py
@@ -420,19 +420,31 @@ class Openshift(object):
             return response.iter_lines()
         return response.content
 
-    def list_builds(self, build_config_id=None, field_selector=None):
+    def list_builds(self, build_config_id=None, koji_task_id=None,
+                    field_selector=None):
         """
         List builds matching criteria
 
-        :param build_config_id: str, name of BuildConfig to list builds for
+        :param build_config_id: str, only list builds created from BuildConfig
+        :param koji_task_id: str, only list builds for Koji Task ID
         :param field_selector: str, field selector for query
         :return: HttpResponse
         """
         query = {}
-        selector = '{field}={value}'
+        selector = '{key}={value}'
+
+        label = {}
         if build_config_id is not None:
-            query['labelSelector'] = selector.format(field='buildconfig',
-                                                     value=build_config_id)
+            label['buildconfig'] = build_config_id
+
+        if koji_task_id is not None:
+            label['koji-task-id'] = koji_task_id
+
+        if label:
+            query['labelSelector'] = ','.join([selector.format(key=key,
+                                                               value=value)
+                                               for key, value in label.items()])
+
         if field_selector is not None:
             query['fieldSelector'] = field_selector
         url = self._build_url("builds/", **query)

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -25,6 +25,7 @@ TEST_ARCH = "x86_64"
 TEST_BUILD_POD = "build-test-build-123"
 TEST_LABEL = "test-label"
 TEST_LABEL_VALUE = "sample-value"
+TEST_KOJI_TASK_ID = 12345
 
 TEST_BUILD_JSON = {
     "metadata": {

--- a/tests/fake_api.py
+++ b/tests/fake_api.py
@@ -18,7 +18,7 @@ from osbs.conf import Configuration
 from osbs.api import OSBS
 from tests.constants import (TEST_BUILD, TEST_COMPONENT, TEST_GIT_REF,
                              TEST_GIT_BRANCH, TEST_BUILD_CONFIG,
-                             TEST_GIT_URI_HUMAN_NAME)
+                             TEST_GIT_URI_HUMAN_NAME, TEST_KOJI_TASK_ID)
 from tempfile import NamedTemporaryFile
 
 try:
@@ -79,6 +79,13 @@ class Connection(object):
 
             (OAPI_PREFIX + "namespaces/default/builds?fieldSelector=status%3DRunning",
              OAPI_PREFIX + "namespaces/default/builds/?fieldSelector=status%3DRunning"): {
+                "get": {
+                    # Contains a list of builds
+                    "file": "builds_list.json",
+                }
+            },
+
+            OAPI_PREFIX + "namespaces/default/builds/?labelSelector=koji-task-id%3D{task}".format(task=TEST_KOJI_TASK_ID): {
                 "get": {
                     # Contains a list of builds
                     "file": "builds_list.json",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -28,13 +28,19 @@ from osbs.http import HttpResponse
 from osbs import utils
 
 from tests.constants import (TEST_ARCH, TEST_BUILD, TEST_COMPONENT, TEST_GIT_BRANCH, TEST_GIT_REF,
-                             TEST_GIT_URI, TEST_TARGET, TEST_USER, INPUTS_PATH)
+                             TEST_GIT_URI, TEST_TARGET, TEST_USER, INPUTS_PATH,
+                             TEST_KOJI_TASK_ID)
 from tests.fake_api import openshift, osbs, osbs106
 
 
 class TestOSBS(object):
-    def test_list_builds_api(self, osbs):
-        response_list = osbs.list_builds()
+    @pytest.mark.parametrize('koji_task_id', [None, TEST_KOJI_TASK_ID])
+    def test_list_builds_api(self, osbs, koji_task_id):
+        kwargs = {}
+        if koji_task_id:
+            kwargs['koji_task_id'] = koji_task_id
+
+        response_list = osbs.list_builds(**kwargs)
         # We should get a response
         assert response_list is not None
         assert len(response_list) > 0


### PR DESCRIPTION
This allows clients to filter listed builds by their koji-task-id label.

CC @lcarva, @breillyrh