### PR TITLE
run compress plugin after pulp_push

### DIFF
--- a/inputs/prod_inner.json
+++ b/inputs/prod_inner.json
@@ -80,13 +80,6 @@
   ],
   "postbuild_plugins": [
     {
-      "name": "compress",
-      "args": {
-        "load_exported_image": true,
-        "method": "gzip"
-      }
-    },
-    {
       "name": "tag_by_labels"
     },
     {
@@ -111,6 +104,13 @@
         "pulp_registry_name": "{{PULP_REGISTRY_NAME}}",
         "docker_registry": "{{DOCKER_REGISTRY}}",
         "dockpulp_loglevel": "INFO"
+      }
+    },
+    {
+      "name": "compress",
+      "args": {
+        "load_exported_image": true,
+        "method": "gzip"
       }
     },
     {


### PR DESCRIPTION
Now that pulp_push is smart enough to strip layers from the tarball, it is more efficient to let it do that manipulation before the tarball we'll upload to Koji is compressed.

This saves a round of decompression.