### PR TITLE
[WIP] prod_inner: use default dont_load setting for squash plugin

### DIFF
--- a/inputs/prod_inner.json
+++ b/inputs/prod_inner.json
@@ -73,8 +73,7 @@
     {
       "name": "squash",
       "args": {
-        "remove_former_image": false,
-        "dont_load": true
+        "remove_former_image": false
       }
     }
   ],
@@ -163,4 +162,3 @@
     }
   ]
 }
-


### PR DESCRIPTION
Currently image-id stored in annotations doesn't match the pulp image id
as we're not loading the squashed image back to Docker