### PR TITLE
prod_inner: use default squash plugin settings

### DIFF
--- a/inputs/prod_inner.json
+++ b/inputs/prod_inner.json
@@ -71,11 +71,7 @@
   ],
   "prepublish_plugins": [
     {
-      "name": "squash",
-      "args": {
-        "remove_former_image": false,
-        "dont_load": true
-      }
+      "name": "squash"
     }
   ],
   "postbuild_plugins": [
@@ -163,4 +159,3 @@
     }
   ]
 }
-


### PR DESCRIPTION
Currently image-id stored in annotations doesn't match the pulp image id
as we're not loading the squashed image back to Docker

A duplicate of #426