### PR TITLE
Don't crash while checking for labels in inexisting buildconfig

### DIFF
--- a/osbs/api.py
+++ b/osbs/api.py
@@ -226,7 +226,7 @@ class OSBS(object):
         - metadata.labels.git-repo-name AND metadata.labels.git-branch are equal
         """
 
-        git_labels = [(key, build_config['metadata']['labels'][key])
+        git_labels = [(key, build_config['metadata']['labels'].get(key, None))
                       for key in self._GIT_LABEL_KEYS]
         name = build_config['metadata']['name']
 


### PR DESCRIPTION
Reproduced on scratchbuild server