### PR TITLE
new 'labels' optional parameter for create_prod_build()

### DIFF
--- a/osbs/api.py
+++ b/osbs/api.py
@@ -320,6 +320,8 @@ class OSBS(object):
                           target,      # may be None
                           architecture=None, yum_repourls=None,
                           koji_task_id=None,
+                          scratch=False,
+                          labels=None,
                           **kwargs):
         """
         Create a production build
@@ -333,6 +335,8 @@ class OSBS(object):
         :param architecture: str, build architecture
         :param yum_repourls: list, URLs for yum repos
         :param koji_task_id: int, koji task ID requesting build
+        :param scratch: bool, this is a scratch build
+        :param labels: dict, overrides for Dockerfile labels
         :return: BuildResponse instance
         """
         df_parser = utils.get_df_parser(git_uri, git_ref, git_branch=git_branch)
@@ -384,8 +388,8 @@ class OSBS(object):
             git_push_url=self.build_conf.get_git_push_url(),
             git_push_username=self.build_conf.get_git_push_username(),
             builder_build_json_dir=self.build_conf.get_builder_build_json_store(),
-            labels=self.build_conf.get_labels(),
-            scratch=kwargs.get("scratch", False)
+            labels=labels,
+            scratch=scratch,
         )
         build_request.set_openshift_required_version(self.os_conf.get_openshift_required_version())
         response = self._create_build_config_and_build(build_request)

--- a/osbs/cli/main.py
+++ b/osbs/cli/main.py
@@ -278,8 +278,6 @@ def cmd_build(args, osbs):
         target=osbs.build_conf.get_koji_target(),
         architecture=osbs.build_conf.get_architecture(),
         yum_repourls=osbs.build_conf.get_yum_repourls(),
-        build_image=osbs.build_conf.get_build_image(),
-        build_imagestream=osbs.build_conf.get_build_imagestream(),
         scratch=args.scratch,
         labels=labels,
     )

--- a/osbs/cli/main.py
+++ b/osbs/cli/main.py
@@ -263,6 +263,11 @@ def cmd_cancel_build(args, osbs):
 
 
 def cmd_build(args, osbs):
+    if args.labels:
+        labels = dict(args.labels)
+    else:
+        labels = None
+
     build = osbs.create_build(
         git_uri=osbs.build_conf.get_git_uri(),
         git_ref=osbs.build_conf.get_git_ref(),
@@ -276,7 +281,7 @@ def cmd_build(args, osbs):
         build_image=osbs.build_conf.get_build_image(),
         build_imagestream=osbs.build_conf.get_build_imagestream(),
         scratch=args.scratch,
-        labels=osbs.build_conf.get_labels(),
+        labels=labels,
     )
     build_id = build.get_build_name()
     # we need to wait for kubelet to schedule the build, otherwise it's 500

--- a/osbs/conf.py
+++ b/osbs/conf.py
@@ -9,7 +9,6 @@ from __future__ import print_function, absolute_import, unicode_literals
 
 import logging
 import os
-import json
 import warnings
 from pkg_resources import parse_version
 
@@ -362,15 +361,6 @@ class Configuration(object):
 
     def get_proxy(self):
         return self._get_value("yum_proxy", self.conf_section, "yum_proxy")
-
-    def get_labels(self):
-        labels_list = self._get_value("labels", self.conf_section, "labels")
-        if labels_list is None:
-            return {}
-        # When read from config file, it needs to be deserialized
-        if type(labels_list) is not list:
-            labels_list = json.loads(labels_list)
-        return dict(labels_list)
 
     def get_oauth2_token(self):
         # token overrides token_file

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -150,38 +150,3 @@ class TestConfiguration(object):
                                      **kwargs)
 
                 assert conf.get_oauth2_token() == expected
-
-    @pytest.mark.parametrize(('config', 'kwargs', 'cli_args', 'expected'), [
-        # No labels
-        ({'default': {}},
-         {},
-         {},
-         {}),
-        # From config
-        ({'default': {'labels': '[["spam", "maps"]]'}},
-         {},
-         {},
-         {'spam': 'maps'}),
-        # From keyword arguments
-        ({'default': {}},
-         # Hmm this is confusing. Try to make it labels?
-         {'labels': [['spam', 'maps']]},
-         {},
-         {'spam': 'maps'}),
-        # From CLI arguments
-        ({'default': {}},
-         {},
-         {'labels': [['spam', 'maps']]},
-         {'spam': 'maps'}),
-    ])
-    def test_explicit_labels(self, config, kwargs, cli_args, expected):
-        if 'token_file' in kwargs:
-            tmpf = self.tmpfile_with_content(kwargs['token_file'])
-            kwargs['token_file'] = tmpf.name
-
-        with self.build_cli_args(cli_args) as args:
-            with self.config_file(config) as config_file:
-                conf = Configuration(conf_file=config_file, cli_args=args,
-                                     **kwargs)
-
-                assert conf.get_labels() == expected


### PR DESCRIPTION
This parameter provides overrides for the labels in the Dockerfile. It cannot be set in the configuration file but can be provided at the command line.

Not providing configuration file compatibility because (a) it was never documented, and (b) config values would not get merged with CLI/kwarg values.