### PR TITLE
Enable tag_from_config plugin

### DIFF
--- a/inputs/prod_inner.json
+++ b/inputs/prod_inner.json
@@ -85,6 +85,9 @@
       "name": "tag_by_labels"
     },
     {
+      "name": "tag_from_config"
+    },
+    {
       "name": "tag_and_push",
       "args": {
         "registries": {


### PR DESCRIPTION
This can be merged, but a new release would require a release of atomic-reactor containing the following changes: https://github.com/projectatomic/atomic-reactor/pull/515