### PR TITLE
buildresponse: return a meaningful error message

### DIFF
--- a/osbs/build/build_response.py
+++ b/osbs/build/build_response.py
@@ -119,6 +119,22 @@ class BuildResponse(object):
         else:
             return logs
 
+    def get_error_message(self):
+        """
+        Return an error message based on atomic-reactor's metadata
+        """
+        try:
+            str_metadata = graceful_chain_get(self.get_annotations_or_labels(), "plugins-metadata")
+            metadata_dict = json.loads(str_metadata)
+            plugin, error_message = list(metadata_dict['errors'].items())[0]
+            if error_message:
+                # Plugin has non-empty error description
+                return "Error in plugin %s: %s" % (plugin, error_message)
+            else:
+                return "Error in plugin %s" % plugin
+        except Exception:
+            return None
+
     def get_commit_id(self):
         return graceful_chain_get(self.get_annotations_or_labels(), "commit_id")
 

--- a/tests/build/test_build_response.py
+++ b/tests/build/test_build_response.py
@@ -6,6 +6,7 @@ This software may be modified and distributed under the terms
 of the BSD license. See the LICENSE file for details.
 """
 import json
+import pytest
 from osbs.build.build_response import BuildResponse
 
 class TestBuildResponse(object):
@@ -39,3 +40,24 @@ class TestBuildResponse(object):
         })
         assert build_response.get_koji_build_id() == koji_build_id
 
+    @pytest.mark.parametrize(('plugin', 'message', 'expected_error_message'), [
+        ('dockerbuild', None, 'Error in plugin dockerbuild'),
+        ('foo', 'bar', 'Error in plugin foo: bar'),
+        (None, None, None)
+    ])
+    def test_error_message(self, plugin, message, expected_error_message):
+        plugins_metadata = json.dumps({
+            'errors': {
+                plugin: message,
+            },
+        })
+        if not plugin:
+            plugins_metadata = ''
+        build_response = BuildResponse({
+            'metadata': {
+                'annotations': {
+                    'plugins-metadata': plugins_metadata
+                }
+            }
+        })
+        assert build_response.get_error_message() == expected_error_message


### PR DESCRIPTION
This is handy for koji-containerbuild to return a more descriptive error message