### PR TITLE
Support setting email/login/email for registries in tag_and_push plugin

### DIFF
--- a/osbs/api.py
+++ b/osbs/api.py
@@ -354,6 +354,7 @@ class OSBS(object):
             base_image=df_parser.baseimage,
             name_label=name_label,
             registry_uris=self.build_conf.get_registry_uris(),
+            registry_secrets=self.build_conf.get_registry_secrets(),
             source_registry_uri=self.build_conf.get_source_registry_uri(),
             registry_api_versions=self.build_conf.get_registry_api_versions(),
             openshift_uri=self.os_conf.get_openshift_base_uri(),

--- a/osbs/build/spec.py
+++ b/osbs/build/spec.py
@@ -121,6 +121,7 @@ class BuildSpec(object):
     user = UserParam()
     component = BuildParam('component')
     registry_uris = RegistryURIsParam()
+    registry_secrets = BuildParam('registry_secrets', allow_none=True)
     source_registry_uri = SourceRegistryURIParam()
     openshift_uri = BuildParam('openshift_uri')
     builder_openshift_url = BuildParam('builder_openshift_url')
@@ -188,7 +189,8 @@ class BuildSpec(object):
 
     def set_params(self, git_uri=None, git_ref=None,
                    registry_uri=None,  # compatibility name for registry_uris
-                   registry_uris=None, user=None,
+                   registry_uris=None, registry_secrets=None,
+                   user=None,
                    component=None, openshift_uri=None, source_registry_uri=None,
                    yum_repourls=None, use_auth=None, builder_openshift_url=None,
                    build_image=None, build_imagestream=None, proxy=None,
@@ -215,6 +217,7 @@ class BuildSpec(object):
             registry_uris = [registry_uri]
 
         self.registry_uris.value = registry_uris or []
+        self.registry_secrets.value = registry_secrets or []
         self.source_registry_uri.value = source_registry_uri
         self.openshift_uri.value = openshift_uri
         self.builder_openshift_url.value = builder_openshift_url

--- a/osbs/conf.py
+++ b/osbs/conf.py
@@ -245,6 +245,13 @@ class Configuration(object):
         else:
             return []
 
+    def get_registry_secrets(self):
+        value = self._get_value("registry_secret", self.conf_section, "registry_secret")
+        if value:
+            return value.split(',')
+        else:
+            return []
+
     def get_registry_api_versions(self):
         value = self._get_value("registry_api_versions",
                                 self.conf_section,

--- a/tests/build/test_build_request.py
+++ b/tests/build/test_build_request.py
@@ -553,6 +553,66 @@ class TestBuildRequest(object):
         assert plugin_value_get(plugins, "postbuild_plugins", "tag_and_push", "args",
                                 "registries") == {}
 
+    def test_render_prod_with_registry_secrets(self):
+        build_request = BuildRequest(INPUTS_PATH)
+
+        kwargs = {
+            'git_uri': TEST_GIT_URI,
+            'git_ref': TEST_GIT_REF,
+            'git_branch': TEST_GIT_BRANCH,
+            'user': "john-foo",
+            'component': TEST_COMPONENT,
+            'base_image': 'fedora:latest',
+            'name_label': 'fedora/resultingimage',
+            'registry_uri': "registry.example.com",
+            'nfs_server_path': "server:path",
+            'openshift_uri': "http://openshift/",
+            'builder_openshift_url': "http://openshift/",
+            'koji_target': "koji-target",
+            'kojiroot': "http://root/",
+            'kojihub': "http://hub/",
+            'sources_command': "make",
+            'architecture': "x86_64",
+            'vendor': "Foo Vendor",
+            'build_host': "our.build.host.example.com",
+            'authoritative_registry': "registry.example.com",
+            'distribution_scope': "authoritative-source-only",
+            'registry_api_versions': ['v1'],
+            'source_secret': 'mysecret',
+            'registry_secrets': ['registry_secret'],
+        }
+        build_request.set_params(**kwargs)
+        build_json = build_request.render()
+
+        assert 'sourceSecret' not in build_json["spec"]["source"]
+        secrets = build_json['spec']['strategy']['customStrategy']['secrets']
+        registry_secret = [secret for secret in secrets
+                           if secret['secretSource']['name'] == 'registry_secret']
+        assert len(registry_secret) > 0
+        assert 'mountPath' in registry_secret[0]
+        mount_path = registry_secret[0]['mountPath']
+        plugins = get_plugins_from_build_json(build_json)
+        assert get_plugin(plugins, "postbuild_plugins", "tag_and_push")
+        assert plugin_value_get(
+            plugins, "postbuild_plugins", "tag_and_push", "args", "registries",
+            "registry.example.com", "secret") == mount_path
+
+        with pytest.raises(NoSuchPluginException):
+            get_plugin(plugins, "prebuild_plugins", "check_and_set_rebuild")
+        with pytest.raises(NoSuchPluginException):
+            get_plugin(plugins, "prebuild_plugins",
+                       "stop_autorebuild_if_disabled")
+        assert get_plugin(plugins, "prebuild_plugins", "bump_release")
+        assert get_plugin(plugins, "prebuild_plugins", "koji")
+        with pytest.raises(NoSuchPluginException):
+            get_plugin(plugins, "postbuild_plugins", "pulp_sync")
+        with pytest.raises(NoSuchPluginException):
+            get_plugin(plugins, "postbuild_plugins", "cp_built_image_to_nfs")
+        with pytest.raises(NoSuchPluginException):
+            get_plugin(plugins, "postbuild_plugins", "import_image")
+        with pytest.raises(NoSuchPluginException):
+            get_plugin(plugins, "exit_plugins", "sendmail")
+
     def test_render_prod_request_requires_newer(self):
         """
         We should get an OsbsValidationException when trying to use the


### PR DESCRIPTION
This also enables setting several secrets for a plugin and adds test.

Supersedes #443, as it contains suggestions from Tim and Luiz