### PR TITLE
Set git branch to empty string instead of None

### DIFF
--- a/osbs/build/build_request.py
+++ b/osbs/build/build_request.py
@@ -151,6 +151,8 @@ class BuildRequest(object):
         return False
 
     def set_label(self, name, value):
+        if not value:
+            value = ''
         self.template['metadata'].setdefault('labels', {})
         self.template['metadata']['labels'][name] = value
 

--- a/osbs/build/build_request.py
+++ b/osbs/build/build_request.py
@@ -694,7 +694,10 @@ class BuildRequest(object):
         # use case must be handled properly, the git URI must be taken into
         # account.
         self.set_label('git-repo-name', repo_name)
-        self.set_label('git-branch', self.spec.git_branch.value)
+        if self.spec.git_branch.value:
+            self.set_label('git-branch', self.spec.git_branch.value)
+        else:
+            self.set_label('git-branch', 'unknown')
 
         if self.spec.sources_command.value is not None:
             self.dj.dock_json_set_arg('prebuild_plugins', "distgit_fetch_artefacts",

--- a/tests/build/test_build_request.py
+++ b/tests/build/test_build_request.py
@@ -1156,6 +1156,8 @@ class TestBuildRequest(object):
         build_request.set_params(**kwargs)
         build_json = build_request.render()
 
+        assert build_json["metadata"]["labels"]["git-branch"] is not None
+
         # Verify the triggers are now disabled
         assert "triggers" not in build_json["spec"]
 


### PR DESCRIPTION
This unblocks builds using rhpkg, which doesn't pass git branch parameter