### PR TITLE
Create a new Build for scratch builds

### DIFF
--- a/osbs/build/build_request.py
+++ b/osbs/build/build_request.py
@@ -50,7 +50,7 @@ class BuildRequest(object):
         self._resource_limits = None
         self._openshift_required_version = parse_version('1.0.6')
         # For the koji "scratch" build type
-        self.scratch = False
+        self.scratch = None
         self.base_image = None
 
     def set_params(self, **kwargs):

--- a/osbs/cli/main.py
+++ b/osbs/cli/main.py
@@ -566,7 +566,7 @@ def cli():
     build_parser.add_argument("--storage-limit", action='store', required=False,
                               help="storage limit")
     build_parser.add_argument("--scratch", action='store_true', required=False,
-                              default=False, help="perform a scratch build")
+                              help="perform a scratch build")
     build_parser.add_argument("--yum-proxy", action='store', required=False,
                               help="set yum proxy to repos from koji/add-yum-repo params")
     group = build_parser.add_mutually_exclusive_group()

--- a/osbs/conf.py
+++ b/osbs/conf.py
@@ -366,6 +366,10 @@ class Configuration(object):
     def get_proxy(self):
         return self._get_value("yum_proxy", self.conf_section, "yum_proxy")
 
+    def get_scratch(self, default_value):
+        return self._get_value("scratch", self.conf_section, "scratch",
+                               default=default_value, is_bool_val=True)
+
     def get_oauth2_token(self):
         # token overrides token_file
         # either in kwargs overrides cli args

--- a/osbs/core.py
+++ b/osbs/core.py
@@ -287,7 +287,7 @@ class Openshift(object):
         """
         url = self._build_url("builds/")
         logger.debug(build_json)
-        return self._post(url, data=build_json,
+        return self._post(url, data=json.dumps(build_json),
                           headers={"Content-Type": "application/json"})
 
     def cancel_build(self, build_id):


### PR DESCRIPTION
This creates a new build on existing BuildConfig (if found) instead of updating BuildConfig

TODO:
 * [x] Add a new config option for scratch builds (after build_types were removed)
 * [x] Add tests
 * [x] Verify on several existing projects