### PR TITLE
Add support for unique_tag_only config

### DIFF
--- a/osbs/api.py
+++ b/osbs/api.py
@@ -396,6 +396,7 @@ class OSBS(object):
             git_push_username=self.build_conf.get_git_push_username(),
             builder_build_json_dir=self.build_conf.get_builder_build_json_store(),
             scratch=self.build_conf.get_scratch(scratch),
+            unique_tag_only=self.build_conf.get_unique_tag_only(),
         )
         build_request.set_openshift_required_version(self.os_conf.get_openshift_required_version())
         if build_request.scratch:

--- a/osbs/build/build_request.py
+++ b/osbs/build/build_request.py
@@ -221,6 +221,18 @@ class BuildRequest(object):
                                       "store_metadata_in_osv3",
                                       "use_auth", use_auth)
 
+    def render_unique_tag_only(self):
+
+        if not self.spec.unique_tag_only.value:
+            return
+
+        if self.dj.dock_json_has_plugin_conf('postbuild_plugins',
+                                             'tag_by_labels'):
+            self.dj.dock_json_set_arg('postbuild_plugins', 'tag_by_labels',
+                                      'unique_tag_only', True)
+
+        self.dj.remove_plugin('postbuild_plugins', 'tag_from_config')
+
     def set_secret_for_plugin(self, plugin, secret):
         has_plugin_conf = self.dj.dock_json_has_plugin_conf(plugin[0],
                                                             plugin[1])
@@ -678,6 +690,8 @@ class BuildRequest(object):
             self.template['spec']['output']['to']['name'] = self.spec.image_tag.value
 
         self.render_tag_and_push_registries()
+
+        self.render_unique_tag_only()
 
         if 'triggers' in self.template['spec']:
             imagechange = self.template['spec']['triggers'][0]['imageChange']

--- a/osbs/build/spec.py
+++ b/osbs/build/spec.py
@@ -158,6 +158,7 @@ class BuildSpec(object):
     git_push_url = BuildParam("git_push_url", allow_none=True)
     git_push_username = BuildParam("git_push_username", allow_none=True)
     builder_build_json_dir = BuildParam("builder_build_json_dir", allow_none=True)
+    unique_tag_only = BuildParam("unique_tag_only", allow_none=True)
 
     def __init__(self):
         self.required_params = [
@@ -203,6 +204,7 @@ class BuildSpec(object):
                    nfs_dest_dir=None, git_branch=None, base_image=None,
                    name_label=None, git_push_url=None, git_push_username=None,
                    builder_build_json_dir=None, registry_api_versions=None,
+                   unique_tag_only=None,
                    **kwargs):
         self.git_uri.value = git_uri
         self.git_ref.value = git_ref
@@ -283,6 +285,8 @@ class BuildSpec(object):
             self.koji_target.value or 'none',
             timestamp
         )
+
+        self.unique_tag_only.value = unique_tag_only
 
     def validate(self):
         logger.info("Validating params of %s", self.__class__.__name__)

--- a/osbs/conf.py
+++ b/osbs/conf.py
@@ -370,6 +370,10 @@ class Configuration(object):
         return self._get_value("scratch", self.conf_section, "scratch",
                                default=default_value, is_bool_val=True)
 
+    def get_unique_tag_only(self):
+        return self._get_value("unique_tag_only", self.conf_section, "unique_tag_only",
+                               default=False, is_bool_val=True)
+
     def get_oauth2_token(self):
         # token overrides token_file
         # either in kwargs overrides cli args

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -150,3 +150,49 @@ class TestConfiguration(object):
                                      **kwargs)
 
                 assert conf.get_oauth2_token() == expected
+
+    @pytest.mark.parametrize(('config', 'kwargs', 'cli_args', 'expected'), [
+        ({'default': {}},
+         {},
+         {},
+         {'get_unique_tag_only': False}),
+
+        ({'default': {'unique_tag_only': 'true'}},
+         {},
+         {},
+         {'get_unique_tag_only': True}),
+
+        ({'default': {}},
+         {'unique_tag_only': 'true'},
+         {},
+         {'get_unique_tag_only': True}),
+
+        ({'default': {}},
+         {},
+         {'unique_tag_only': 'true'},
+         {'get_unique_tag_only': True}),
+
+        ({'default': {'unique_tag_only': 'false'}},
+         {},
+         {},
+         {'get_unique_tag_only': False}),
+
+        ({'default': {}},
+         {'unique_tag_only': 'false'},
+         {},
+         {'get_unique_tag_only': False}),
+
+        ({'default': {}},
+         {},
+         {'unique_tag_only': 'false'},
+         {'get_unique_tag_only': False}),
+
+    ])
+    def test_param_retrieval(self, config, kwargs, cli_args, expected):
+        with self.build_cli_args(cli_args) as args:
+            with self.config_file(config) as config_file:
+                conf = Configuration(conf_file=config_file, cli_args=args,
+                                     **kwargs)
+
+                for fn, value in expected.items():
+                    assert getattr(conf, fn)() == value


### PR DESCRIPTION
When `unique_tag_only` is set to True, atomic-reactor will be configured to ensure built image is only tagged with its unique timestamp tag.

If `unique_tag_only` is either not set or set to False, behavior remains unchanged. This should allow using an older atomic-reactor version than the one containing these changes: https://github.com/projectatomic/atomic-reactor/pull/554