### PR TITLE
Add --oc to get-token for full oc login command

### DIFF
--- a/osbs/cli/main.py
+++ b/osbs/cli/main.py
@@ -340,7 +340,11 @@ def cmd_import_image(args, osbs):
 
 def cmd_get_token(args, osbs):  # pylint: disable=W0613
     token = osbs.get_token()
-    print(token)
+    if args.oc:
+        print('oc login --token {} {}'
+              .format(token, osbs.os_conf.get_openshift_base_uri()))
+    else:
+        print(token)
 
 
 def cmd_get_user(args, osbs):
@@ -508,6 +512,8 @@ def cli():
     import_image_parser.set_defaults(func=cmd_import_image)
 
     get_token_parser = subparsers.add_parser(str_on_2_unicode_on_3('get-token'), help='get authentication token')
+    get_token_parser.add_argument("--oc", help="display oc login command",
+                                  action="store_true", default=False)
     get_token_parser.set_defaults(func=cmd_get_token)
 
     get_user_parser = subparsers.add_parser(str_on_2_unicode_on_3('get-user'), help='get info about user')


### PR DESCRIPTION
```
$ osbs --instance prod get-token --help
usage: osbs get-token [-h] [--oc]

optional arguments:
  -h, --help  show this help message and exit
  --oc        display oc login command
```

New `--oc` param in action:
```
$ osbs --instance prod get-token --oc
oc login --token ABCDEFGH0123 https://prod.example.com:9443/
```

Existing behavior is unaffected:
```
$ osbs --instance rcm-img-docker03-test get-token 
ABCDEFGH0123
```