### PR TITLE
Run distribution_scope pre-build plugin

### DIFF
--- a/inputs/prod_inner.json
+++ b/inputs/prod_inner.json
@@ -72,6 +72,9 @@
     },
     {
       "name": "dockerfile_content"
+    },
+    {
+      "name": "distribution_scope"
     }
   ],
   "prepublish_plugins": [


### PR DESCRIPTION
Requires atomic-reactor >= 1.6.18 for:
https://github.com/projectatomic/atomic-reactor/pull/565