### PR TITLE
configure pulp_pull plugin

### DIFF
--- a/inputs/prod_inner.json
+++ b/inputs/prod_inner.json
@@ -124,6 +124,10 @@
       }
     },
     {
+      "name": "pulp_pull",
+      "args": {}
+    },
+    {
       "args": {
         "imagestream": "{{IMAGESTREAM}}",
         "docker_image_repo": "{{DOCKER_IMAGE_REPO}}",


### PR DESCRIPTION
Only run this when Pulp is used and we are producing v2 images.

Depends on https://github.com/projectatomic/atomic-reactor/pull/574.