### PR TITLE
scratch builds: don't run compress plugin

### DIFF
--- a/osbs/build/build_request.py
+++ b/osbs/build/build_request.py
@@ -388,7 +388,8 @@ class BuildRequest(object):
             # Note: only one for now, but left in a list like other adjust_for_
             # functions in the event that this needs to be expanded
             for when, which in [
-                ("exit_plugins", "koji_promote"),
+                    ("postbuild_plugins", "compress"),
+                    ("exit_plugins", "koji_promote"),
             ]:
                 logger.info("removing %s from request because there are no triggers",
                             which)

--- a/tests/build/test_build_request.py
+++ b/tests/build/test_build_request.py
@@ -713,7 +713,8 @@ class TestBuildRequest(object):
         ['v1', 'v2'],
         ['v2'],
     ])
-    def test_render_prod_request_v1_v2(self, registry_api_versions):
+    @pytest.mark.parametrize('scratch', [False, True])
+    def test_render_prod_request_v1_v2(self, registry_api_versions, scratch):
         build_request = BuildRequest(INPUTS_PATH)
         # OpenShift Origin >= 1.0.6 is required for v2
         build_request.set_openshift_required_version(parse_version('1.0.6'))
@@ -756,6 +757,7 @@ class TestBuildRequest(object):
             'authoritative_registry': "registry.example.com",
             'distribution_scope': "authoritative-source-only",
             'registry_api_versions': registry_api_versions,
+            'scratch': scratch,
         })
         build_request.set_params(**kwargs)
         build_json = build_request.render()
@@ -809,8 +811,6 @@ class TestBuildRequest(object):
         with pytest.raises(NoSuchPluginException):
             get_plugin(plugins, "postbuild_plugins", "cp_built_image_to_nfs")
 
-        assert get_plugin(plugins, "postbuild_plugins", "compress")
-
         if 'v1' in registry_api_versions:
             assert get_plugin(plugins, "postbuild_plugins",
                               "pulp_push")
@@ -839,6 +839,16 @@ class TestBuildRequest(object):
         else:
             with pytest.raises(NoSuchPluginException):
                 get_plugin(plugins, "postbuild_plugins", "pulp_sync")
+
+        if scratch:
+            with pytest.raises(NoSuchPluginException):
+                get_plugin(plugins, "postbuild_plugins", "compress")
+
+            with pytest.raises(NoSuchPluginException):
+                get_plugin(plugins, "exit_plugins", "koji_promote")
+        else:
+            assert get_plugin(plugins, "postbuild_plugins", "compress")
+            assert get_plugin(plugins, "exit_plugins", "koji_promote")
 
     def test_render_with_yum_repourls(self):
         kwargs = {


### PR DESCRIPTION
The compress plugin is only used by the koji_promote plugin now.
