### PR TITLE
Revert "configure pulp_pull plugin"

### DIFF
--- a/inputs/prod_inner.json
+++ b/inputs/prod_inner.json
@@ -127,10 +127,6 @@
       }
     },
     {
-      "name": "pulp_pull",
-      "args": {}
-    },
-    {
       "args": {
         "imagestream": "{{IMAGESTREAM}}",
         "docker_image_repo": "{{DOCKER_IMAGE_REPO}}",


### PR DESCRIPTION
This reverts commit 6d9bf3c79d103e6fbc61cd37d65de1ca02c8bce8.

Pub doesn't support associating images via v2 ID, so we have to temporary revert it