### PR TITLE
-c is optional, and having no effect

### DIFF
--- a/osbs/api.py
+++ b/osbs/api.py
@@ -362,10 +362,10 @@ class OSBS(object):
         """
 
         def get_required_label(labels, names):
-        """
-        get value of label list, first found is returned
-        names has to be non empty tuple
-        """
+            """
+            get value of label list, first found is returned
+            names has to be non empty tuple
+            """
             assert names  # always called with a non-empty literal tuple so names[0] is safe
             for label_name in names:
                 if label_name in labels:

--- a/osbs/api.py
+++ b/osbs/api.py
@@ -365,7 +365,7 @@ class OSBS(object):
             for label_name in names:
                 if label_name in labels:
                     return labels[label_name]
-            
+
             raise OsbsValidationException("required label '{name}' missing "
                                           "from Dockerfile"
                                           .format(name=names[-1]))

--- a/osbs/api.py
+++ b/osbs/api.py
@@ -362,20 +362,25 @@ class OSBS(object):
         """
 
         def get_required_label(labels, names):
+        """
+        get value of label list, first found is returned
+        names has to be non empty tuple
+        """
+            assert names  # always called with a non-empty literal tuple so names[0] is safe
             for label_name in names:
                 if label_name in labels:
                     return labels[label_name]
 
             raise OsbsValidationException("required label '{name}' missing "
                                           "from Dockerfile"
-                                          .format(name=names[-1]))
+                                          .format(name=names[0]))
 
         df_parser = utils.get_df_parser(git_uri, git_ref, git_branch=git_branch)
         build_request = self.get_build_request()
         labels = df_parser.labels
 
-        name_label = get_required_label(labels, ('Name', 'name'))
-        component = get_required_label(labels, ('BZComponent', 'com.redhat.component'))
+        name_label = get_required_label(labels, ('name', 'Name'))
+        component = get_required_label(labels, ('com.redhat.component', 'BZComponent'))
 
         build_request.set_params(
             git_uri=git_uri,

--- a/osbs/api.py
+++ b/osbs/api.py
@@ -338,8 +338,9 @@ class OSBS(object):
     @osbsapi
     def create_prod_build(self, git_uri, git_ref,
                           git_branch,  # may be None
-                          user, component,
-                          target,      # may be None
+                          user,
+                          component=None,
+                          target=None,
                           architecture=None, yum_repourls=None,
                           koji_task_id=None,
                           scratch=None,
@@ -351,25 +352,30 @@ class OSBS(object):
         :param git_ref: str, reference to commit
         :param git_branch: str, branch name (may be None)
         :param user: str, user name
-        :param component: str, component name
-        :param target: str, koji target (may be None)
+        :param component: str, not used anymore
+        :param target: str, koji target
         :param architecture: str, build architecture
         :param yum_repourls: list, URLs for yum repos
         :param koji_task_id: int, koji task ID requesting build
         :param scratch: bool, this is a scratch build
         :return: BuildResponse instance
         """
+
+        def get_required_label(labels, names):
+            for label_name in names:
+                if label_name in labels:
+                    return labels[label_name]
+            
+            raise OsbsValidationException("required label '{name}' missing "
+                                          "from Dockerfile"
+                                          .format(name=names[-1]))
+
         df_parser = utils.get_df_parser(git_uri, git_ref, git_branch=git_branch)
         build_request = self.get_build_request()
         labels = df_parser.labels
-        for name_label_name in ['name', 'Name']:
-            if name_label_name in labels:
-                name_label = labels[name_label_name]
-                break
-        else:
-            raise OsbsValidationException("required label '{name}' missing "
-                                          "from Dockerfile"
-                                          .format(name=name_label_name))
+
+        name_label = get_required_label(labels, ('Name', 'name'))
+        component = get_required_label(labels, ('BZComponent', 'com.redhat.component'))
 
         build_request.set_params(
             git_uri=git_uri,
@@ -426,14 +432,14 @@ class OSBS(object):
         return response
 
     @osbsapi
-    def create_prod_with_secret_build(self, git_uri, git_ref, git_branch, user, component,
-                                      target, architecture=None, yum_repourls=None, **kwargs):
+    def create_prod_with_secret_build(self, git_uri, git_ref, git_branch, user, component=None,
+                                      target=None, architecture=None, yum_repourls=None, **kwargs):
         warnings.warn("create_prod_with_secret_build is deprecated, please use create_build")
         return self.create_prod_build(git_uri, git_ref, git_branch, user, component, target,
                                       architecture, yum_repourls=yum_repourls, **kwargs)
 
     @osbsapi
-    def create_prod_without_koji_build(self, git_uri, git_ref, git_branch, user, component,
+    def create_prod_without_koji_build(self, git_uri, git_ref, git_branch, user, component=None,
                                        architecture=None, yum_repourls=None, **kwargs):
         warnings.warn("create_prod_without_koji_build is deprecated, please use create_build")
         return self.create_prod_build(git_uri, git_ref, git_branch, user, component, None,
@@ -453,7 +459,6 @@ class OSBS(object):
         :return: instance of BuildRequest
         """
         kwargs.setdefault('git_branch', None)
-        kwargs.setdefault('target', None)
         return self.create_prod_build(**kwargs)
 
     @osbsapi

--- a/osbs/build/spec.py
+++ b/osbs/build/spec.py
@@ -168,7 +168,6 @@ class BuildSpec(object):
             self.git_uri,
             self.git_ref,
             self.user,
-            self.component,
             self.registry_uris,
             self.openshift_uri,
             self.sources_command,

--- a/osbs/cli/main.py
+++ b/osbs/cli/main.py
@@ -277,7 +277,6 @@ def cmd_build(args, osbs):
         git_ref=osbs.build_conf.get_git_ref(),
         git_branch=osbs.build_conf.get_git_branch(),
         user=osbs.build_conf.get_user(),
-        component=osbs.build_conf.get_component(),
         tag=osbs.build_conf.get_tag(),
         target=osbs.build_conf.get_koji_target(),
         architecture=osbs.build_conf.get_architecture(),

--- a/osbs/cli/main.py
+++ b/osbs/cli/main.py
@@ -559,8 +559,8 @@ def cli():
                               help="build architecture")
     build_parser.add_argument("-u", "--user", action='store', required=True,
                               help="prefix for docker image repository")
-    build_parser.add_argument("-c", "--component", action='store', required=True,
-                              help="name of component")
+    build_parser.add_argument("-c", "--component", action='store', required=False,
+                              help="not used; use com.redhat.component label in Dockerfile")
     build_parser.add_argument("-A", "--tag", action='store', required=False,
                               help="tag of the built image (simple builds only)")
     build_parser.add_argument("--no-logs", action='store_true', required=False, default=False,

--- a/osbs/conf.py
+++ b/osbs/conf.py
@@ -186,9 +186,6 @@ class Configuration(object):
         """ user namespace when tagging and pushing image """
         return self._get_value("user", self.conf_section, "user")
 
-    def get_component(self):
-        return self._get_value("component", self.conf_section, "component")
-
     def get_tag(self):
         return self._get_value("tag", self.conf_section, "tag")
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -72,7 +72,7 @@ class TestOSBS(object):
 
     def test_create_build_with_deprecated_params(self, osbs):
         class MockParser(object):
-            labels = {'Name': 'fedora23/something'}
+            labels = {'Name': 'fedora23/something', 'com.redhat.component': TEST_COMPONENT}
             baseimage = 'fedora23/python'
         (flexmock(utils)
             .should_receive('get_df_parser')
@@ -102,7 +102,7 @@ class TestOSBS(object):
     def test_create_prod_build(self, osbs, name_label_name):
         # TODO: test situation when a buildconfig already exists
         class MockParser(object):
-            labels = {name_label_name: 'fedora23/something'}
+            labels = {name_label_name: 'fedora23/something', 'com.redhat.component':  TEST_COMPONENT}
             baseimage = 'fedora23/python'
         (flexmock(utils)
             .should_receive('get_df_parser')
@@ -116,7 +116,7 @@ class TestOSBS(object):
     @pytest.mark.parametrize('unique_tag_only', [True, False, None])
     def test_create_prod_build_unique_tag_only(self, osbs, unique_tag_only):
         class MockParser(object):
-            labels = {'Name': 'fedora23/something'}
+            labels = {'Name': 'fedora23/something', 'com.redhat.component': TEST_COMPONENT}
             baseimage = 'fedora23/python'
         (flexmock(utils)
             .should_receive('get_df_parser')
@@ -154,9 +154,34 @@ class TestOSBS(object):
                                    TEST_GIT_BRANCH, TEST_USER,
                                    TEST_COMPONENT, TEST_TARGET, TEST_ARCH)
 
-    def test_create_prod_build_missing_args(self, osbs):
+
+    @pytest.mark.parametrize('label_name', ['BZComponent', 'com.redhat.component', 'Name', 'name'])
+    def test_missing_component_and_name_labels(self, osbs, label_name):
+        """
+        tests if raises exception if there is only component
+        or only name in labels
+        """
+
         class MockParser(object):
-            labels = {'Name': 'fedora23/something'}
+            labels = {label_name: 'something'}
+            baseimage = 'fedora23/python'
+        (flexmock(utils)
+            .should_receive('get_df_parser')
+            .with_args(TEST_GIT_URI, TEST_GIT_REF, git_branch=TEST_GIT_BRANCH)
+            .and_return(MockParser()))
+        with pytest.raises(OsbsValidationException):
+            osbs.create_prod_build(TEST_GIT_URI, TEST_GIT_REF,
+                                   TEST_GIT_BRANCH, TEST_USER,
+                                   TEST_COMPONENT, TEST_TARGET, TEST_ARCH)
+
+
+    def test_create_prod_build_missing_args(self, osbs):
+        """
+        tests if setdefault for arguments works in create_build
+        """
+
+        class MockParser(object):
+            labels = {'Name': 'fedora23/something', 'com.redhat.component': TEST_COMPONENT}
             baseimage = 'fedora23/python'
         (flexmock(utils)
             .should_receive('get_df_parser')
@@ -169,7 +194,6 @@ class TestOSBS(object):
                        git_branch=None,
                        user=TEST_USER,
                        component=TEST_COMPONENT,
-                       target=None,
                        architecture=TEST_ARCH)
             .once()
             .and_return(None))
@@ -179,9 +203,47 @@ class TestOSBS(object):
                                      component=TEST_COMPONENT,
                                      architecture=TEST_ARCH)
 
+
+    @pytest.mark.parametrize('component_label_name', ['com.redhat.component', 'BZComponent'])
+    def test_component_is_changed_from_label(self, osbs, component_label_name):
+        """
+        tests if component is changed in create_prod_build
+        with value from component label
+        """
+
+        class MockParser(object):
+            labels = {'Name': 'fedora23/something', component_label_name: TEST_COMPONENT}
+            baseimage = 'fedora23/python'
+        (flexmock(utils)
+            .should_receive('get_df_parser')
+            .with_args(TEST_GIT_URI, TEST_GIT_REF, git_branch=TEST_GIT_BRANCH)
+            .and_return(MockParser()))
+        flexmock(OSBS, _create_build_config_and_build=request_as_response)
+        req = osbs.create_prod_build(TEST_GIT_URI, TEST_GIT_REF,
+                                     TEST_GIT_BRANCH, TEST_USER,
+                                     TEST_COMPONENT, TEST_TARGET,
+                                     TEST_ARCH)
+        assert req.spec.component.value == TEST_COMPONENT
+
+
+    def test_missing_component_argument_doesnt_break_build(self, osbs):
+        # TODO: test situation when a buildconfig already exists
+        class MockParser(object):
+            labels = {'Name': 'fedora23/something', 'com.redhat.component': TEST_COMPONENT}
+            baseimage = 'fedora23/python'
+        (flexmock(utils)
+            .should_receive('get_df_parser')
+            .with_args(TEST_GIT_URI, TEST_GIT_REF, git_branch=TEST_GIT_BRANCH)
+            .and_return(MockParser()))
+        response = osbs.create_prod_build(TEST_GIT_URI, TEST_GIT_REF,
+                                     TEST_GIT_BRANCH, TEST_USER)
+        assert isinstance(response, BuildResponse)
+
+
+
     def test_create_prod_build_set_required_version(self, osbs106):
         class MockParser(object):
-            labels = {'Name': 'fedora23/something'}
+            labels = {'Name': 'fedora23/something', 'com.redhat.component': TEST_COMPONENT}
             baseimage = 'fedora23/python'
         (flexmock(utils)
             .should_receive('get_df_parser')
@@ -199,7 +261,7 @@ class TestOSBS(object):
     def test_create_prod_with_secret_build(self, osbs):
         # TODO: test situation when a buildconfig already exists
         class MockParser(object):
-            labels = {'Name': 'fedora23/something'}
+            labels = {'Name': 'fedora23/something', 'com.redhat.component': TEST_COMPONENT}
             baseimage = 'fedora23/python'
         (flexmock(utils)
             .should_receive('get_df_parser')
@@ -214,7 +276,7 @@ class TestOSBS(object):
     def test_create_prod_without_koji_build(self, osbs):
         # TODO: test situation when a buildconfig already exists
         class MockParser(object):
-            labels = {'Name': 'fedora23/something'}
+            labels = {'Name': 'fedora23/something', 'com.redhat.component': TEST_COMPONENT}
             baseimage = 'fedora23/python'
         (flexmock(utils)
             .should_receive('get_df_parser')
@@ -429,7 +491,7 @@ build_image = {build_image}
         assert config.get_build_image() == build_image
 
         class MockParser(object):
-            labels = {'Name': 'fedora23/something'}
+            labels = {'Name': 'fedora23/something', 'com.redhat.component': TEST_COMPONENT}
             baseimage = 'fedora23/python'
         (flexmock(utils)
             .should_receive('get_df_parser')
@@ -884,7 +946,7 @@ build_image = {build_image}
         osbs = OSBS(config, config)
 
         class MockParser(object):
-            labels = {'Name': 'fedora23/something'}
+            labels = {'Name': 'fedora23/something', 'com.redhat.component': TEST_COMPONENT}
             baseimage = 'fedora23/python'
 
         kwargs = {

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -140,7 +140,6 @@ class TestOSBS(object):
                                           TEST_COMPONENT, TEST_TARGET, TEST_ARCH)
         assert isinstance(response, BuildResponse)
 
-
     def test_create_prod_build_missing_name_label(self, osbs):
         class MockParser(object):
             labels = {}
@@ -153,7 +152,6 @@ class TestOSBS(object):
             osbs.create_prod_build(TEST_GIT_URI, TEST_GIT_REF,
                                    TEST_GIT_BRANCH, TEST_USER,
                                    TEST_COMPONENT, TEST_TARGET, TEST_ARCH)
-
 
     @pytest.mark.parametrize('label_name', ['BZComponent', 'com.redhat.component', 'Name', 'name'])
     def test_missing_component_and_name_labels(self, osbs, label_name):
@@ -173,7 +171,6 @@ class TestOSBS(object):
             osbs.create_prod_build(TEST_GIT_URI, TEST_GIT_REF,
                                    TEST_GIT_BRANCH, TEST_USER,
                                    TEST_COMPONENT, TEST_TARGET, TEST_ARCH)
-
 
     def test_create_prod_build_missing_args(self, osbs):
         """
@@ -203,7 +200,6 @@ class TestOSBS(object):
                                      component=TEST_COMPONENT,
                                      architecture=TEST_ARCH)
 
-
     @pytest.mark.parametrize('component_label_name', ['com.redhat.component', 'BZComponent'])
     def test_component_is_changed_from_label(self, osbs, component_label_name):
         """
@@ -225,9 +221,7 @@ class TestOSBS(object):
                                      TEST_ARCH)
         assert req.spec.component.value == TEST_COMPONENT
 
-
     def test_missing_component_argument_doesnt_break_build(self, osbs):
-        # TODO: test situation when a buildconfig already exists
         class MockParser(object):
             labels = {'Name': 'fedora23/something', 'com.redhat.component': TEST_COMPONENT}
             baseimage = 'fedora23/python'
@@ -236,10 +230,8 @@ class TestOSBS(object):
             .with_args(TEST_GIT_URI, TEST_GIT_REF, git_branch=TEST_GIT_BRANCH)
             .and_return(MockParser()))
         response = osbs.create_prod_build(TEST_GIT_URI, TEST_GIT_REF,
-                                     TEST_GIT_BRANCH, TEST_USER)
+                                          TEST_GIT_BRANCH, TEST_USER)
         assert isinstance(response, BuildResponse)
-
-
 
     def test_create_prod_build_set_required_version(self, osbs106):
         class MockParser(object):


### PR DESCRIPTION
I want to resolve #476 

-c is optional now, and has no effect whatsoever

instead of it, is used labels 'com.redhat.component' or 'BZComponent' from dockerfile

also made component label in dockerfile mandatory, if no found will raise exception