### PR TITLE
Chain rebuild fixes

### DIFF
--- a/osbs/api.py
+++ b/osbs/api.py
@@ -411,8 +411,6 @@ class OSBS(object):
             pulp_registry=self.os_conf.get_pulp_registry(),
             nfs_server_path=self.os_conf.get_nfs_server_path(),
             nfs_dest_dir=self.build_conf.get_nfs_destination_dir(),
-            git_push_url=self.build_conf.get_git_push_url(),
-            git_push_username=self.build_conf.get_git_push_username(),
             builder_build_json_dir=self.build_conf.get_builder_build_json_store(),
             scratch=self.build_conf.get_scratch(scratch),
             unique_tag_only=self.build_conf.get_unique_tag_only(),

--- a/osbs/build/build_request.py
+++ b/osbs/build/build_request.py
@@ -77,7 +77,6 @@ class BuildRequest(object):
         :param distribution_scope: str, distribution scope for this image
                                    (private, authoritative-source-only, restricted, public)
         :param use_auth: bool, use auth from atomic-reactor?
-        :param git_push_url: str, URL for git push
         """
 
         # Here we cater to the koji "scratch" build type, this will disable
@@ -724,16 +723,8 @@ class BuildRequest(object):
         self.dj.dock_json_set_arg('prebuild_plugins', "pull_base_image", "parent_registry",
                                   source_registry.docker_uri if source_registry else None)
 
-        # The rebuild trigger requires git_branch and git_push_url
-        # parameters, but those parameters are optional. If either was
-        # not provided, remove the trigger.
+        # Set to true to disable triggers in BuildConfig
         remove_triggers = False
-        for param_name in ['git_branch', 'git_push_url']:
-            param = getattr(self.spec, param_name)
-            if not param.value:
-                logger.info("removing triggers as no %s specified", param_name)
-                remove_triggers = True
-                # Continue the loop so we log everything that's missing
 
         if self.is_custom_base_image():
             logger.info('removing triggers for custom base image build')

--- a/osbs/build/spec.py
+++ b/osbs/build/spec.py
@@ -158,8 +158,6 @@ class BuildSpec(object):
     smtp_uri = BuildParam("smtp_uri", allow_none=True)
     nfs_server_path = BuildParam("nfs_server_path", allow_none=True)
     nfs_dest_dir = BuildParam("nfs_dest_dir", allow_none=True)
-    git_push_url = BuildParam("git_push_url", allow_none=True)
-    git_push_username = BuildParam("git_push_username", allow_none=True)
     builder_build_json_dir = BuildParam("builder_build_json_dir", allow_none=True)
     unique_tag_only = BuildParam("unique_tag_only", allow_none=True)
 
@@ -186,8 +184,6 @@ class BuildSpec(object):
             self.pdc_url,
             self.smtp_uri,
             self.nfs_server_path,
-            self.git_push_url,
-            self.git_push_username,
         ]
 
     def set_params(self, git_uri=None, git_ref=None,
@@ -206,7 +202,7 @@ class BuildSpec(object):
                    pulp_secret=None, pulp_registry=None, pdc_secret=None, pdc_url=None,
                    smtp_uri=None, nfs_server_path=None,
                    nfs_dest_dir=None, git_branch=None, base_image=None,
-                   name_label=None, git_push_url=None, git_push_username=None,
+                   name_label=None,
                    builder_build_json_dir=None, registry_api_versions=None,
                    unique_tag_only=None,
                    **kwargs):
@@ -255,8 +251,6 @@ class BuildSpec(object):
         self.smtp_uri.value = smtp_uri
         self.nfs_server_path.value = nfs_server_path
         self.nfs_dest_dir.value = nfs_dest_dir
-        self.git_push_url.value = git_push_url
-        self.git_push_username.value = git_push_username
         self.git_branch.value = git_branch
         self.name.value = make_name_from_git(self.git_uri.value, self.git_branch.value)
         if not base_image:

--- a/osbs/conf.py
+++ b/osbs/conf.py
@@ -321,9 +321,8 @@ class Configuration(object):
         key = "builder_build_json_dir"
         builder_build_json_dir = self._get_value(key, self.conf_section, key)
         if builder_build_json_dir is None:
-            fallback_key = "build_json_dir"
-            logger.warning("%r not found, falling back %r", key, fallback_key)
-            builder_build_json_dir = self._get_value(fallback_key, self.conf_section, fallback_key)
+            logger.warning("%r not found, falling back to build_json_dir", key)
+            builder_build_json_dir = self.get_build_json_store()
         return builder_build_json_dir
 
     def get_pulp_secret(self):

--- a/osbs/conf.py
+++ b/osbs/conf.py
@@ -361,12 +361,6 @@ class Configuration(object):
     def get_storage_limit(self):
         return self._get_value("storage_limit", self.conf_section, "storage_limit")
 
-    def get_git_push_url(self):
-        return self._get_value("git_push_url", self.conf_section, "git_push_url")
-
-    def get_git_push_username(self):
-        return self._get_value("git_push_username", self.conf_section, "git_push_username")
-
     def get_build_image(self):
         return self._get_value("build_image", self.conf_section, "build_image")
 

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -244,3 +244,19 @@ class TestConfiguration(object):
 
                 for fn, value in expected.items():
                     assert getattr(conf, fn)() == value
+
+    @pytest.mark.parametrize(('config', 'expected'), [
+        ({
+            'default': {'builder_build_json_dir': 'builder'},
+            'general': {'build_json_dir': 'general'},
+         }, 'builder'),
+        ({
+            'default': {},
+            'general': {'build_json_dir': 'general'},
+         }, 'general'),
+    ])
+    def test_builder_build_json_dir(self, config, expected):
+        with self.config_file(config) as config_file:
+            conf = Configuration(conf_file=config_file)
+
+            assert conf.get_builder_build_json_store() == expected


### PR DESCRIPTION
Addresses a couple of issues:

1. If `builder_build_json_dir` is not defined, it properly falls back to `build_json_dir` from the `[general]` section. This was causing the `import_image` plugin to be configured with `build_json_dir` param as `None`.

2. Removed check for requiring `git_push_url` and `git_push_username` when using triggers. Also removed all references to those as there's no longer an intention to use them. Verified that if these values are in osbs.conf, they are simply ignored.