### PR TITLE
prod.json: set runPolicy explicitely

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,9 @@ python:
 install:
   - "pip install -r requirements.txt"
   - "pip install -r tests/requirements.txt"
-  - "pip install pytest-cov coveralls"
+# coverage 4.3.2 fails with py 2.6:
+# https://bitbucket.org/ned/coveragepy/issues/555/coverage-432-claims-support-for-py26-but
+  - "pip install coverage==4.3.1 pytest-cov coveralls"
   - "if [[ ${TRAVIS_PYTHON_VERSION%.*} -gt 2 ]]; then pip install -r requirements-py3.txt; fi"
 # command to run tests
 script: py.test -vv tests --cov osbs

--- a/inputs/prod.json
+++ b/inputs/prod.json
@@ -8,6 +8,7 @@
     }
   },
   "spec": {
+    "runPolicy": "Serial",
     "source": {
       "type": "Git",
       "git": {


### PR DESCRIPTION
This should help us to fight https://bugzilla.redhat.com/show_bug.cgi?id=1400132

It seems the builds stuck in New are caused by the following code path:
 * If the BuildConfig has no runPolicy set, Serial policy [will be assigned to it](https://github.com/openshift/origin/blob/master/pkg/build/controller/controller.go#L100)
 * When the build is complete OSE calls [OnComplete](https://github.com/openshift/origin/blob/master/pkg/build/controller/controller.go#L106) handler, which in its turn starts Policy's [handleComplete](https://github.com/openshift/origin/blob/master/pkg/build/controller/policy/policy.go#L130) handler
 * In `handleComplete` OSE tries to find the next build to run by listing all builds and looking for a suitable one.
 * Since this situation is happening for almost each build, OSE spends most of its time listing all builds.

Setting a policy is a stab to stop this sooner - run `handleComplete` after the build is moving to Complete and not in BuildController's `HandleBuild`