### PR TITLE
Fix name of client_version parameter in build JSON

### DIFF
--- a/inputs/prod_inner.json
+++ b/inputs/prod_inner.json
@@ -1,5 +1,5 @@
 {
-  "client-version": "{{VERSION}}",
+  "client_version": "{{VERSION}}",
   "prebuild_plugins": [
     {
       "args": {

--- a/osbs/build/build_request.py
+++ b/osbs/build/build_request.py
@@ -745,7 +745,7 @@ class BuildRequest(object):
                     logger.debug("Invalid custom configuration found for enable_plugins")
 
     def render_version(self):
-        self.dj.dock_json_set_param('client-version', client_version)
+        self.dj.dock_json_set_param('client_version', client_version)
 
     def render(self, validate=True):
         if validate:

--- a/tests/build/test_build_request.py
+++ b/tests/build/test_build_request.py
@@ -1515,8 +1515,8 @@ class TestBuildRequest(object):
     def test_has_version(self):
         br = BuildRequest(INPUTS_PATH)
         br.render()
-        assert 'client-version' in br.dj.dock_json
+        assert 'client_version' in br.dj.dock_json
 
-        actual_version = br.dj.dock_json['client-version']
+        actual_version = br.dj.dock_json['client_version']
         assert isinstance(actual_version, six.string_types)
         assert expected_version == actual_version


### PR DESCRIPTION
The client version should be in snake_case instead of kebab-case. The atomic-reactor object which handles the build JSON will ignore client_version but warn about client-version:
```
unprocessed keyword arguments: {u'client-version': ...}
```