### PR TITLE
Implement reactor_config_secret configuration keyword

### DIFF
--- a/docs/configuration_file.md
+++ b/docs/configuration_file.md
@@ -117,6 +117,8 @@ Some options are also mandatory.
 
 * `storage_limit` (*optional*, `string`) — storage limit to apply to build (for more info, see [documentation for resources](https://github.com/projectatomic/osbs-client/blob/master/docs/resource.md)
 
+* `reactor_config_secret` (*optional*, `string`) — name of Kubernetes secret holding [atomic-reactor configuration file](https://github.com/projectatomic/atomic-reactor/blob/master/docs/config.md)
+
 
 ## Build JSON Templates
 

--- a/inputs/prod_inner.json
+++ b/inputs/prod_inner.json
@@ -2,6 +2,12 @@
   "client_version": "{{VERSION}}",
   "prebuild_plugins": [
     {
+      "name": "reactor_config",
+      "args": {
+        "config_path": "{{CONFIG_PATH}}"
+      }
+    },
+    {
       "args": {
         "label_key": "is_autorebuild",
         "label_value": "true",

--- a/osbs/build/spec.py
+++ b/osbs/build/spec.py
@@ -162,6 +162,7 @@ class BuildSpec(object):
     unique_tag_only = BuildParam("unique_tag_only", allow_none=True)
     platform = BuildParam("platform", allow_none=True)
     release = BuildParam("release", allow_none=True)
+    reactor_config_secret = BuildParam("reactor_config_secret", allow_none=True)
 
     def __init__(self):
         self.required_params = [
@@ -206,6 +207,7 @@ class BuildSpec(object):
                    name_label=None,
                    builder_build_json_dir=None, registry_api_versions=None,
                    unique_tag_only=None, platform=None, release=None,
+                   reactor_config_secret=None,
                    **kwargs):
         self.git_uri.value = git_uri
         self.git_ref.value = git_ref
@@ -291,6 +293,7 @@ class BuildSpec(object):
         self.unique_tag_only.value = unique_tag_only
         self.platform.value = platform
         self.release.value = release
+        self.reactor_config_secret.value = reactor_config_secret
 
     def validate(self):
         logger.info("Validating params of %s", self.__class__.__name__)

--- a/osbs/conf.py
+++ b/osbs/conf.py
@@ -422,3 +422,7 @@ class Configuration(object):
                              token_file, ex)
 
         return value
+
+    def get_reactor_config_secret(self):
+        return self._get_value("reactor_config_secret", self.conf_section,
+                               "reactor_config_secret")


### PR DESCRIPTION
This keyword causes the reactor_config plugin to be run, using the Kubernetes secret whose name is specified by the reactor_config_secret configuration keyword.