### PR TITLE
Aid testing by not wrapping flexmock expectation exceptions

### DIFF
--- a/osbs/api.py
+++ b/osbs/api.py
@@ -41,6 +41,10 @@ def osbsapi(func):
             # Re-raise OsbsExceptions
             raise
         except Exception as ex:
+            # Propogate flexmock errors immediately (used in test cases)
+            if getattr(ex, '__module__', None) == 'flexmock':
+                raise
+
             # Convert anything else to OsbsException
 
             # Python 3 has implicit exception chaining and enhanced

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -7,7 +7,7 @@ of the BSD license. See the LICENSE file for details.
 """
 from types import GeneratorType
 
-from flexmock import flexmock
+from flexmock import flexmock, MethodCallError
 from textwrap import dedent
 import json
 from pkg_resources import parse_version
@@ -20,7 +20,7 @@ import copy
 import datetime
 from tempfile import NamedTemporaryFile
 
-from osbs.api import OSBS
+from osbs.api import OSBS, osbsapi
 from osbs.conf import Configuration
 from osbs.build.build_request import BuildRequest
 from osbs.build.build_response import BuildResponse
@@ -49,6 +49,25 @@ def request_as_response(request):
 
 
 class TestOSBS(object):
+    def test_osbsapi_wrapper(self):
+        """
+        Test that a .never() expectation works inside a .raises()
+        block.
+        """
+
+        (flexmock(utils)
+            .should_receive('get_df_parser')
+            .never())
+
+        @osbsapi
+        def dummy_api_function():
+            """A function that calls something it's not supposed to"""
+            utils.get_df_parser(TEST_GIT_URI, TEST_GIT_REF)
+
+        # Check we get the correct exception
+        with pytest.raises(MethodCallError):
+            dummy_api_function()
+
     @pytest.mark.parametrize('koji_task_id', [None, TEST_KOJI_TASK_ID])
     def test_list_builds_api(self, osbs, koji_task_id):
         kwargs = {}


### PR DESCRIPTION
Usually API methods will wrap any exceptions in OsbsException. However, if the exception is e.g. a MethodCallError, perhaps because a function expected never to be called has been called, this may cause a test to pass and mask a bug.

Don't wrap MethodCallError or other flexmock expectation exceptions.

Signed-off-by: Tim Waugh <twaugh@redhat.com>