### PR TITLE
auth_credentials_provided should be set to true if token is specified

### DIFF
--- a/osbs/core.py
+++ b/osbs/core.py
@@ -84,6 +84,7 @@ class Openshift(object):
 
         self.ca = None
         auth_credentials_provided = bool(use_kerberos or
+                                         token or
                                          (username and password))
         if use_auth is None:
             self.use_auth = auth_credentials_provided


### PR DESCRIPTION
Orchestration builds are running osbs-client inside the same container, where 
atomic-reactor runs, with a custom config. Some cluster, which didn't use 
kerberos could not be contacted, although correct config was provided.

The problem was in `__init__` function - it didn't qualify token as a sufficient 
credential and tried to read a serviceaccount token. This token is valid for 
orchestration cluster only and not for the target cluster.

This PR makes the token a valid authentication credential so that osbs client wouldn't try to read serviceaccount token if there is one in the configuration