### PR TITLE
consolidate unique_tag_only and scratch config

### DIFF
--- a/osbs/api.py
+++ b/osbs/api.py
@@ -483,7 +483,6 @@ class OSBS(object):
             nfs_dest_dir=self.build_conf.get_nfs_destination_dir(),
             builder_build_json_dir=self.build_conf.get_builder_build_json_store(),
             scratch=self.build_conf.get_scratch(scratch),
-            unique_tag_only=self.build_conf.get_unique_tag_only(),
             reactor_config_secret=self.build_conf.get_reactor_config_secret(),
             client_config_secret=self.build_conf.get_client_config_secret(),
             token_secrets=self.build_conf.get_token_secrets(),

--- a/osbs/build/spec.py
+++ b/osbs/build/spec.py
@@ -159,7 +159,6 @@ class BuildSpec(object):
     nfs_server_path = BuildParam("nfs_server_path", allow_none=True)
     nfs_dest_dir = BuildParam("nfs_dest_dir", allow_none=True)
     builder_build_json_dir = BuildParam("builder_build_json_dir", allow_none=True)
-    unique_tag_only = BuildParam("unique_tag_only", allow_none=True)
     platform = BuildParam("platform", allow_none=True)
     platforms = BuildParam("platforms", allow_none=True)
     release = BuildParam("release", allow_none=True)
@@ -210,7 +209,7 @@ class BuildSpec(object):
                    nfs_dest_dir=None, git_branch=None, base_image=None,
                    name_label=None,
                    builder_build_json_dir=None, registry_api_versions=None,
-                   unique_tag_only=None, platform=None, platforms=None, release=None,
+                   platform=None, platforms=None, release=None,
                    reactor_config_secret=None, client_config_secret=None,
                    token_secrets=None, arrangement_version=None,
                    **kwargs):
@@ -295,7 +294,6 @@ class BuildSpec(object):
             timestamp
         )
 
-        self.unique_tag_only.value = unique_tag_only
         self.platform.value = platform
         self.platforms.value = platforms
         self.release.value = release

--- a/osbs/conf.py
+++ b/osbs/conf.py
@@ -373,10 +373,6 @@ class Configuration(object):
         return self._get_value("scratch", self.conf_section, "scratch",
                                default=default_value, is_bool_val=True)
 
-    def get_unique_tag_only(self):
-        return self._get_value("unique_tag_only", self.conf_section, "unique_tag_only",
-                               default=False, is_bool_val=True)
-
     def get_oauth2_token(self):
         # token overrides token_file
         # either in kwargs overrides cli args

--- a/tests/build_/test_build_request.py
+++ b/tests/build_/test_build_request.py
@@ -877,10 +877,18 @@ class TestBuildRequest(object):
                 get_plugin(plugins, "postbuild_plugins", "compress")
 
             with pytest.raises(NoSuchPluginException):
+                get_plugin(plugins, "postbuild_plugins", "tag_from_config")
+
+            with pytest.raises(NoSuchPluginException):
                 get_plugin(plugins, "exit_plugins", "koji_promote")
+
         else:
             assert get_plugin(plugins, "postbuild_plugins", "compress")
+            assert get_plugin(plugins, "postbuild_plugins", "tag_from_config")
             assert get_plugin(plugins, "exit_plugins", "koji_promote")
+
+        assert (get_plugin(plugins, "postbuild_plugins", "tag_by_labels")
+                .get('args', {}).get('unique_tag_only', False) == scratch)
 
     def test_render_with_yum_repourls(self):
         kwargs = {
@@ -1077,41 +1085,6 @@ class TestBuildRequest(object):
                                             'build_kwargs')
             assert build_kwargs['arrangement_version'] == arrangement_version
 
-    @pytest.mark.parametrize('unique_tag_only', [False, None, True])
-    def test_render_unique_tag_only(self, unique_tag_only):
-        kwargs = {
-            'git_uri': TEST_GIT_URI,
-            'git_ref': TEST_GIT_REF,
-            'user': "john-foo",
-            'component': TEST_COMPONENT,
-            'base_image': 'fedora:latest',
-            'name_label': 'fedora/resultingimage',
-            'openshift_uri': "http://openshift/",
-            'registry_api_versions': ['v1', 'v2'],
-        }
-
-        if unique_tag_only is not None:
-            kwargs['unique_tag_only'] = unique_tag_only
-
-        build_request = BuildRequest(INPUTS_PATH)
-        build_request.set_params(**kwargs)
-        build_json = build_request.render()
-        strategy = build_json['spec']['strategy']['customStrategy']['env']
-        plugins = get_plugins_from_build_json(build_json)
-
-        if unique_tag_only:
-            assert plugin_value_get(plugins,
-                                    'postbuild_plugins',
-                                    'tag_by_labels',
-                                    'args',
-                                    'unique_tag_only') == True
-            assert not has_plugin(plugins, 'postbuild_plugins', 'tag_from_config')
-        else:
-            tag_and_push_args = get_plugin(plugins,
-                                           'postbuild_plugins',
-                                           'tag_and_push')['args']
-            assert 'unique_tag_only' not in tag_and_push_args
-            assert has_plugin(plugins, 'postbuild_plugins', 'tag_from_config')
 
     def test_render_prod_with_pulp_no_auth(self):
         """

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -418,30 +418,6 @@ class TestOSBS(object):
 
         assert 'arrangement_version' in ex.value.message
 
-    @pytest.mark.parametrize('unique_tag_only', [True, False, None])
-    def test_create_prod_build_unique_tag_only(self, osbs, unique_tag_only):
-        (flexmock(utils)
-            .should_receive('get_df_parser')
-            .with_args(TEST_GIT_URI, TEST_GIT_REF, git_branch=TEST_GIT_BRANCH)
-            .and_return(MockDfParser()))
-
-        original_create_build_config_and_build = osbs._create_build_config_and_build
-        def check_build_request(build_request):
-            assert build_request.spec.unique_tag_only.value == unique_tag_only
-            return original_create_build_config_and_build(build_request)
-
-        (flexmock(osbs)
-            .should_receive('_create_build_config_and_build')
-            .replace_with(check_build_request)
-            .once())
-        (flexmock(osbs.build_conf)
-            .should_receive('get_unique_tag_only')
-            .and_return(unique_tag_only))
-        response = osbs.create_prod_build(TEST_GIT_URI, TEST_GIT_REF,
-                                          TEST_GIT_BRANCH, TEST_USER,
-                                          TEST_COMPONENT, TEST_TARGET, TEST_ARCH)
-        assert isinstance(response, BuildResponse)
-
     def test_create_prod_build_missing_name_label(self, osbs):
         class MockParser(object):
             labels = {}

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -202,41 +202,6 @@ class TestConfiguration(object):
                 assert conf.get_oauth2_token() == expected
 
     @pytest.mark.parametrize(('config', 'kwargs', 'cli_args', 'expected'), [
-        ({'default': {}},
-         {},
-         {},
-         {'get_unique_tag_only': False}),
-
-        ({'default': {'unique_tag_only': 'true'}},
-         {},
-         {},
-         {'get_unique_tag_only': True}),
-
-        ({'default': {}},
-         {'unique_tag_only': 'true'},
-         {},
-         {'get_unique_tag_only': True}),
-
-        ({'default': {}},
-         {},
-         {'unique_tag_only': 'true'},
-         {'get_unique_tag_only': True}),
-
-        ({'default': {'unique_tag_only': 'false'}},
-         {},
-         {},
-         {'get_unique_tag_only': False}),
-
-        ({'default': {}},
-         {'unique_tag_only': 'false'},
-         {},
-         {'get_unique_tag_only': False}),
-
-        ({'default': {}},
-         {},
-         {'unique_tag_only': 'false'},
-         {'get_unique_tag_only': False}),
-
         ({'default': {'client_config_secret': 'client_secret'}},
          {},
          {},


### PR DESCRIPTION
Removes the config option `unique_tag_only`. Its behavior is now implemented as part of `scratch` option.
In other words, when `scratch=True`, builds will only be tagged with a unique tag.

If `unique_tag_only` is defined in `osbs.conf`, it'll simply be ignored.