### PR TITLE
Bump version number to development release

### DIFF
--- a/osbs-client.spec
+++ b/osbs-client.spec
@@ -24,14 +24,22 @@
 
 %global commit 14012aff94eaff24569b518d2887d74ee94458d6
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
+
 # set to 0 to create a normal release
+%global dev_release 1
+
+%if 0{?dev_release}
+%global postrelease dev
+%global release 0
+%else
 %global postrelease 0
 %global release 1
+%endif
 
 %global osbs_obsolete_vr 0.14-2
 
 Name:           osbs-client
-Version:        0.35
+Version:        0.36
 %if "x%{postrelease}" != "x0"
 Release:        %{release}.%{postrelease}.git.%{shortcommit}%{?dist}
 %else

--- a/osbs/__init__.py
+++ b/osbs/__init__.py
@@ -10,7 +10,7 @@ from __future__ import print_function, absolute_import, unicode_literals
 import logging
 
 
-__version__ = "0.35"
+__version__ = "0.36.dev"
 
 
 def set_logging(name="osbs", level=logging.DEBUG):

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ def _install_requirements():
 setup(
     name="osbs-client",
     description='Python module and command line client for OpenShift Build Service',
-    version="0.35",
+    version="0.36.dev",
     author='Red Hat, Inc.',
     author_email='atomic-devel@projectatomic.io',
     url='https://github.com/projectatomic/osbs-client',

--- a/tests/test_osbs.py
+++ b/tests/test_osbs.py
@@ -23,11 +23,16 @@ def test_if_all_versions_match():
                 raise Exception("Version not found!")
     import osbs
     from osbs import __version__
+    if __version__.endswith('.dev'):
+        version_without_dev = __version__[:-4]
+    else:
+        version_without_dev = __version__
+
     fp = inspect.getfile(osbs)
     project_dir = os.path.dirname(os.path.dirname(fp))
     specfile = os.path.join(project_dir, "osbs-client.spec")
     setup_py = os.path.join(project_dir, "setup.py")
     spec_version = read_version(specfile, r"\nVersion:\s*(.+?)\s*\n")
     setup_py_version = read_version(setup_py, r"version=['\"](.+)['\"]")
-    assert spec_version == __version__
+    assert spec_version == version_without_dev
     assert setup_py_version == __version__


### PR DESCRIPTION
Doing this can avoid dependency problems when installing using pip (when testing, for example).
https://www.python.org/dev/peps/pep-0440/#implicit-development-release-number

The rules for specfiles are that development release indicators go into the release field:
https://fedoraproject.org/wiki/Packaging:Versioning#Prerelease_versions

Next final release should be 0.36.

Signed-off-by: Tim Waugh <twaugh@redhat.com>