### PR TITLE
Configure koji_ssl_certs_dir for bump_release and koji plugins

### DIFF
--- a/osbs/build/build_request.py
+++ b/osbs/build/build_request.py
@@ -974,6 +974,12 @@ class BuildRequest(object):
                           ('prebuild_plugins', 'add_filesystem', 'koji_ssl_certs_dir'):
                           self.spec.koji_certs_secret.value,
 
+                          ('prebuild_plugins', 'bump_release', 'koji_ssl_certs_dir'):
+                          self.spec.koji_certs_secret.value,
+
+                          ('prebuild_plugins', 'koji', 'koji_ssl_certs_dir'):
+                          self.spec.koji_certs_secret.value,
+
                           ('exit_plugins', 'sendmail', 'koji_ssl_certs_dir'):
                           self.spec.koji_certs_secret.value,
 


### PR DESCRIPTION
Related: https://github.com/projectatomic/atomic-reactor/pull/676

Signed-off-by: Vadim Rutkovsky <vrutkovs@redhat.com>