### PR TITLE
Make scratch build names unique

### DIFF
--- a/osbs/api.py
+++ b/osbs/api.py
@@ -14,7 +14,6 @@ import os.path
 import stat
 import sys
 import warnings
-import datetime
 import getpass
 from functools import wraps
 
@@ -305,7 +304,10 @@ class OSBS(object):
             builder_img['kind'] = 'DockerImage'
             builder_img['name'] = ref
 
-        build_config_name = 'scratch-%s' % datetime.datetime.now().strftime('%Y%m%d%H%M%S')
+        output_image_name = build_json['spec']['output']['to']['name']
+        # Reuse random string and timestamp values.
+        build_config_name = 'scratch-%s-%s' % tuple(
+            output_image_name.rsplit('-', 2)[-2:])
         logger.debug('starting scratch build %s', build_config_name)
         build_json['metadata']['name'] = build_config_name
         return BuildResponse(self.os.create_build(build_json).json())

--- a/osbs/api.py
+++ b/osbs/api.py
@@ -288,8 +288,6 @@ class OSBS(object):
         logger.debug(build_request)
         build_json = build_request.render()
         build_json['kind'] = 'Build'
-        if 'spec' not in build_json.keys():
-            build_json['spec'] = {}
         build_json['spec']['serviceAccount'] = 'builder'
         build_json['metadata']['labels']['scratch'] = 'true'
 

--- a/osbs/build/spec.py
+++ b/osbs/build/spec.py
@@ -8,14 +8,14 @@ of the BSD license. See the LICENSE file for details.
 from __future__ import print_function, absolute_import, unicode_literals
 
 import logging
-import datetime
 import os
 import re
-from osbs.constants import DEFAULT_GIT_REF, DEFAULT_BUILD_IMAGE
+import random
+from osbs.constants import DEFAULT_GIT_REF, DEFAULT_BUILD_IMAGE, RAND_DIGITS
 from osbs.exceptions import OsbsValidationException
 from osbs.utils import (get_imagestreamtag_from_image,
                         make_name_from_git,
-                        RegistryURI)
+                        RegistryURI, utcnow)
 
 logger = logging.getLogger(__name__)
 
@@ -297,11 +297,12 @@ class BuildSpec(object):
             self.imagestream_insecure_registry.value = insecure
             logger.debug("setting 'imagestream_insecure_registry' to %r", insecure)
 
-        timestamp = datetime.datetime.now().strftime('%Y%m%d%H%M%S')
-        self.image_tag.value = "%s/%s:%s-%s" % (
+        timestamp = utcnow().strftime('%Y%m%d%H%M%S')
+        self.image_tag.value = "%s/%s:%s-%s-%s" % (
             self.user.value,
             self.component.value,
             self.koji_target.value or 'none',
+            random.randrange(10**(RAND_DIGITS - 1), 10**RAND_DIGITS),
             timestamp
         )
 

--- a/osbs/constants.py
+++ b/osbs/constants.py
@@ -64,3 +64,6 @@ BACKUP_RESOURCES = ('buildconfigs', 'imagestreams', 'builds',)
 
 CLI_LIST_BUILDS_DEFAULT_COLS = ["name", "status", "image"]
 CLI_WATCH_BUILDS_DEFAULT_COLS = ["changetype", "status", "created", "name"]
+
+# number of digits used for unique image tags
+RAND_DIGITS = 5

--- a/osbs/utils.py
+++ b/osbs/utils.py
@@ -289,6 +289,14 @@ def get_time_from_rfc3339(rfc3339):
         return timegm(time_tuple)
 
 
+def utcnow():
+    """
+    Return current time in UTC.
+
+    This function is created to make mocking in unit tests easier.
+    """
+    return datetime.utcnow()
+
 
 VALID_BUILD_CONFIG_NAME_CHARS = re.compile('[-a-z0-9]')
 

--- a/tests/build_/test_build_request.py
+++ b/tests/build_/test_build_request.py
@@ -205,7 +205,7 @@ class TestBuildRequest(object):
         assert build_json["spec"]["source"]["git"]["uri"] == TEST_GIT_URI
         assert build_json["spec"]["source"]["git"]["ref"] == TEST_GIT_REF
 
-        expected_output = "john-foo/component:none-20"
+        expected_output = "john-foo/component:none-"
         if registry_uris:
             expected_output = registry_uris[0] + "/" + expected_output
         assert build_json["spec"]["output"]["to"]["name"].startswith(expected_output)


### PR DESCRIPTION
As of now two scratch builds could have the same name,
due to the fact that build names were generated using a timestamp.

This changes is adding a random 5 digit number to the build names,
which should ensure uniqueness of the build names.