### PR TITLE
Remove unused --git-push-url cli argument

### DIFF
--- a/osbs/cli/main.py
+++ b/osbs/cli/main.py
@@ -658,10 +658,6 @@ def cli():
                               help="directory with build jsons")
     build_parser.add_argument("-g", "--git-url", action='store', metavar="URL",
                               required=True, help="URL to git repo (fetch)")
-    build_parser.add_argument("--git-push-url", action='store', metavar="URL",
-                              required=False, help="URL to git repo (push)")
-    build_parser.add_argument("--git-push-username", action='store',
-                              required=False, help="username for git push")
     build_parser.add_argument("--git-commit", action='store', default="master",
                               help="checkout this commit")
     build_parser.add_argument("-b", "--git-branch", action='store', required=True,


### PR DESCRIPTION
There are no users of this argument, just remove it.

resolves #460

Signed-off-by: Don Zickus <dzickus@redhat.com>