### PR TITLE
Make sure BuildRequest has low_priority_node_selector set

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
   - "3.5"
 # command to install dependencies
 install:
+  - "pip install -U pip"
   - "pip install -r requirements.txt"
   - "pip install -r tests/requirements.txt"
   - "pip install pytest-cov coveralls"

--- a/osbs/build/build_request.py
+++ b/osbs/build/build_request.py
@@ -85,6 +85,7 @@ class BuildRequest(object):
         :param distribution_scope: str, distribution scope for this image
                                    (private, authoritative-source-only, restricted, public)
         :param use_auth: bool, use auth from atomic-reactor?
+        :param low_priority_node_selector: dict, a nodeselector for builds with lower priority
         """
 
         # Here we cater to the koji "scratch" build type, this will disable
@@ -95,6 +96,7 @@ class BuildRequest(object):
             pass
 
         self.base_image = kwargs.get('base_image')
+        self.low_priority_node_selector = kwargs.get('low_priority_node_selector')
 
         logger.debug("setting params '%s' for %s", kwargs, self.spec)
         self.spec.set_params(**kwargs)
@@ -420,7 +422,6 @@ class BuildRequest(object):
         """
         Enable/disable plugins depending on supported registry API versions
         """
-
         versions = self.spec.registry_api_versions.value
 
         try:


### PR DESCRIPTION
Related: #556

Since the whole class is flexmocked in tests this has slipped: the class instance 
should store the received low_priority_node_selector

Signed-off-by: Vadim Rutkovsky <vrutkovs@redhat.com>