### PR TITLE
support old setuptools on el7

### DIFF
--- a/osbs/build/build_request.py
+++ b/osbs/build/build_request.py
@@ -26,7 +26,7 @@ from osbs.build.manipulate import DockJsonManipulator
 from osbs.build.spec import BuildSpec
 from osbs.constants import SECRETS_PATH, DEFAULT_OUTER_TEMPLATE, DEFAULT_INNER_TEMPLATE, DEFAULT_CUSTOMIZE_CONF
 from osbs.exceptions import OsbsException, OsbsValidationException
-from osbs.utils import looks_like_git_hash, git_repo_humanish_part_from_uri
+from osbs.utils import looks_like_git_hash, git_repo_humanish_part_from_uri, sanitize_version
 from osbs import __version__ as client_version
 
 
@@ -217,7 +217,7 @@ class BuildRequest(object):
             'info_url_format': self.spec.info_url_format.value,
             'koji_hub': self.spec.kojihub.value,
             'koji_root': self.spec.kojiroot.value,
-            'openshift_required_version': self._openshift_required_version,
+            'openshift_required_version': sanitize_version(self._openshift_required_version),
             'pulp_registry_name': self.spec.pulp_registry.value,
             'registry_api_versions': ','.join(self.spec.registry_api_versions.value or []) or None,
             'smtp_additional_addresses': ','.join(self.spec.smtp_additional_addresses.value or []) or None,

--- a/osbs/build/build_request.py
+++ b/osbs/build/build_request.py
@@ -549,6 +549,9 @@ class BuildRequest(object):
             if self.spec.yum_repourls.value:
                 self.dj.dock_json_set_arg(phase, plugin, 'repos',
                                           self.spec.yum_repourls.value)
+            if self.spec.platforms.value:
+                self.dj.dock_json_set_arg(phase, plugin, 'architectures',
+                                          self.spec.platforms.value)
 
     def render_add_labels_in_dockerfile(self):
         phase = 'prebuild_plugins'

--- a/osbs/utils.py
+++ b/osbs/utils.py
@@ -385,6 +385,31 @@ def run_command(*popenargs, **kwargs):
     return output
 
 
+def sanitize_version(version):
+    """
+    Take parse_version() output and standardize output from older
+    setuptools' parse_version() to match current setuptools.
+    """
+    if hasattr(version, 'base_version'):
+        if version.base_version:
+            parts = version.base_version.split('.')
+        else:
+            parts = []
+    else:
+            parts = []
+            for part in version:
+                if part.startswith('*'):
+                    break
+                parts.append(part)
+    parts = [int(p) for p in parts]
+
+    if len(parts) < 3:
+        parts += [0] * (3 - len(parts))
+
+    major, minor, micro = parts[:3]
+    cleaned_version = '{0}.{1}.{2}'.format(major, minor, micro)
+    return cleaned_version
+
 class Labels(object):
     """
     Provide access to a set of labels which have specific semantics

--- a/tests/build_/test_build_request.py
+++ b/tests/build_/test_build_request.py
@@ -24,7 +24,6 @@ from osbs.conf import Configuration
 
 from flexmock import flexmock
 import pytest
-from pkg_resources import parse_version
 
 from tests.constants import (INPUTS_PATH, TEST_BUILD_CONFIG, TEST_BUILD_JSON,
                              TEST_COMPONENT, TEST_GIT_BRANCH, TEST_GIT_REF,
@@ -1189,7 +1188,7 @@ class TestBuildRequest(object):
                 build_request.set_params(**kwargs)
             return
         if openshift_req_version:
-            build_request.set_openshift_required_version(openshift_req_version)
+            build_request.set_openshift_required_version(parse_version(openshift_req_version))
         build_json = build_request.render()
         strategy = build_json['spec']['strategy']['customStrategy']['env']
         plugins = get_plugins_from_build_json(build_json)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,13 +13,14 @@ import datetime
 import re
 import sys
 from time import tzset
+from pkg_resources import parse_version
 
 from osbs.utils import (buildconfig_update,
                         get_imagestreamtag_from_image,
                         git_repo_humanish_part_from_uri,
                         get_time_from_rfc3339, strip_registry_from_image,
                         TarWriter, TarReader, make_name_from_git,
-                        get_instance_token_file_name, Labels)
+                        get_instance_token_file_name, Labels, sanitize_version)
 from osbs.exceptions import OsbsException
 import osbs.kerberos_ccache
 
@@ -332,3 +333,33 @@ def test_labels(labels, fnc, expect):
             assert getattr(label, fn)(arg) == expect
         else:
             assert getattr(label, fn)() == expect
+
+
+vstr_re = re.compile('\d+\.\d+\.\d+')
+@pytest.mark.parametrize(('version', 'valid'), [
+    ('1.0.4', True),
+    ('5.3', True),
+    ('2', True),
+    ('7.3.1', True),
+    ('9', True),
+    ('6.8', True),
+    ('10.127.43', True),
+    ('bacon', False),
+    ('5x3yj', False),
+    ('x.y.z', False),
+])
+def test_sanitize_version(version, valid):
+    if valid:
+        assert vstr_re.match(sanitize_version(parse_version(version)))
+    else:
+        # with old-style parse_version(), we'll get a numerical string
+        # back from sanitize_version(), but current parse_version() will
+        # give us a ValueError exception
+        try:
+            val = sanitize_version(parse_version(version))
+            if val != version:
+                return
+        except:
+            pass
+        with pytest.raises(ValueError):
+            sanitize_version(parse_version(version))


### PR DESCRIPTION
The ancient setuptools in el7 behaves differently from more recent
setuptools, which results in unit test failures when running on an el7
host.

A quick illustration of the differences:

  # Python 2.7.13 (fedora)
  >>> from pkg_resources import parse_version
  >>> parse_version('1.0.1')
  <Version('1.0.1')>
  >>> str(parse_version('1.0.1'))
  '1.0.1'

  # Python 2.7.5 (rhel 7)
  >>> from pkg_resources import parse_version
  >>> parse_version('1.0.1')
  ('00000001', '00000000', '00000001', '*final')
  >>> str(parse_version('1.0.1'))
  "('00000001', '00000000', '00000001', '*final')"

With this change, all 12 test failures I was previously encountering are
now passing. The key to this change is standardizing the old setuptools
output to look just like current setuptools output, using a new function
sanitize_version() in osbs/util.py, rather than calling parse_version()
directly.

A special nod to
http://www.programcreek.com/python/example/7930/pkg_resources.parse_version
for Example 4, which provides the basis for this work-around.

Resolves: #564

Signed-off-by: Jarod Wilson <jarod@redhat.com>