### PR TITLE
core: trap ChunkedEncodingError along with of httplib.IncompleteRead, as python-requests throws two exceptions for different cases

### DIFF
--- a/osbs/core.py
+++ b/osbs/core.py
@@ -24,6 +24,7 @@ from osbs.exceptions import (OsbsResponseException, OsbsException,
                              OsbsWatchBuildNotFound, OsbsAuthException)
 from osbs.http import decoded_json
 from osbs.utils import graceful_chain_get
+from requests.exceptions import ChunkedEncodingError
 
 try:
     # py2
@@ -436,7 +437,7 @@ class Openshift(object):
                 for line in decoded_json(response.iter_lines()):
                     last_activity = time.time()
                     yield line
-            except httplib.IncompleteRead:
+            except (ChunkedEncodingError, httplib.IncompleteRead):
                 pass
 
             idle = time.time() - last_activity

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -80,8 +80,7 @@ class TestOpenshift(object):
         labels = openshift.set_labels_on_build(TEST_BUILD, {TEST_LABEL: TEST_LABEL_VALUE})
         assert labels.json() is not None
 
-
-    def test_stream_logs_no_data(self, openshift):  #noqa
+    def test_stream_logs_no_data(self, openshift):  # noqa
         response = flexmock(status_code=httplib.OK)
         (response
             .should_receive('iter_lines')


### PR DESCRIPTION
Signed-off-by: Vadim Rutkovsky <vrutkovs@redhat.com>