### PR TITLE
core: trap ConnectionError and handle it like ChunkedEncodingError

### DIFF
--- a/osbs/core.py
+++ b/osbs/core.py
@@ -24,7 +24,7 @@ from osbs.exceptions import (OsbsResponseException, OsbsException,
                              OsbsWatchBuildNotFound, OsbsAuthException)
 from osbs.http import decoded_json
 from osbs.utils import graceful_chain_get
-from requests.exceptions import ChunkedEncodingError
+from requests.exceptions import ChunkedEncodingError, ConnectionError
 
 try:
     # py2
@@ -437,7 +437,9 @@ class Openshift(object):
                 for line in decoded_json(response.iter_lines()):
                     last_activity = time.time()
                     yield line
-            except (ChunkedEncodingError, httplib.IncompleteRead):
+            except (ChunkedEncodingError,
+                    ConnectionError,
+                    httplib.IncompleteRead):
                 pass
 
             idle = time.time() - last_activity

--- a/osbs/http.py
+++ b/osbs/http.py
@@ -45,7 +45,9 @@ def decoded_json(iterable):
                 yield line
             else:
                 yield line.decode(requests.utils.guess_json_utf(line))
-    except (requests.exceptions.ChunkedEncodingError, httplib.IncompleteRead):
+    except (requests.exceptions.ChunkedEncodingError,
+            requests.exceptions.ConnectionError,
+            httplib.IncompleteRead):
         raise StopIteration
 
 
@@ -165,7 +167,9 @@ class HttpStream(object):
             kwargs['chunk_size'] = 1
         try:
             return self.req.iter_lines(**kwargs)
-        except (requests.exceptions.ChunkedEncodingError, httplib.IncompleteRead):
+        except (requests.exceptions.ChunkedEncodingError,
+                requests.exceptions.ConnectionError,
+                httplib.IncompleteRead):
             return []
 
     def close(self):


### PR DESCRIPTION
This is to handle BadStatusLine-caused ConnectionErrors.

Signed-off-by: Tim Waugh <twaugh@redhat.com>