### PR TITLE
Handle ConnectionError via OsbsException

### DIFF
--- a/osbs/core.py
+++ b/osbs/core.py
@@ -443,10 +443,10 @@ class Openshift(object):
             # OsbsNetworkException or OsbsException
             # NOTE2: If decode_json or iter_lines causes ChunkedEncodingError, ConnectionError,
             # or IncompleteRead to be raised, it'll simply be silenced.
-            # NOTE3: An error may occur in iter_lines during initial contact
-            # with server - prior to streaming data. In this case, exception will be
-            # wrapped in OsbsException or OsbsNetworkException, inspect cause
-            # to detect ConnectionError.
+            # NOTE3: An exception may be raised from
+            # check_response(). In this case, exception will be
+            # wrapped in OsbsException or OsbsNetworkException,
+            # inspect cause to detect ConnectionError.
             except OsbsException as exc:
                 if not isinstance(exc.cause, ConnectionError):
                     raise

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -10,8 +10,14 @@ import sys
 
 from flexmock import flexmock
 import pytest
-import httplib
 import requests
+
+try:
+    # py2
+    import httplib
+except ImportError:
+    # py3
+    import http.client as httplib
 
 import osbs.http as osbs_http
 from osbs.http import HttpSession, HttpStream


### PR DESCRIPTION
The unit tests in `test_core.py` don't leverage the class HttpSession in http.py.
Instead they use the `Connection` class from fake_api.py.
Added additional tests in test_http.py to properly simulate behavior.

The except block in HttpStream.iter_lines didn't seem very useful.
When self.req.iter_lines is called, it returns a generator.
This wouldn't raise CheckedEncodingError, ConnectionError, nor IncompleteRead.
Those error cases are only valid when actually iterating through the generator, not during its creation.
The method decoded_json seemed to handle this properly. 
However, given that decoded_json is always used with iter_lines, I moved the correct error handling out of decoded_json and into iter_lines.

The errors we were seeing is because by the time the exception propagates to Openshift class in core.py, it's been wrapped in either OsbsException or OsbsNetworkException. We should catch those exceptions instead and inspect its cause for `ConnectionError`.

I built a simple hello world image to perform basic sanity checks, but further integration tests should be performed.
