### PR TITLE
get node_selector.platform values from conf

### DIFF
--- a/osbs/api.py
+++ b/osbs/api.py
@@ -505,7 +505,8 @@ class OSBS(object):
             info_url_format=self.build_conf.get_info_url_format(),
             artifacts_allowed_domains=self.build_conf.get_artifacts_allowed_domains(),
             low_priority_node_selector=self.build_conf.get_low_priority_node_selector(),
-            equal_labels=self.build_conf.get_equal_labels()
+            equal_labels=self.build_conf.get_equal_labels(),
+            platform_node_selector=self.build_conf.get_platform_node_selector(platform)
         )
         build_request.set_openshift_required_version(self.os_conf.get_openshift_required_version())
         if build_request.scratch:

--- a/osbs/conf.py
+++ b/osbs/conf.py
@@ -532,3 +532,19 @@ class Configuration(object):
                 raise OsbsValidationException("Wrong equal_labels configuration")
 
         return equal_labels
+
+    def get_platform_node_selector(self, platform):
+        """
+        search the configuration for entries of the form node_selector.platform
+        :return None or str
+
+        :param platform: str, platform to search for, can be null
+        """
+        nodeselector = None
+        if platform:
+            nodeselector_str = self._get_value("node_selector." + platform, self.conf_section,
+                                               "node_selector." + platform)
+            if nodeselector_str:
+                nodeselector = nodeselector_str
+
+        return nodeselector

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -399,3 +399,34 @@ class TestConfiguration(object):
                     conf.get_equal_labels()
             else:
                 assert conf.get_equal_labels() == expected
+
+    @pytest.mark.parametrize(('platform', 'config', 'kwargs', 'expected'), [
+        ('',
+         {},
+         {},
+         None),
+        ('',
+         {'default': {'node_selector.dinner': 'steak.com'}},
+         {},
+         None),
+        ('',
+         {'default': {}},
+         {'node_selector.dinner': 'steak.com'},
+         None),
+        ('breakfast',
+         {'default': {'node_selector.breakfast': 'eggs.com', 'node_selector.dinner': 'steak.com'}},
+         {},
+         'eggs.com'),
+        ('breakfast',
+         {'default': {}},
+         {'node_selector.breakfast': 'eggs.com', 'node_selector.dinner': 'steak.com'},
+         'eggs.com'),
+        ('breakfast',
+         {'default': {'node_selector.breakfast': 'bacon.com'}},
+         {'node_selector.breakfast': 'eggs.com', 'node_selector.dinner': 'steak.com'},
+         'eggs.com'),
+    ])
+    def test_get_node_selector_platform(self, platform, kwargs, config, expected):
+        with self.config_file(config) as config_file:
+            conf = Configuration(conf_file=config_file, **kwargs)
+            assert conf.get_platform_node_selector(platform) == expected


### PR DESCRIPTION
Fixes #578

if platform exists at the time of build_request.set_params, read the
conf file for a variable node_selector.platform and return its value.

Signed-off-by: Mark Langsdorf <mlangsdo@redhat.com>