### PR TITLE
build_request: Set 'release' label when provided

### DIFF
--- a/inputs/orchestrator_inner:1.json
+++ b/inputs/orchestrator_inner:1.json
@@ -9,6 +9,12 @@
       }
     },
     {
+      "name": "add_labels_in_dockerfile",
+      "args": {
+        "labels": "{{IMPLICIT_LABELS}}"
+      }
+    },
+    {
       "name": "bump_release",
       "args": {
         "hub": "{{KOJI_HUB}}"

--- a/inputs/worker_inner:1.json
+++ b/inputs/worker_inner:1.json
@@ -16,12 +16,6 @@
       }
     },
     {
-      "name": "bump_release",
-      "args": {
-        "hub": "{{KOJI_HUB}}"
-      }
-    },
-    {
       "name": "add_labels_in_dockerfile",
       "args": {
         "labels": "{{IMPLICIT_LABELS}}"

--- a/osbs/build/build_request.py
+++ b/osbs/build/build_request.py
@@ -562,6 +562,7 @@ class BuildRequest(object):
             'vendor': self.spec.vendor,
             'authoritative-source-url': self.spec.authoritative_registry,
             'distribution-scope': self.spec.distribution_scope,
+            'release': self.spec.release,
         }
 
         for label, spec in label_spec.items():
@@ -614,6 +615,12 @@ class BuildRequest(object):
         phase = 'prebuild_plugins'
         plugin = 'bump_release'
         if not self.dj.dock_json_has_plugin_conf(phase, plugin):
+            return
+
+        if self.spec.release.value:
+            logger.info('removing %s from request as release already specified',
+                        plugin)
+            self.dj.remove_plugin(phase, plugin)
             return
 
         hub = self.spec.kojihub.value


### PR DESCRIPTION
[Looking for early feedback]

Currently if the spec provides a 'release' param, it is not passed along
to the orchestrator as a label.  Detect that and provide it.  Also remove
the bump_release plugin if the 'release' param is passed in.

Updated tests to verify change.

Signed-off-by: Don Zickus <dzickus@redhat.com>