### PR TITLE
no longer attempt to decoded streamed build logs

### DIFF
--- a/osbs-client.spec
+++ b/osbs-client.spec
@@ -104,6 +104,7 @@ Requires:       python-dockerfile-parse
 Requires:       python-requests
 Requires:       python-requests-kerberos
 Requires:       python-setuptools
+Requires:       python-six
 Requires:       krb5-workstation
 %if 0%{?rhel} && 0%{?rhel} <= 6
 Requires:       python-argparse
@@ -128,6 +129,7 @@ Requires:       python3-requests
 Requires:       python3-requests-kerberos
 Requires:       python3-dateutil
 Requires:       python3-setuptools
+Requires:       python3-six
 Requires:       krb5-workstation
 
 Provides:       python3-osbs = %{version}-%{release}

--- a/osbs/cli/capture.py
+++ b/osbs/cli/capture.py
@@ -10,6 +10,7 @@ from __future__ import print_function, absolute_import, unicode_literals
 import json
 import os
 import logging
+from requests.utils import guess_json_utf
 
 
 logger = logging.getLogger(__name__)
@@ -26,12 +27,18 @@ class IterLinesSaver(object):
         self.line = 0
 
     def iter_lines(self):
+        encoding = None
         for line in self.fn():
             path = "{f}-{n:0>3}.json".format(f=self.path, n=self.line)
             logger.debug("capturing to %s", path)
+
+            if not encoding:
+                encoding = guess_json_utf(line)
+
             with open(path, "w") as outf:
                 try:
-                    json.dump(json.loads(line), outf, sort_keys=True, indent=4)
+                    json.dump(json.loads(line.decode(encoding)), outf,
+                              sort_keys=True, indent=4)
                 except ValueError:
                     outf.write(line)
 

--- a/osbs/exceptions.py
+++ b/osbs/exceptions.py
@@ -11,6 +11,8 @@ Exceptions raised by OSBS
 from __future__ import print_function, absolute_import, unicode_literals
 
 import json
+from requests.utils import guess_json_utf
+import six
 from traceback import format_tb
 
 
@@ -49,6 +51,10 @@ class OsbsResponseException(OsbsException):
 
         # try decoding openshift Status object
         # https://docs.openshift.org/latest/rest_api/openshift_v1.html#v1-status
+        if isinstance(message, six.binary_type):
+            encoding = guess_json_utf(message)
+            message = message.decode(encoding)
+
         try:
             self.json = json.loads(message)
         except ValueError:

--- a/osbs/http.py
+++ b/osbs/http.py
@@ -143,7 +143,13 @@ class HttpStream(object):
 
     def iter_lines(self):
         kwargs = {
-            'decode_unicode': True
+            # OpenShift does not respond with any encoding value.
+            # This causes requests module to guess it as ISO-8859-1.
+            # Likely, the encoding is actually UTF-8, but we can't
+            # guarantee it. Therefore, we take the approach of simply
+            # passing through the encoded data with no effort to
+            # attempt decoding it.
+            'decode_unicode': False
         }
         if requests.__version__.startswith('2.6.'):
             kwargs['chunk_size'] = 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 dockerfile-parse
 requests
 requests-kerberos
+six

--- a/tests/fake_api.py
+++ b/tests/fake_api.py
@@ -45,7 +45,7 @@ class StreamingResponse(object):
         self.headers = headers or {}
 
     def iter_lines(self):
-        yield self.content.decode("utf-8")
+        yield self.content
 
     def __enter__(self):
         return self

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,3 @@
 flexmock
 pytest
 pytest-capturelog
-six

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -831,14 +831,16 @@ class TestOSBS(object):
     # osbs is a fixture here
     def test_build_logs_api(self, osbs):  # noqa
         logs = osbs.get_build_logs(TEST_BUILD)
-        assert isinstance(logs, six.string_types)
+        assert isinstance(logs, six.text_type)  # Note! Inconsistent
         assert logs == "line 1"
 
     # osbs is a fixture here
     def test_build_logs_api_follow(self, osbs):  # noqa
         logs = osbs.get_build_logs(TEST_BUILD, follow=True)
         assert isinstance(logs, GeneratorType)
-        assert next(logs) == "line 1"
+        content = next(logs)
+        assert isinstance(content, six.binary_type)
+        assert content == b"line 1"
         with pytest.raises(StopIteration):
             assert next(logs)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -47,14 +47,14 @@ class Response(object):
 
 
 class TestCheckResponse(object):
-    @pytest.mark.parametrize('content', [None, 'OK'])
+    @pytest.mark.parametrize('content', [None, b'OK'])
     @pytest.mark.parametrize('status_code', [httplib.OK, httplib.CREATED])
     def test_check_response_ok(self, status_code, content):
         response = Response(status_code, content=content)
         check_response(response)
 
     def test_check_response_bad_stream(self, caplog):
-        iterable = ['iter', 'lines']
+        iterable = [b'iter', b'lines']
         status_code = httplib.CONFLICT
         response = Response(status_code, iterable=iterable)
         with pytest.raises(OsbsResponseException):
@@ -63,11 +63,11 @@ class TestCheckResponse(object):
         logged = [l.getMessage() for l in caplog.records()]
         assert len(logged) == 1
         assert logged[0] == '[{code}] {message}'.format(code=status_code,
-                                                        message='iterlines')
+                                                        message=b'iterlines')
 
     def test_check_response_bad_nostream(self, caplog):
         status_code = httplib.CONFLICT
-        content = 'content'
+        content = b'content'
         response = Response(status_code, content=content)
         with pytest.raises(OsbsResponseException):
             check_response(response)
@@ -90,7 +90,7 @@ class TestOpenshift(object):
         response = flexmock(status_code=httplib.OK)
         (response
             .should_receive('iter_lines')
-            .and_return(["{'stream': 'foo\n'}"])
+            .and_return([b"{'stream': 'foo\n'}"])
             .and_raise(StopIteration))
 
         wrapped_exc = OsbsNetworkException('http://spam.com', str(exc), status_code=None,
@@ -114,7 +114,7 @@ class TestOpenshift(object):
         response = flexmock(status_code=httplib.OK)
         (response
             .should_receive('iter_lines')
-            .and_return(["{'stream': 'Uňícode íš hářd\n'}"])
+            .and_return([u"{'stream': 'Uňícode íš hářd\n'}".encode('utf-8')])
             .and_raise(StopIteration))
 
         (flexmock(openshift)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8,9 +8,11 @@ of the BSD license. See the LICENSE file for details.
 """
 from flexmock import flexmock
 from textwrap import dedent
+import requests
 import six
 import time
 import json
+import logging
 
 from osbs.http import HttpResponse
 from osbs.constants import (BUILD_FINISHED_STATES,
@@ -121,6 +123,29 @@ class TestOpenshift(object):
 
         logs = openshift.stream_logs(TEST_BUILD)
         assert len([log for log in logs]) == 1
+
+    def test_stream_logs_not_decoded(self, caplog):
+        server = Openshift('/oapi/v1/', 'v1', '/oauth/authorize', k8s_api_url='/api/v1/')
+
+        logs = (
+            u'Lógs'.encode('utf-8'),
+            u'Lðgs'.encode('utf-8'),
+        )
+
+        fake_response = flexmock(status_code=httplib.OK, headers={})
+
+        (fake_response
+            .should_receive('iter_lines')
+            .and_yield(*logs)
+            .with_args(decode_unicode=False))
+
+        (flexmock(requests)
+            .should_receive('request')
+            .and_return(fake_response))
+
+        with caplog.atLevel(logging.ERROR):
+            for result in server.stream_logs('anything'):
+                assert isinstance(result, six.binary_type)
 
     def test_list_builds(self, openshift):
         list_builds = openshift.list_builds()


### PR DESCRIPTION
OpenShift does not respond with any encoding value.
This causes requests module to guess it as ISO-8859-1.
Likely, the enconding is actually UTF-8, but we can't
guarantee it. Therefore, we take the approach of simply
passing through the encoded data with no effort to
attempt decoding it.

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>