### PR TITLE
inputs: Add 'add_labels_in_dockerfile' to orchestrator_inner:1.json

### DIFF
--- a/inputs/orchestrator_inner:1.json
+++ b/inputs/orchestrator_inner:1.json
@@ -9,6 +9,12 @@
       }
     },
     {
+      "name": "add_labels_in_dockerfile",
+      "args": {
+        "labels": "{{IMPLICIT_LABELS}}"
+      }
+    },
+    {
       "name": "bump_release",
       "args": {
         "hub": "{{KOJI_HUB}}"


### PR DESCRIPTION
Allow ability to set 'release' number outside of a Dockerfile or a bump_verion()
plugin.  This sets the add_labels_in_dockerfile plugin to be executed by the
orchestrator to set a 'release' label in the Dockerfile passed to the worker.

Untested.  Relying on integration tests to verify this.

Signed-off-by: Don Zickus <dzickus@redhat.com>