### PR TITLE
janitorial: clean up whitespace and other linter errors

### DIFF
--- a/osbs/__init__.py
+++ b/osbs/__init__.py
@@ -9,7 +9,7 @@ from __future__ import print_function, absolute_import, unicode_literals
 
 import logging
 
-from osbs.version import __version__
+from osbs.version import __version__  # noqa
 
 
 def set_logging(name="osbs", level=logging.DEBUG):

--- a/osbs/api.py
+++ b/osbs/api.py
@@ -43,7 +43,8 @@ def osbsapi(func):
     def catch_exceptions(*args, **kwargs):
         # XXX: remove this in the future
         if kwargs.pop("namespace", None):
-            warnings.warn("OSBS.%s: the 'namespace' argument is no longer supported" % func.__name__)
+            warnings.warn("OSBS.%s: the 'namespace' argument is no longer supported" %
+                          func.__name__)
         try:
             return func(*args, **kwargs)
         except OsbsException:
@@ -227,9 +228,7 @@ class OSBS(object):
             new_label_value = new_labels.get(key)
             existing_label_value = existing_labels.get(key)
 
-            if (existing_label_value and
-                existing_label_value != new_label_value):
-
+            if (existing_label_value and existing_label_value != new_label_value):
                 msg = (
                     'Git labels collide with existing build config "%s". '
                     'Existing labels: %r, '
@@ -757,7 +756,7 @@ class OSBS(object):
     @osbsapi
     def login(self, token=None, username=None, password=None):
         if self.os.use_kerberos:
-             raise OsbsValidationException("can't use login when using kerberos")
+            raise OsbsValidationException("can't use login when using kerberos")
 
         if not token:
             if username:

--- a/osbs/build/__init__.py
+++ b/osbs/build/__init__.py
@@ -7,5 +7,5 @@ of the BSD license. See the LICENSE file for details.
 """
 from __future__ import absolute_import
 
-from .build_response import BuildResponse
-from .pod_response import PodResponse
+from .build_response import BuildResponse  # noqa
+from .pod_response import PodResponse  # noqa

--- a/osbs/build/build_request.py
+++ b/osbs/build/build_request.py
@@ -22,7 +22,8 @@ except ImportError:
 
 from osbs.build.manipulate import DockJsonManipulator
 from osbs.build.spec import BuildSpec
-from osbs.constants import SECRETS_PATH, DEFAULT_OUTER_TEMPLATE, DEFAULT_INNER_TEMPLATE, DEFAULT_CUSTOMIZE_CONF
+from osbs.constants import (SECRETS_PATH, DEFAULT_OUTER_TEMPLATE, DEFAULT_INNER_TEMPLATE,
+                            DEFAULT_CUSTOMIZE_CONF)
 from osbs.exceptions import OsbsException, OsbsValidationException
 from osbs.utils import git_repo_humanish_part_from_uri, sanitize_version
 from osbs import __version__ as client_version
@@ -154,7 +155,7 @@ class BuildRequest(object):
             logger.debug("loading customize conf from path %s", path)
             try:
                 with open(path, "r") as fp:
-                    self._customize_conf= json.load(fp)
+                    self._customize_conf = json.load(fp)
             except IOError:
                 # File not found, which is perfectly fine. Set to empty string
                 self._customize_conf = {}
@@ -234,7 +235,8 @@ class BuildRequest(object):
             'openshift_required_version': sanitize_version(self._openshift_required_version),
             'pulp_registry_name': self.spec.pulp_registry.value,
             'registry_api_versions': ','.join(self.spec.registry_api_versions.value or []) or None,
-            'smtp_additional_addresses': ','.join(self.spec.smtp_additional_addresses.value or []) or None,
+            'smtp_additional_addresses': ','.join(self.spec.smtp_additional_addresses.value or [])
+                                         or None,
             'smtp_email_domain': self.spec.smtp_email_domain.value,
             'smtp_error_addresses': ','.join(self.spec.smtp_error_addresses.value or []) or None,
             'smtp_from': self.spec.smtp_from.value,
@@ -871,7 +873,6 @@ class BuildRequest(object):
                         "requires pulp_registry and a v2 registry")
             self.dj.remove_plugin("postbuild_plugins", "pulp_sync")
             self.dj.remove_plugin("exit_plugins", "delete_from_registry")
-
 
     def render_import_image(self, use_auth=None):
         """

--- a/osbs/build/spec.py
+++ b/osbs/build/spec.py
@@ -335,7 +335,8 @@ class BuildSpec(object):
                     logger.debug("param '%s' is None; None is allowed", param.name)
                 else:
                     logger.error("param '%s' is None; None is NOT allowed", param.name)
-                    raise OsbsValidationException("param '%s' is not valid: None is not allowed" % param.name)
+                    raise OsbsValidationException("param '%s' is not valid: None is not allowed" %
+                                                  param.name)
 
     def __repr__(self):
         return "Spec(%s)" % self.__dict__

--- a/osbs/cli/main.py
+++ b/osbs/cli/main.py
@@ -26,7 +26,8 @@ from osbs.conf import Configuration
 from osbs.constants import (DEFAULT_CONFIGURATION_FILE, DEFAULT_CONFIGURATION_SECTION,
                             CLI_LIST_BUILDS_DEFAULT_COLS, PY3, BACKUP_RESOURCES,
                             BUILD_FINISHED_STATES, CLI_WATCH_BUILDS_DEFAULT_COLS)
-from osbs.exceptions import OsbsNetworkException, OsbsException, OsbsAuthException, OsbsResponseException
+from osbs.exceptions import (OsbsNetworkException, OsbsException, OsbsAuthException,
+                             OsbsResponseException)
 from osbs.cli.capture import setup_json_capture
 from osbs.utils import (strip_registry_from_image, paused_builds, TarReader,
                         TarWriter, get_time_from_rfc3339, graceful_chain_get)
@@ -61,12 +62,12 @@ def check_provided_args(args, check, check_func, error_msg):
 
 def check_unwanted_args(args, unwanted):
     check_provided_args(args, unwanted, lambda item: item[-1],
-                         'Unwanted params: {0}')
+                        'Unwanted params: {0}')
 
 
 def check_required_args(args, required):
     check_provided_args(args, required, lambda item: not item[-1],
-                         'Missing required params: {0}')
+                        'Missing required params: {0}')
 
 
 def cmd_get_all_resource_quota(args, osbs):
@@ -584,33 +585,38 @@ def cli():
 
     subparsers = parser.add_subparsers(help='commands')
 
-    list_builds_parser = subparsers.add_parser(str_on_2_unicode_on_3('list-builds'), help='list builds in OSBS',
+    list_builds_parser = subparsers.add_parser(str_on_2_unicode_on_3('list-builds'),
+                                               help='list builds in OSBS',
                                                description="list all builds in the namespace")
     list_builds_parser.add_argument("FILTER", help="list only builds which contain provided string",
                                     nargs="?")
     list_builds_parser.add_argument("--columns",
-                                    help="comma-separated list of columns to display, possible values: "
-                                    "base_image, base_image_id, commit, image, unique_image, image_id, "
-                                    "name, status, time_created")
+                                    help="comma-separated list of columns to display, possible "
+                                    "values: base_image, base_image_id, commit, image, "
+                                    "unique_image, image_id, name, status, time_created")
     # this may be a bit confusing, but for users, "running" means not done but
     # for us, "running" means scheduled on kubelet
-    list_builds_parser.add_argument("--running", help="list only running builds", action="store_true")
+    list_builds_parser.add_argument("--running", help="list only running builds",
+                                    action="store_true")
     list_builds_parser.add_argument("--from-json",
                                     help="fetch builds list from JSON file instead of from server")
 
     list_builds_parser.set_defaults(func=cmd_list_builds)
 
-    watch_build_parser = subparsers.add_parser(str_on_2_unicode_on_3('watch-build'), help='wait till build finishes')
+    watch_build_parser = subparsers.add_parser(str_on_2_unicode_on_3('watch-build'),
+                                               help='wait till build finishes')
     watch_build_parser.add_argument("BUILD_ID", help="build ID", nargs=1)
     watch_build_parser.set_defaults(func=cmd_watch_build)
 
-    watch_builds_parser = subparsers.add_parser(str_on_2_unicode_on_3('watch-builds'), help='watch running builds')
+    watch_builds_parser = subparsers.add_parser(str_on_2_unicode_on_3('watch-builds'),
+                                                help='watch running builds')
     watch_builds_parser.add_argument("--columns",
-                                     help="comma-separated list of columns to display, possible values: "
-                                     "changetype, status, created, name")
+                                     help="comma-separated list of columns to display, possible "
+                                     "values: changetype, status, created, name")
     watch_builds_parser.set_defaults(func=cmd_watch_builds)
 
-    get_build_parser = subparsers.add_parser(str_on_2_unicode_on_3('get-build'), help='get info about build')
+    get_build_parser = subparsers.add_parser(str_on_2_unicode_on_3('get-build'),
+                                             help='get info about build')
     get_build_parser.add_argument("BUILD_ID", help="build ID", nargs=1)
     get_build_parser.set_defaults(func=cmd_get_build)
 
@@ -624,30 +630,35 @@ def cli():
     import_image_parser.add_argument("NAME", help="ImageStream name", nargs=1)
     import_image_parser.set_defaults(func=cmd_import_image)
 
-    get_token_parser = subparsers.add_parser(str_on_2_unicode_on_3('get-token'), help='get authentication token')
+    get_token_parser = subparsers.add_parser(str_on_2_unicode_on_3('get-token'),
+                                             help='get authentication token')
     get_token_parser.add_argument("--oc", help="display oc login command",
                                   action="store_true", default=False)
     get_token_parser.set_defaults(func=cmd_get_token)
 
-
     get_login_parser = subparsers.add_parser(str_on_2_unicode_on_3('login'),
                                              help='perform login and store token for later use')
     get_login_parser.add_argument('--token', help='token to be used for login', action="store")
-    get_login_parser.add_argument('-u', '--username', help='Username, will prompt if not provided', action="store")
-    get_login_parser.add_argument('-p', '--password', help='Password, will prompt if not provided', action="store")
+    get_login_parser.add_argument('-u', '--username', help='Username, will prompt if not provided',
+                                  action="store")
+    get_login_parser.add_argument('-p', '--password', help='Password, will prompt if not provided',
+                                  action="store")
     get_login_parser.set_defaults(func=cmd_login)
 
-    get_user_parser = subparsers.add_parser(str_on_2_unicode_on_3('get-user'), help='get info about user')
+    get_user_parser = subparsers.add_parser(str_on_2_unicode_on_3('get-user'),
+                                            help='get info about user')
     get_user_parser.add_argument("USERNAME", nargs="?", default=None)
     get_user_parser.set_defaults(func=cmd_get_user)
 
-    build_logs_parser = subparsers.add_parser(str_on_2_unicode_on_3('build-logs'), help='get or follow build logs')
+    build_logs_parser = subparsers.add_parser(str_on_2_unicode_on_3('build-logs'),
+                                              help='get or follow build logs')
     build_logs_parser.add_argument("BUILD_ID", help="build ID", nargs=1)
-    build_logs_parser.add_argument("-f", "--follow", help="follow logs as they come", action="store_true",
-                                   default=False)
-    build_logs_parser.add_argument("--wait-if-missing", help="if build is not created yet, wait", action="store_true",
-                                   default=False)
-    build_logs_parser.add_argument("--from-docker-build", help="return logs from `docker build` instead",
+    build_logs_parser.add_argument("-f", "--follow", help="follow logs as they come",
+                                   action="store_true", default=False)
+    build_logs_parser.add_argument("--wait-if-missing", help="if build is not created yet, wait",
+                                   action="store_true", default=False)
+    build_logs_parser.add_argument("--from-docker-build",
+                                   help="return logs from `docker build` instead",
                                    action="store_true", default=False)
     build_logs_parser.set_defaults(func=cmd_build_logs)
 
@@ -657,7 +668,8 @@ def cli():
     get_quota_parser.add_argument("QUOTA_NAME", help="name of quota", nargs="?", default=None)
     get_quota_parser.set_defaults(func=cmd_get_all_resource_quota)
 
-    build_parser = subparsers.add_parser(str_on_2_unicode_on_3('build'), help='build an image in OSBS')
+    build_parser = subparsers.add_parser(str_on_2_unicode_on_3('build'),
+                                         help='build an image in OSBS')
     build_parser.add_argument("--build-json-dir", action="store", metavar="PATH",
                               help="directory with build jsons")
     build_parser.add_argument("-g", "--git-url", action='store', metavar="URL",
@@ -693,9 +705,9 @@ def cli():
     build_parser.add_argument("--yum-proxy", action='store', required=False,
                               help="set yum proxy to repos from koji/add-yum-repo params")
 
-    worker_group = build_parser.add_argument_group(
-        title='arguments for --worker',
-        description='Required arguments for creating a worker build')
+    worker_group = build_parser.add_argument_group(title='arguments for --worker',
+                                                   description='Required arguments for creating a '
+                                                   'worker build')
     worker_group.add_argument('--platform', action='store', required=False,
                               help='platform name to use')
     worker_group.add_argument('--release', action='store', required=False,
@@ -703,12 +715,11 @@ def cli():
     worker_group.add_argument('--arrangement-version', action='store', required=False,
                               help='version of inner template to use')
 
-    orchestrator_group = build_parser.add_argument_group(
-        title='arguments for --orchestrator',
-        description='Required arguments for creating an orchestrator build')
-    orchestrator_group.add_argument(
-        '--platforms', action='append', metavar='PLATFORM',
-        help='name of each platform to use')
+    orchestrator_group = build_parser.add_argument_group(title='arguments for --orchestrator',
+                                                         description='Required arguments for '
+                                                         'creating an orchestrator build')
+    orchestrator_group.add_argument('--platforms', action='append', metavar='PLATFORM',
+                                    help='name of each platform to use')
 
     build_parser.add_argument('--source-registry-uri', action='store', required=False,
                               help="set source registry for pulling parent image")
@@ -730,26 +741,30 @@ def cli():
 
     get_build_image_id = subparsers.add_parser(str_on_2_unicode_on_3('get-build-image-id'),
                                                help='get build container image ID',
-                                               description='get build container images for a build in a namespace')
+                                               description='get build container images for a '
+                                               'build in a namespace')
     get_build_image_id.add_argument("BUILD_ID", help="build ID", nargs=1)
     get_build_image_id.set_defaults(func=cmd_get_build_image_id)
 
     backup_builder = subparsers.add_parser(str_on_2_unicode_on_3('backup-builder'),
                                            help='dump builder data (admin)',
                                            description='create backup of all OSBS data')
-    backup_builder.add_argument("-f", "--filename", help="name of the resulting tar.bz2 file (use - for stdout)")
+    backup_builder.add_argument("-f", "--filename",
+                                help="name of the resulting tar.bz2 file (use - for stdout)")
     backup_builder.set_defaults(func=cmd_backup)
 
     restore_builder = subparsers.add_parser(str_on_2_unicode_on_3('restore-builder'),
                                             help='restore builder data (admin)',
                                             description='restore OSBS data from backup')
-    restore_builder.add_argument("BACKUP_ARCHIVE", help="name of the tar.bz2 archive to restore (use - for stdin)")
+    restore_builder.add_argument("BACKUP_ARCHIVE",
+                                 help="name of the tar.bz2 archive to restore (use - for stdin)")
     restore_builder.add_argument("--continue-on-error", action='store_true',
                                  help="don't stop when restoring a resource fails")
     restore_builder.set_defaults(func=cmd_restore)
 
     token_url_builder = subparsers.add_parser(str_on_2_unicode_on_3('print-token-url'),
-                                              description='print a url to oauth authentication page')
+                                              description='print a url to oauth authentication '
+                                              'page')
     token_url_builder.set_defaults(func=cmd_print_token_url)
 
     serviceaccount_builder = subparsers.add_parser(
@@ -770,7 +785,8 @@ def cli():
     parser.add_argument("--config", action='store', metavar="PATH",
                         help="path to configuration file", default=DEFAULT_CONFIGURATION_FILE)
     parser.add_argument("--instance", "-i", action='store', metavar="SECTION_NAME",
-                        help="section within config for requested instance", default=DEFAULT_CONFIGURATION_SECTION)
+                        help="section within config for requested instance",
+                        default=DEFAULT_CONFIGURATION_SECTION)
     parser.add_argument("--username", action='store',
                         help="name of user to use for Basic Authentication in OSBS")
     parser.add_argument("--password", action='store',
@@ -875,6 +891,7 @@ def main():
         else:
             logger.error("Exception caught: %s", repr(ex))
             return -1
+
 
 if __name__ == '__main__':
     sys.exit(main())

--- a/osbs/cli/render.py
+++ b/osbs/cli/render.py
@@ -118,8 +118,8 @@ class TablePrinter(TableFormatter):
                 self.default_column_space = self.total_free_space // self.col_count
                 self.default_column_space_remainder = self.total_free_space % self.col_count
                 logger.debug("total free space: %d, column space: %d, remainder: %d, columns: %d",
-                             self.total_free_space, self.default_column_space, self.default_column_space_remainder,
-                             self.col_count)
+                             self.total_free_space, self.default_column_space,
+                             self.default_column_space_remainder, self.col_count)
         else:
             self.total_free_space = None
 

--- a/osbs/conf.py
+++ b/osbs/conf.py
@@ -42,7 +42,8 @@ class Configuration(object):
      * dict
     """
 
-    def __init__(self, conf_file=DEFAULT_CONFIGURATION_FILE, conf_section=DEFAULT_CONFIGURATION_SECTION,
+    def __init__(self, conf_file=DEFAULT_CONFIGURATION_FILE,
+                 conf_section=DEFAULT_CONFIGURATION_SECTION,
                  cli_args=None, **kwargs):
         """
         sample initialization:
@@ -212,13 +213,15 @@ class Configuration(object):
         return self._get_value("koji_certs_secret", self.conf_section, "koji_certs_secret")
 
     def get_koji_use_kerberos(self):
-        return self._get_value("koji_use_kerberos", self.conf_section, "koji_use_kerberos", is_bool_val=True)
+        return self._get_value("koji_use_kerberos", self.conf_section, "koji_use_kerberos",
+                               is_bool_val=True)
 
     def get_koji_kerberos_keytab(self):
         return self._get_value("koji_kerberos_keytab", self.conf_section, "koji_kerberos_keytab")
 
     def get_koji_kerberos_principal(self):
-        return self._get_value("koji_kerberos_principal", self.conf_section, "koji_kerberos_principal")
+        return self._get_value("koji_kerberos_principal", self.conf_section,
+                               "koji_kerberos_principal")
 
     def get_sources_command(self):
         return self._get_value("sources_command", self.conf_section, "sources_command")
@@ -487,7 +490,8 @@ class Configuration(object):
             raise OsbsValidationException("Invalid arrangement_version: %s" % value)
 
     def get_can_orchestrate(self):
-        return self._get_value("can_orchestrate", self.conf_section, "can_orchestrate", default=False, is_bool_val=True)
+        return self._get_value("can_orchestrate", self.conf_section, "can_orchestrate",
+                               default=False, is_bool_val=True)
 
     def get_info_url_format(self):
         return self._get_value("info_url_format", self.conf_section,

--- a/osbs/core.py
+++ b/osbs/core.py
@@ -233,7 +233,8 @@ class Openshift(object):
         try:
             redir_url = r.headers['location']
         except KeyError:
-            logger.error("[%s] 'Location' header is missing in response, cannot retrieve token", r.status_code)
+            logger.error("[%s] 'Location' header is missing in response, cannot retrieve token",
+                         r.status_code)
             return ""
         parsed_url = urlparse.urlparse(redir_url)
         fragment = parsed_url.fragment
@@ -396,7 +397,8 @@ class Openshift(object):
             if changetype == WATCH_MODIFIED:
                 version = graceful_chain_get(obj, 'status', 'lastVersion')
                 if not isinstance(version, numbers.Integral):
-                    logger.error("BuildConfig %s has unexpected lastVersion: %s", build_config_id, version)
+                    logger.error("BuildConfig %s has unexpected lastVersion: %s", build_config_id,
+                                 version)
                     continue
 
                 if version > prev_version:
@@ -649,7 +651,8 @@ class Openshift(object):
         #   2. our object was not found and we keep waiting (in the loop)
         # Therefore, let's raise here
         logger.error("build '%s' was not found during wait", build_id)
-        raise OsbsWatchBuildNotFound("build '%s' was not found and response stream ended" % build_id)
+        raise OsbsWatchBuildNotFound("build '%s' was not found and response stream ended" %
+                                     build_id)
 
     def wait_for_build_to_finish(self, build_id):
         for retry in range(1, 10):

--- a/osbs/utils.py
+++ b/osbs/utils.py
@@ -410,6 +410,7 @@ def sanitize_version(version):
     cleaned_version = '{0}.{1}.{2}'.format(major, minor, micro)
     return cleaned_version
 
+
 class Labels(object):
     """
     Provide access to a set of labels which have specific semantics

--- a/tests/build_/test_build_response.py
+++ b/tests/build_/test_build_response.py
@@ -9,6 +9,7 @@ import json
 import pytest
 from osbs.build.build_response import BuildResponse
 
+
 class TestBuildResponse(object):
     def test_get_logs(self):
         msg = "This is an error message"
@@ -55,7 +56,6 @@ class TestBuildResponse(object):
         assert not build_response.cancelled
         assert 'cancelled' in build_response.json['status']
         assert not build_response.json['status'].get('cancelled')
-
 
     @pytest.mark.parametrize(('plugin', 'message', 'expected_error_message'), [
         ('dockerbuild', None, 'Error in plugin dockerbuild'),

--- a/tests/cli/test_capture.py
+++ b/tests/cli/test_capture.py
@@ -12,7 +12,7 @@ import pytest
 
 from osbs.constants import DEFAULT_NAMESPACE
 from osbs.cli.capture import setup_json_capture
-from tests.fake_api import openshift, osbs
+from tests.fake_api import openshift, osbs  # noqa
 from tests.constants import TEST_BUILD
 from osbs.conf import Configuration
 
@@ -22,7 +22,7 @@ API_PREFIX = "/oapi/{v}/".format(v=API_VER)
 PREFIX = API_PREFIX.replace('/', '_')
 
 
-@pytest.fixture
+@pytest.fixture  # noqa
 def osbs_with_capture(osbs, tmpdir):
     setup_json_capture(osbs, osbs.os_conf, str(tmpdir))
     return osbs
@@ -39,6 +39,7 @@ def test_json_capture_no_watch(osbs_with_capture, tmpdir):
             obj = json.load(fp)
 
         assert obj
+
 
 def test_json_capture_watch(osbs_with_capture, tmpdir):
     osbs_with_capture.wait_for_build_to_finish(TEST_BUILD)

--- a/tests/fake_api.py
+++ b/tests/fake_api.py
@@ -87,7 +87,8 @@ class Connection(object):
                 }
             },
 
-            OAPI_PREFIX + "namespaces/default/builds/?labelSelector=koji-task-id%3D{task}".format(task=TEST_KOJI_TASK_ID): {
+            OAPI_PREFIX + "namespaces/default/builds/"
+                          "?labelSelector=koji-task-id%3D{task}".format(task=TEST_KOJI_TASK_ID): {
                 "get": {
                     # Contains a list of builds
                     "file": "builds_list.json",
@@ -347,6 +348,7 @@ can_orchestrate = true
     osbs.os = openshift
     return osbs
 
+
 @pytest.fixture
 def osbs_cant_orchestrate(openshift):
     with NamedTemporaryFile(mode="wt") as fp:
@@ -371,6 +373,7 @@ use_auth = false
 
     osbs.os = openshift
     return osbs
+
 
 @pytest.fixture
 def osbs106(openshift):

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -191,7 +191,6 @@ class TestConfiguration(object):
                 .with_args('default')
                 .and_return(login_tmpf.name))
 
-
         with self.build_cli_args(cli_args) as args:
             with self.config_file(config) as config_file:
                 conf = Configuration(conf_file=config_file, cli_args=args,
@@ -252,7 +251,8 @@ class TestConfiguration(object):
         ({'default': {'token_secrets': '\n   secret:path     secret2\n\n secret3:path3'}},
          {'secret': 'path', 'secret2': None, 'secret3': 'path3'}),
 
-        ({'default': {'token_secrets': '\t\n   secret:path   \t\t  secret2\n\n \tsecret3:path3 \n\t\n'}},
+        ({'default': {'token_secrets': '\t\n   secret:path   \t\t  secret2\n\n '
+                      '\tsecret3:path3 \n\t\n'}},
          {'secret': 'path', 'secret2': None, 'secret3': 'path3'}),
     ])
     def test_get_token_secrets(self, config, expected):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -24,7 +24,7 @@ from osbs.core import check_response, Openshift
 
 from tests.constants import (TEST_BUILD, TEST_CANCELLED_BUILD, TEST_LABEL,
                              TEST_LABEL_VALUE, TEST_IMAGESTREAM)
-from tests.fake_api import openshift, OAPI_PREFIX, API_VER
+from tests.fake_api import openshift, OAPI_PREFIX, API_VER  # noqa
 from requests.exceptions import ConnectionError
 import pytest
 
@@ -175,25 +175,25 @@ class TestOpenshift(object):
             for result in server.stream_logs('anything'):
                 assert isinstance(result, six.binary_type)
 
-    def test_list_builds(self, openshift):
+    def test_list_builds(self, openshift):  # noqa
         list_builds = openshift.list_builds()
         assert list_builds is not None
         assert bool(list_builds.json())  # is there at least something
 
-    def test_list_pods(self, openshift):
+    def test_list_pods(self, openshift):  # noqa
         response = openshift.list_pods(label="openshift.io/build.name=%s" %
                                        TEST_BUILD)
         assert isinstance(response, HttpResponse)
 
-    def test_get_oauth_token(self, openshift):
+    def test_get_oauth_token(self, openshift):  # noqa
         token = openshift.get_oauth_token()
         assert token is not None
 
-    def test_get_user(self, openshift):
+    def test_get_user(self, openshift):  # noqa
         l = openshift.get_user()
         assert l.json() is not None
 
-    def test_watch_build(self, openshift):
+    def test_watch_build(self, openshift):  # noqa
         response = openshift.wait_for_build_to_finish(TEST_BUILD)
         status_lower = response["status"]["phase"].lower()
         assert response["metadata"]["name"] == TEST_BUILD
@@ -201,19 +201,19 @@ class TestOpenshift(object):
         assert isinstance(TEST_BUILD, six.text_type)
         assert isinstance(status_lower, six.text_type)
 
-    def test_create_build(self, openshift):
+    def test_create_build(self, openshift):  # noqa
         response = openshift.create_build({})
         assert response is not None
         assert response.json()["metadata"]["name"] == TEST_BUILD
         assert response.json()["status"]["phase"].lower() in BUILD_FINISHED_STATES
 
-    def test_cancel_build(self, openshift):
+    def test_cancel_build(self, openshift):  # noqa
         response = openshift.cancel_build(TEST_CANCELLED_BUILD)
         assert response is not None
         assert response.json()["metadata"]["name"] == TEST_CANCELLED_BUILD
         assert response.json()["status"]["phase"].lower() in BUILD_CANCELLED_STATE
 
-    def test_get_build_config(self, openshift):
+    def test_get_build_config(self, openshift):  # noqa
         mock_response = {"spam": "maps"}
         build_config_name = 'some-build-config-name'
         expected_url = openshift._build_url("buildconfigs/%s/" % build_config_name)
@@ -225,7 +225,7 @@ class TestOpenshift(object):
         response = openshift.get_build_config(build_config_name)
         assert response['spam'] == 'maps'
 
-    def test_get_missing_build_config(self, openshift):
+    def test_get_missing_build_config(self, openshift):  # noqa
         build_config_name = 'some-build-config-name'
         expected_url = openshift._build_url("buildconfigs/%s/" % build_config_name)
         (flexmock(openshift)
@@ -236,9 +236,8 @@ class TestOpenshift(object):
         with pytest.raises(OsbsResponseException):
             openshift.get_build_config(build_config_name)
 
-    def test_get_build_config_by_labels(self, openshift):
+    def test_get_build_config_by_labels(self, openshift):  # noqa
         mock_response = {"items": [{"spam": "maps"}]}
-        build_config_name = 'some-build-config-name'
         label_selectors = (
             ('label-1', 'value-1'),
             ('label-2', 'value-2'),
@@ -253,9 +252,8 @@ class TestOpenshift(object):
         response = openshift.get_build_config_by_labels(label_selectors)
         assert response['spam'] == 'maps'
 
-    def test_get_missing_build_config_by_labels(self, openshift):
+    def test_get_missing_build_config_by_labels(self, openshift):  # noqa
         mock_response = {"items": []}
-        build_config_name = 'some-build-config-name'
         label_selectors = (
             ('label-1', 'value-1'),
             ('label-2', 'value-2'),
@@ -272,9 +270,8 @@ class TestOpenshift(object):
             openshift.get_build_config_by_labels(label_selectors)
         assert str(exc.value).startswith('Build config not found')
 
-    def test_get_multiple_build_config_by_labels(self, openshift):
+    def test_get_multiple_build_config_by_labels(self, openshift):  # noqa
         mock_response = {"items": [{"spam": "maps"}, {"eggs": "sgge"}]}
-        build_config_name = 'some-build-config-name'
         label_selectors = (
             ('label-1', 'value-1'),
             ('label-2', 'value-2'),
@@ -291,7 +288,7 @@ class TestOpenshift(object):
             openshift.get_build_config_by_labels(label_selectors)
         assert str(exc.value).startswith('More than one build config found')
 
-    @pytest.mark.parametrize(('status_codes', 'should_raise'), [
+    @pytest.mark.parametrize(('status_codes', 'should_raise'), [  # noqa
         ([httplib.OK], False),
         ([httplib.CONFLICT, httplib.CONFLICT, httplib.OK], False),
         ([httplib.CONFLICT, httplib.OK], False),
@@ -341,7 +338,7 @@ class TestOpenshift(object):
         else:
             fn(*args)
 
-    def test_put_image_stream_tag(self, openshift):
+    def test_put_image_stream_tag(self, openshift):  # noqa
         tag_name = 'spam'
         tag_id = 'maps:' + tag_name
         mock_data = {
@@ -382,7 +379,7 @@ class TestOpenshift(object):
             }
         '''))
 
-    @pytest.mark.parametrize('existing_scheduled', (True, False, None))
+    @pytest.mark.parametrize('existing_scheduled', (True, False, None))  # noqa
     @pytest.mark.parametrize('existing_insecure', (True, False, None))
     @pytest.mark.parametrize('expected_scheduled', (True, False))
     @pytest.mark.parametrize(('s_annotations', 'expected_insecure'), (

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -19,19 +19,18 @@ logger = logging.getLogger("osbs.tests")
 
 
 def test_missing_config():
-    os_conf = Configuration(conf_file="/nonexistent/path",
-                            conf_section="default")
+    os_conf = Configuration(conf_file="/nonexistent/path", conf_section="default")  # noqa
+
 
 def test_no_config():
-    os_conf = Configuration(conf_file=None,
-                            openshift_uri='https://example:8443')
-    assert os_conf.get_openshift_oauth_api_uri() == \
-            'https://example:8443/oauth/authorize'
+    os_conf = Configuration(conf_file=None, openshift_uri='https://example:8443')
+    assert os_conf.get_openshift_oauth_api_uri() == 'https://example:8443/oauth/authorize'
+
 
 def test_missing_section():
     with NamedTemporaryFile() as f:
-        os_conf = Configuration(conf_file=f.name,
-                                conf_section="missing")
+        os_conf = Configuration(conf_file=f.name, conf_section="missing")  # noqa
+
 
 def test_no_build_image():
     with NamedTemporaryFile(mode='w+') as f:
@@ -44,6 +43,7 @@ build_host=localhost
         os_conf = Configuration(conf_file=f.name,
                                 conf_section="default")
         assert os_conf.get_build_image() is None
+
 
 def test_no_inputs():
     with NamedTemporaryFile(mode='w+') as f:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -107,7 +107,8 @@ def test_get_time_from_rfc3339_valid(rfc3339, seconds, tz):
     ('longer--name--than', 'this', 22, '-', 'longer--name--tha-this'),
 ])
 def test_make_name_from_git(repo, branch, limit, separator, expected, hash_size=5):
-    bc_name = make_name_from_git(repo, branch, limit + len(separator) + hash_size, separator, hash_size=hash_size)
+    bc_name = make_name_from_git(repo, branch, limit + len(separator) + hash_size, separator,
+                                 hash_size=hash_size)
 
     assert expected == bc_name[:-(hash_size + len(separator))]
 
@@ -115,18 +116,21 @@ def test_make_name_from_git(repo, branch, limit, separator, expected, hash_size=
     valid = re.compile(BC_NAME_REGEX)
     assert valid.match(bc_name)
 
+
 def test_make_name_from_git_collide():
     bc1 = make_name_from_git("very_log_repo name_first", "also_long_branch_name", 30, '-')
     bc2 = make_name_from_git("very_log_repo name_second", "also_long_branch_name", 30, '-')
     assert bc1 != bc2
 
+
 SHA_INPUT_FILE = 'tests/input_for_sha.txt'
+
 
 def test_make_name_from_git_all_from_file():
 
     all_sha = set()
     with open(SHA_INPUT_FILE) as f:
-        lines =  f.read().splitlines()
+        lines = f.read().splitlines()
 
     for line in lines:
         repo, branch = line.split()
@@ -138,6 +142,7 @@ def test_make_name_from_git_all_from_file():
         assert valid.match(bc_name)
 
     assert len(lines) == len(all_sha)
+
 
 @pytest.mark.skipif(sys.version_info[0] < 3,
                     reason="requires python3")
@@ -284,6 +289,7 @@ def test_get_instance_token_file_name():
 
     assert get_instance_token_file_name('spam') == expected
 
+
 @pytest.mark.parametrize(('labels', 'fnc', 'expect'), [
     ({},
      ("get_name", Labels.LABEL_TYPE_COMPONENT),
@@ -291,11 +297,11 @@ def test_get_instance_token_file_name():
     ({},
      ("get_name", "doesnt_exist"),
      Exception),
-    ({"Name" : "old",
-      "name" : "new"},
+    ({"Name": "old",
+      "name": "new"},
      ("get_name", Labels.LABEL_TYPE_NAME),
      "name"),
-    ({"Name" : "old"},
+    ({"Name": "old"},
      ("get_name", Labels.LABEL_TYPE_NAME),
      "Name"),
     ({"Name": "old"},
@@ -310,8 +316,8 @@ def test_get_instance_token_file_name():
       "RUN": "run",
       "INSTALL": "install",
       "UNINSTALL": "uninstall"}),
-    ({"Name" : "old",
-      "name" : "new"},
+    ({"Name": "old",
+      "name": "new"},
      ("get_name_and_value", Labels.LABEL_TYPE_NAME),
      ("name", "new")),
     ({},
@@ -339,6 +345,8 @@ def test_labels(labels, fnc, expect):
 
 
 vstr_re = re.compile('\d+\.\d+\.\d+')
+
+
 @pytest.mark.parametrize(('version', 'valid'), [
     ('1.0.4', True),
     ('5.3', True),

--- a/tests/throughput-test-harness.py
+++ b/tests/throughput-test-harness.py
@@ -17,7 +17,10 @@ DEFAULT_KOJI_BIN = "koji"
 DEFAULT_KOJI_TARGET = "extras-rhel-7.2-candidate"
 DEFAULT_GIT_REMOTE = "origin"
 
-class SubprocessError(Exception): pass
+
+class SubprocessError(Exception):
+    pass
+
 
 def run(*args):
     logging.info("running: %s", " ".join(args))
@@ -32,6 +35,7 @@ def run(*args):
         raise SubprocessError("Subprocess failed w/ return code {0}".format(p.returncode))
 
     return out
+
 
 def bump_release(df_path, branch):
     parser = DockerfileParser(df_path)
@@ -49,12 +53,14 @@ def bump_release(df_path, branch):
     parser.labels["Release"] = newrelease
     return newrelease
 
+
 def set_initial_release(df_path, branch):
     parser = DockerfileParser(df_path)
     oldrelease = parser.labels.get("Release", "1")
     newrelease = "{0}.{1}.iteration001".format(oldrelease, branch)
     parser.labels["Release"] = newrelease
     return newrelease
+
 
 def get_branches(branch_prefix):
     branches = run("git", "branch", "--list")
@@ -63,6 +69,7 @@ def get_branches(branch_prefix):
     if not branches:
         raise RuntimeError("No branches starting with %s found" % branch_prefix)
     return branches
+
 
 def cmd_create_branches(args):
     branches = ["{0}{1:03d}".format(args.branch_prefix, n+1) for n in range(args.number)]
@@ -81,10 +88,11 @@ def cmd_create_branches(args):
     logging.info("Pusing ALL branches to %s", args.git_remote)
     run("git", "push", "--force", args.git_remote, *branches)
 
+
 def cmd_delete_branches(args):
     branches = get_branches(args.branch_prefix)
 
-    #otherwise we get Cannot delete the branch 'branch005' which you are currently on.
+    # otherwise we get Cannot delete the branch 'branch005' which you are currently on.
     run("git", "checkout", "master")
 
     logging.info("Deleting %d branches", len(branches))
@@ -92,6 +100,7 @@ def cmd_delete_branches(args):
 
     logging.info("Deleting remote branches in %s", args.git_remote)
     run("git", "push", "--force", args.git_remote, *[":"+b for b in branches])
+
 
 def cmd_bump_release(args):
     branches = get_branches(args.branch_prefix)
@@ -104,6 +113,7 @@ def cmd_bump_release(args):
 
     logging.info("Pusing ALL branches to %s", args.git_remote)
     run("git", "push", "--force", args.git_remote, *branches)
+
 
 def cmd_start_builds(args):
     branches = get_branches(args.branch_prefix)
@@ -167,6 +177,7 @@ def cmd_start_builds(args):
         for b, ex in failed_builds.items():
             logging.error("Branch %s:", b, exc_info=ex)
 
+
 def main():
     parser = argparse.ArgumentParser(description="OSBS throughput test harness",
                                      formatter_class=argparse.ArgumentDefaultsHelpFormatter)
@@ -193,15 +204,20 @@ def main():
 
     start_builds = subparsers.add_parser("start-builds",
                                          formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    start_builds.add_argument("--stagger-number", metavar="N", type=int, default=DEFAULT_STAGGER_NUMBER,
+    start_builds.add_argument("--stagger-number", metavar="N", type=int,
+                              default=DEFAULT_STAGGER_NUMBER,
                               help="wait between starting N first builds")
-    start_builds.add_argument("--stagger-wait", metavar="SECONDS", type=int, default=DEFAULT_STAGGER_WAIT,
+    start_builds.add_argument("--stagger-wait", metavar="SECONDS", type=int,
+                              default=DEFAULT_STAGGER_WAIT,
                               help="amount of time to wait between initial builds")
     start_builds.add_argument("--use-koji", default=False, action="store_true",
                               help="use koji to submit builds (default: use osbs")
     start_builds.add_argument("--koji-bin", default=DEFAULT_KOJI_BIN, help="koji executable")
-    start_builds.add_argument("--koji-target", default=DEFAULT_KOJI_TARGET, help="koji target to build in")
-    start_builds.add_argument("--git-url", help="url of git repo to pass to koji (autodetected if not specified)")
+    start_builds.add_argument("--koji-target", default=DEFAULT_KOJI_TARGET,
+                              help="koji target to build in")
+    start_builds.add_argument("--git-url",
+                              help="url of git repo to pass to koji "
+                              "(autodetected if not specified)")
     start_builds.add_argument("--repo-url", help="url of rpm repo to install for builds")
     start_builds.set_defaults(func=cmd_start_builds)
 
@@ -209,6 +225,7 @@ def main():
 
     args = parser.parse_args()
     args.func(args)
+
 
 if __name__ == '__main__':
     sys.exit(main())


### PR DESCRIPTION
I ran flake8 on osbs/ and tests/ and fixed all the long lines, incorrect
whitespace, and unused variables.

The only functional change was in tests/build_/test_build_request.py:

@@ -1238,7 +1230,7 @@ class TestBuildRequest(object):
             if isinstance(worker_build_image, type):
                 with pytest.raises(worker_build_image):
                     worker_config_kwargs['build_image']
-                worker_config.get_build_image() == None
+                assert not worker_config.get_build_image()

which converts a nonsense statement into the intended assert.

Signed-off-by: Mark Langsdorf <mlangsdo@redhat.com>