### PR TITLE
get_platform_node_selector: handle platform of 'none'

### DIFF
--- a/osbs/conf.py
+++ b/osbs/conf.py
@@ -545,7 +545,7 @@ class Configuration(object):
         :param platform: str, platform to search for, can be null
         """
         nodeselector = None
-        if platform:
+        if platform and platform != 'none':
             nodeselector_str = self._get_value("node_selector." + platform, self.conf_section,
                                                "node_selector." + platform)
             if nodeselector_str:

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -431,6 +431,10 @@ class TestConfiguration(object):
          {'default': {'node_selector.meal': 'breakfast=eggs.com'}},
          {'node_selector.meal': 'breakfast=bacon.com', 'node_selector.expense': 'ride=taxi.com'},
          {'breakfast': 'bacon.com'}),
+        ('none',
+         {'default': {'node_selector.none': 'breakfast=eggs.com'}},
+         {'node_selector.meal': 'breakfast=bacon.com', 'node_selector.expense': 'ride=taxi.com'},
+         None),
     ])
     def test_get_node_selector_platform(self, platform, kwargs, config, expected):
         with self.config_file(config) as config_file:


### PR DESCRIPTION
get_platform_node_selector() should return None if the platform is None or
if it is 'none'. Update the code to handle the second instance and add a
test case that fails if get_plaform_node_selector does a search for
'node_selector.none = $SOMETHING'

Signed-of-by: Mark Langsdorf <mlangsdo@redhat.com>