### PR TITLE
get_platform_node_selector: handle node_selector.platform = None

### DIFF
--- a/osbs/conf.py
+++ b/osbs/conf.py
@@ -548,7 +548,7 @@ class Configuration(object):
         if platform:
             nodeselector_str = self._get_value("node_selector." + platform, self.conf_section,
                                                "node_selector." + platform)
-            if nodeselector_str:
+            if nodeselector_str and nodeselector_str != 'none':
                 constraints = nodeselector_str.split(',')
                 raw_nodeselector = dict([constraint.split('=', 1) for constraint in constraints])
                 nodeselector = dict([k.strip(), v.strip()] for (k, v) in raw_nodeselector.items())

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -431,6 +431,14 @@ class TestConfiguration(object):
          {'default': {'node_selector.meal': 'breakfast=eggs.com'}},
          {'node_selector.meal': 'breakfast=bacon.com', 'node_selector.expense': 'ride=taxi.com'},
          {'breakfast': 'bacon.com'}),
+        ('meal',
+         {'default': {}},
+         {'node_selector.expense': 'ride=taxi.com'},
+         None),
+        ('meal',
+         {'default': {'node_selector.meal': 'none'}},
+         {'node_selector.expense': 'ride=taxi.com'},
+         None),
     ])
     def test_get_node_selector_platform(self, platform, kwargs, config, expected):
         with self.config_file(config) as config_file:


### PR DESCRIPTION
If platform is a valid string, but node_selector.platform = None in the
config file, the existing code will do the wrong thing. Make sure that the
parsed item for node_selector.platform has '=' in it or ignore it.

Add test cases for the node_selector.platform = None path.

Signed-off-by: Mark Langsdorf <mlangsdo@redhat.com>