### PR TITLE
Add documentation for node_selector.(platform)

### DIFF
--- a/docs/configuration_file.md
+++ b/docs/configuration_file.md
@@ -141,7 +141,9 @@ Some options are also mandatory.
 
 * `artifacts_allowed_domains` (*optional*, `string`) — list of domains allowed to be used when fetching artifacts via URL. When not specified, all domains are allowed.
 
-* `low_priority_node_selector` (*optional*, `string`) — a nodeselector to be applied to builds, which are considered to have less priority than normal ones
+* `low_priority_node_selector` (*optional*, `string`) — a node selector to be applied to builds which are considered to have less priority than normal ones, or "none"
+
+* `node_selector.`*platform* (*optional*, `string`) — a node selector to be used for worker builds for the specified platform, or "none"
 
 * `equal_labels` (*optional*, `string`) — list of equal-preference label groups; if any of each set is missing, aliases will be added to complete the set; label delimiter ':', group delimiter ',' (e.g. `name1:name2:name3, release1:release2, version1:version2`)
 

--- a/osbs/conf.py
+++ b/osbs/conf.py
@@ -509,7 +509,7 @@ class Configuration(object):
         nodeselector = {}
         nodeselector_str = self._get_value("low_priority_node_selector", self.conf_section,
                                            "low_priority_node_selector")
-        if nodeselector_str:
+        if nodeselector_str and nodeselector_str != 'none':
             constraints = nodeselector_str.split(',')
             raw_nodeselector = dict([constraint.split('=', 1) for constraint in constraints])
             nodeselector = dict([k.strip(), v.strip()] for (k, v) in raw_nodeselector.items())


### PR DESCRIPTION
Also allow literal none for low_priority_node_selector, for consistency with how node_selector.(platform) works.

Signed-off-by: Tim Waugh <twaugh@redhat.com>