### PR TITLE
Deprecate create_prod_build

### DIFF
--- a/osbs/api.py
+++ b/osbs/api.py
@@ -542,6 +542,8 @@ class OSBS(object):
         :param arrangement_version: int, numbered arrangement of plugins for orchestration workflow
         :return: BuildResponse instance
         """
+        warnings.warn("prod (all-in-one) builds are deprecated, "
+                      "please use create_orchestrator_build")
         return self._do_create_prod_build(*args, **kwargs)
 
     @osbsapi


### PR DESCRIPTION
Maintaining the code for all-in-one builds will become harder
over time. The sooner we can remove create_prod_build(), the
easier we will make future maintenance.

Signed-off-by: Tim Waugh <twaugh@redhat.com>