### PR TITLE
ConfigMap API: better data encoding

### DIFF
--- a/osbs/api.py
+++ b/osbs/api.py
@@ -985,7 +985,10 @@ class OSBS(object):
         config_data_file = os.path.join(self.os_conf.get_build_json_store(), 'config_map.json')
         config_data = json.load(open(config_data_file))
         config_data['metadata']['name'] = name
-        config_data['data'] = data
+        data_dict = {}
+        for key, value in data.items():
+            data_dict[key] = json.dumps(value)
+        config_data['data'] = data_dict
 
         response = self.os.create_config_map(config_data)
         config_map_response = ConfigMapResponse(response.json())

--- a/osbs/build/config_map_response.py
+++ b/osbs/build/config_map_response.py
@@ -8,6 +8,7 @@ of the BSD license. See the LICENSE file for details.
 from __future__ import print_function, absolute_import, unicode_literals
 
 import logging
+import json
 
 from osbs.utils import graceful_chain_get
 
@@ -34,10 +35,27 @@ class ConfigMapResponse(object):
         """
         Find the data stored in the config_map
 
-        :return: dict, the json data that was passed into the ConfigMap on creation
+        :return: dict, the json of the data data that was passed into the ConfigMap on creation
         """
         data = graceful_chain_get(self.json, "data")
         if data is None:
             return {}
 
-        return data
+        data_dict = {}
+        for key in data:
+            data_dict[key] = json.loads(data[key])
+
+        return data_dict
+
+    def get_data_by_key(self, name):
+        """
+        Find the object stored by a JSON string at key 'name'
+
+        :return: str or dict, the json of the str or dict stored in the ConfigMap at that location
+        """
+        data = graceful_chain_get(self.json, "data")
+
+        if data is None or name not in data:
+            return {}
+
+        return json.loads(data[name])

--- a/tests/mock_jsons/0.5.4/create_config_map.json
+++ b/tests/mock_jsons/0.5.4/create_config_map.json
@@ -1,8 +1,8 @@
 {
     "apiVersion": "v1",
     "data": {
-        "special.how": "very",
-        "special.type": "charm"
+        "special.how": "\"very\"",
+        "special.type": "{\"quark\": \"charm\"}"
     },
     "kind": "ConfigMap",
     "metadata": {

--- a/tests/mock_jsons/1.0.4/create_config_map.json
+++ b/tests/mock_jsons/1.0.4/create_config_map.json
@@ -1,8 +1,8 @@
 {
     "apiVersion": "v1",
     "data": {
-        "special.how": "very",
-        "special.type": "charm"
+        "special.how": "\"very\"",
+        "special.type": "{\"quark\": \"charm\"}"
     },
     "kind": "ConfigMap",
     "metadata": {


### PR DESCRIPTION
Encode the data as json object pairs to handle nested dictionaries.

Signed-off-by: Mark Langsdorf <mlangsdo@redhat.com>