### PR TITLE
display build summary once build is complete

### DIFF
--- a/osbs/cli/main.py
+++ b/osbs/cli/main.py
@@ -396,11 +396,34 @@ def cmd_build(args, osbs):
                 print(line)
         except Exception as ex:
             logger.error("Error during fetching logs for build %s: %s", build_id, repr(ex))
+
+        osbs.wait_for_build_to_finish(build_id)
+        _display_build_summary(osbs.get_build(build_id))
     else:
         if args.output == 'json':
             print_json_nicely(build.json)
         elif args.output == 'text':
             print(build_id)
+
+
+def _display_build_summary(build):
+    output = [
+        "",  # Empty line for cleaner display
+        "build {0} is {1}".format(build.get_build_name(), build.status),
+    ]
+
+    if build.is_succeeded():
+        all_repositories = build.get_repositories() or {}
+
+        for kind, repositories in all_repositories.items():
+            if not repositories:
+                continue
+            output.append('{} repositories:'.format(kind))
+            for repository in repositories:
+                output.append('\t{}'.format(repository))
+
+    for line in output:
+        print(line)
 
 
 def cmd_build_logs(args, osbs):


### PR DESCRIPTION
When starting a build via osbs-client from CLI via `build` subcommand, some critical information gets buried in the logs. This is an attempt to provide user the information needed for pulling image built image, and further inspect OpenShift build if needed.

Example for a successful build:
```
build atomic-reactor-hello-world-master-0d3e8-27 is complete
unique repositories:
	registry.example.com/lucarval/docker-hello-world:none-99021-20170703191647
primary repositories:
	registry.example.com/lucarval/docker-hello-world:7.2.lucarval
	registry.example.com/lucarval/docker-hello-world:7.2.lucarval-106
	registry.example.com/lucarval/docker-hello-world:latest
```