### PR TITLE
Handle koji_upload_dir parameter in build request

### DIFF
--- a/osbs/api.py
+++ b/osbs/api.py
@@ -425,6 +425,7 @@ class OSBS(object):
                               customize_conf=None,
                               arrangement_version=None,
                               filesystem_koji_task_id=None,
+                              koji_upload_dir=None,
                               **kwargs):
         df_parser = utils.get_df_parser(git_uri, git_ref, git_branch=git_branch)
         build_request = self.get_build_request(inner_template=inner_template,
@@ -510,7 +511,8 @@ class OSBS(object):
             low_priority_node_selector=self.build_conf.get_low_priority_node_selector(),
             equal_labels=self.build_conf.get_equal_labels(),
             platform_node_selector=self.build_conf.get_platform_node_selector(platform),
-            filesystem_koji_task_id=filesystem_koji_task_id
+            filesystem_koji_task_id=filesystem_koji_task_id,
+            koji_upload_dir=koji_upload_dir,
         )
         build_request.set_openshift_required_version(self.os_conf.get_openshift_required_version())
         if build_request.scratch:

--- a/osbs/build/build_request.py
+++ b/osbs/build/build_request.py
@@ -693,6 +693,8 @@ class BuildRequest(object):
                                       self.spec.builder_openshift_url.value)
             self.dj.dock_json_set_arg('postbuild_plugins', 'koji_upload',
                                       'build_json_dir', self.spec.builder_build_json_dir.value)
+            self.dj.dock_json_set_arg('postbuild_plugins', 'koji_upload',
+                                      'koji_upload_dir', self.spec.koji_upload_dir.value)
             if use_auth is not None:
                 self.dj.dock_json_set_arg('postbuild_plugins', 'koji_upload',
                                           'use_auth', use_auth)

--- a/osbs/build/spec.py
+++ b/osbs/build/spec.py
@@ -173,6 +173,7 @@ class BuildSpec(object):
     info_url_format = BuildParam("info_url_format", allow_none=True)
     artifacts_allowed_domains = BuildParam("artifacts_allowed_domains", allow_none=True)
     equal_labels = BuildParam("equal_labels", allow_none=True)
+    koji_upload_dir = BuildParam("koji_upload_dir", allow_none=True)
 
     def __init__(self):
         self.required_params = [
@@ -223,7 +224,7 @@ class BuildSpec(object):
                    reactor_config_secret=None, client_config_secret=None,
                    token_secrets=None, arrangement_version=None,
                    info_url_format=None, artifacts_allowed_domains=None,
-                   equal_labels=None, **kwargs):
+                   equal_labels=None, koji_upload_dir=None, **kwargs):
         self.git_uri.value = git_uri
         self.git_ref.value = git_ref
         self.user.value = user
@@ -329,6 +330,7 @@ class BuildSpec(object):
         self.artifacts_allowed_domains.value = artifacts_allowed_domains
         self.equal_labels.value = equal_labels
         self.filesystem_koji_task_id.value = filesystem_koji_task_id
+        self.koji_upload_dir.value = koji_upload_dir
 
     def validate(self):
         logger.info("Validating params of %s", self.__class__.__name__)

--- a/tests/build_/test_build_request.py
+++ b/tests/build_/test_build_request.py
@@ -157,6 +157,8 @@ class TestBuildRequest(object):
                 get_plugin(plugins, "postbuild_plugins", "koji_upload")
         else:
             assert get_plugin(plugins, "postbuild_plugins", "koji_upload")
+            assert plugin_value_get(plugins, "postbuild_plugins", "koji_upload", "args",
+                                    "koji_upload_dir")
 
             if use_auth is not None:
                 assert plugin_value_get(plugins, "postbuild_plugins", "koji_upload", "args",
@@ -188,6 +190,7 @@ class TestBuildRequest(object):
             'name_label': 'fedora/resultingimage',
             'registry_api_versions': ['v1'],
             'kojihub': kojihub,
+            'koji_upload_dir': 'upload',
         }
         if use_auth is not None:
             kwargs['use_auth'] = use_auth


### PR DESCRIPTION
This new parameter is needed when creating worker builds when Koji integration is required.

Signed-off-by: Tim Waugh <twaugh@redhat.com>