### PR TITLE
Don't run fetch_worker_metadata for scratch builds

### DIFF
--- a/osbs/build/build_request.py
+++ b/osbs/build/build_request.py
@@ -523,6 +523,7 @@ class BuildRequest(object):
                     ("postbuild_plugins", "tag_from_config"),
                     ("postbuild_plugins", "compress"),  # only for Koji
                     ("postbuild_plugins", "koji_upload"),
+                    ("postbuild_plugins", "fetch_worker_metadata"),
                     ("exit_plugins", "koji_promote"),
                     ("exit_plugins", "koji_tag_build"),
             ]:


### PR DESCRIPTION
Signed-off-by: Tim Waugh <twaugh@redhat.com>

No unit tests because its presence will be tested properly once the new arrangement including the plugin is created.