### PR TITLE
constants: Add logging format for atomic_reactor

### DIFF
--- a/osbs/constants.py
+++ b/osbs/constants.py
@@ -67,3 +67,7 @@ CLI_WATCH_BUILDS_DEFAULT_COLS = ["changetype", "status", "created", "name"]
 
 # number of digits used for unique image tags
 RAND_DIGITS = 5
+
+# Logging format used in Atomic Reactor
+ATOMIC_REACTOR_LOGGING_FMT = \
+    '%(asctime)s platform:%(arch)s - %(name)s - %(levelname)s - %(message)s'


### PR DESCRIPTION
OSBS client will need the atomic_reactor logs in a specific format
in order to parse them correctly.  Control that in osbs-client and
make it available for atomic_reactor to import.