### PR TITLE
Implement retries in osbs-client's HTTP requests

### DIFF
--- a/osbs/api.py
+++ b/osbs/api.py
@@ -16,6 +16,7 @@ import sys
 import warnings
 import getpass
 from functools import wraps
+from contextlib import contextmanager
 
 from osbs.build.build_request import BuildRequest
 from osbs.build.build_response import BuildResponse
@@ -1024,3 +1025,13 @@ class OSBS(object):
         """
         response = self.os.delete_config_map(name)
         return response
+
+    @contextmanager
+    def retries_disabled(self):
+        """
+        Context manager to disable retries on requests
+        :returns: OSBS object
+        """
+        self.os.retries_enabled = False
+        yield
+        self.os.retries_enabled = True

--- a/osbs/constants.py
+++ b/osbs/constants.py
@@ -73,3 +73,11 @@ ATOMIC_REACTOR_LOGGING_FMT = \
     '%(asctime)s platform:%(arch)s - %(name)s - %(levelname)s - %(message)s'
 
 REPO_CONFIG_FILE = '.osbs-repo-config'
+
+# number of retries for http requests
+HTTP_MAX_RETRIES = 3
+
+# how many seconds should request wait for in case non-critical error has occurred
+HTTP_BACKOFF_FACTOR = 2
+
+HTTP_RETRIES_STATUS_FORCELIST = [408, 500, 502, 503, 504]

--- a/osbs/core.py
+++ b/osbs/core.py
@@ -83,8 +83,7 @@ class Openshift(object):
                  verbose=False, username=None, password=None, use_kerberos=False,
                  kerberos_keytab=None, kerberos_principal=None, kerberos_ccache=None,
                  client_cert=None, client_key=None, verify_ssl=True, use_auth=None,
-                 token=None,
-                 namespace=DEFAULT_NAMESPACE):
+                 token=None, namespace=DEFAULT_NAMESPACE):
         self.os_api_url = openshift_api_url
         self.k8s_api_url = k8s_api_url
         self._os_api_version = openshift_api_version
@@ -93,6 +92,7 @@ class Openshift(object):
         self.verbose = verbose
         self.verify_ssl = verify_ssl
         self._con = HttpSession(verbose=self.verbose)
+        self.retries_enabled = True
 
         # auth stuff
         self.use_kerberos = use_kerberos
@@ -190,20 +190,27 @@ class Openshift(object):
 
     def _post(self, url, with_auth=True, **kwargs):
         headers, kwargs = self._request_args(with_auth, **kwargs)
-        return self._con.post(url, headers=headers, verify_ssl=self.verify_ssl, **kwargs)
+        return self._con.post(
+            url, headers=headers, verify_ssl=self.verify_ssl,
+            retries_enabled=self.retries_enabled, **kwargs)
 
     def _get(self, url, with_auth=True, **kwargs):
         headers, kwargs = self._request_args(with_auth, **kwargs)
-        return self._con.get(url, headers=headers, verify_ssl=self.verify_ssl, **kwargs)
+        return self._con.get(
+            url, headers=headers, verify_ssl=self.verify_ssl,
+            retries_enabled=self.retries_enabled, **kwargs)
 
     def _put(self, url, with_auth=True, **kwargs):
         headers, kwargs = self._request_args(with_auth, **kwargs)
-        return self._con.put(url, headers=headers, verify_ssl=self.verify_ssl, **kwargs)
+        return self._con.put(
+            url, headers=headers, verify_ssl=self.verify_ssl,
+            retries_enabled=self.retries_enabled, **kwargs)
 
     def _delete(self, url, with_auth=True, **kwargs):
         headers, kwargs = self._request_args(with_auth, **kwargs)
-        return self._con.delete(url, headers=headers, verify_ssl=self.verify_ssl,
-                                **kwargs)
+        return self._con.delete(
+            url, headers=headers, verify_ssl=self.verify_ssl,
+            retries_enabled=self.retries_enabled, **kwargs)
 
     def get_oauth_token(self):
         url = self.os_oauth_url + "?response_type=token&client_id=openshift-challenging-client"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -153,7 +153,8 @@ class TestOpenshift(object):
         assert len([log for log in logs]) == 1
 
     def test_stream_logs_not_decoded(self, caplog):
-        server = Openshift('/oapi/v1/', 'v1', '/oauth/authorize', k8s_api_url='/api/v1/')
+        server = Openshift('http://oapi/v1/', 'v1', 'http://oauth/authorize',
+                           k8s_api_url='http://api/v1/')
 
         logs = (
             u'Lógs'.encode('utf-8'),


### PR DESCRIPTION
Initial version of retries in http.py

How to test:
 * `sed -i '557s/.*/            response.status = 500 if url.startswith("\/oapi") and method == "GET" and retries._observed_errors == 0 else response.status/' /usr/lib/python2.7/site-packages/urllib3/connectionpool.py` in buildroot and on builder
 * start a build via osbs
 * the build should pass and buildlog should have warning that Openshift requests were retried once, as first request would always return HTTP 500

TODO:
 * [x] Verify that it works on Py3 and Fedora
 * [x] Tests
 * [x] contextmanager with `retries_disabled`
 * [ ] Rewrite exising code using contextmanager