### PR TITLE
koji_import: don't call worker_fetch_metadata in scratch builds

### DIFF
--- a/osbs/build/build_request.py
+++ b/osbs/build/build_request.py
@@ -529,6 +529,7 @@ class BuildRequest(object):
                     ("postbuild_plugins", "tag_from_config"),
                     ("postbuild_plugins", "compress"),  # only for Koji
                     ("postbuild_plugins", "koji_upload"),
+                    ("postbuild_plugins", "fetch_worker_metadata"),
                     ("exit_plugins", "koji_promote"),
                     ("exit_plugins", "koji_import"),
                     ("exit_plugins", "koji_tag_build"),

--- a/tests/build_/test_arrangements.py
+++ b/tests/build_/test_arrangements.py
@@ -631,10 +631,9 @@ class TestArrangementV3(TestArrangementV2):
         plugins = get_plugins_from_build_json(build_json)
 
         if scratch:
-            try:
+            with pytest.raises(NoSuchPluginException):
                 get_plugin(plugins, 'exit_plugins', 'koji_import')
-            except NoSuchPluginException:
-                return
+            return
 
         args = plugin_value_get(plugins, 'exit_plugins',
                                          'koji_import', 'args')
@@ -659,10 +658,9 @@ class TestArrangementV3(TestArrangementV2):
         plugins = get_plugins_from_build_json(build_json)
 
         if scratch:
-            try:
+            with pytest.raises(NoSuchPluginException):
                 get_plugin(plugins, 'postbuild_plugins', 'fetch_worker_metadata')
-            except NoSuchPluginException:
-                return
+            return
 
         args = plugin_value_get(plugins, 'postbuild_plugins',
                                          'fetch_worker_metadata', 'args')


### PR DESCRIPTION
remove worker_fetch_metadata from scratch builds and make sure that
test_arrangement tests is properly.

Signed-off-by: Mark Langsdorf <mlangsdo@redhat.com>