### PR TITLE
Rework travis to make it run in different Fedora/CentOS containers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,36 @@
 language: python
-python:
-  - "2.6"
-  - "2.7"
-  - "3.4"
-  - "3.5"
-# command to install dependencies
-install:
-  - "pip install -U pip"
-  - "pip install -r requirements.txt"
-  - "pip install -r tests/requirements.txt"
-  - "pip install pytest-cov coveralls"
-  - "if [[ ${TRAVIS_PYTHON_VERSION%.*} -gt 2 ]]; then pip install -r requirements-py3.txt; fi"
-# command to run tests
-script: py.test -vv tests --cov osbs
-# run in a docker container
-sudo: false
+sudo: "required"
+services:
+  - docker
+env:
+  matrix:
+    - OS=centos
+      OS_VERSION=6
+      PYTHON_VERSION=2
+    - OS=centos
+      OS_VERSION=7
+      PYTHON_VERSION=2
+    - OS=fedora
+      OS_VERSION=25
+      PYTHON_VERSION=2
+    - OS=fedora
+      OS_VERSION=25
+      PYTHON_VERSION=3
+    - OS=fedora
+      OS_VERSION=26
+      PYTHON_VERSION=2
+    - OS=fedora
+      OS_VERSION=26
+      PYTHON_VERSION=3
+    - OS=fedora
+      OS_VERSION=rawhide
+      PYTHON_VERSION=2
+    - OS=fedora
+      OS_VERSION=rawhide
+      PYTHON_VERSION=3
+script:
+ - pip install coveralls
+ - ./test.sh
+after_success: coveralls
 notifications:
   email: false
-after_success: "coveralls"
-deploy:
-  provider: pypi
-  user: bkabrda
-  on:
-    tags: true
-  password:
-    secure: Q4pXe0ARf2Mj7ZEqEICpzW6SBB554PxVPKErJkUcaD4V3zO3e/Ckbrk0aHeCMCPZlD5i/tfBXRMsMJhcvQht+jXTwUo5VD55WvkKBmpvQbJBsvmrIvrX+3C8SxVYXyLiSklQxCdGMCE/EN9dmQVI2574BQsXR43uVhwOzuL2V3k=

--- a/osbs-client.spec
+++ b/osbs-client.spec
@@ -18,7 +18,7 @@
 %endif
 
 %if 0%{?fedora}
-# rhel/epel has no flexmock, pytest-capturelog
+# rhel/epel has no pytest-capturelog
 %global with_check 1
 %endif
 

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+set -eux
+
+# Prepare env vars
+OS=${OS:="centos"}
+OS_VERSION=${OS_VERSION:="6"}
+PYTHON_VERSION=${PYTHON_VERSION:="2"}
+IMAGE="$OS:$OS_VERSION"
+
+# Pull fedora images from registry.fedoraproject.org
+if [[ $OS == "fedora" ]]; then
+  IMAGE="registry.fedoraproject.org/$IMAGE"
+fi
+
+CONTAINER_NAME="osbs-client-$OS-$OS_VERSION-py$PYTHON_VERSION"
+RUN="docker exec -ti $CONTAINER_NAME"
+if [[ $OS == "fedora" ]]; then
+  if [[ $OS_VERSION == 25 && $PYTHON_VERSION == 2 ]]; then PIP_PKG="python-pip"; else PIP_PKG="python$PYTHON_VERSION-pip"; fi
+  PIP="pip$PYTHON_VERSION"
+  PKG="dnf"
+  PKG_EXTRA="dnf-plugins-core"
+  BUILDDEP="dnf builddep"
+  PYTHON="python$PYTHON_VERSION"
+  PYTEST="py.test-$PYTHON_VERSION"
+else
+  PIP_PKG="python-pip"
+  PIP="pip"
+  PKG="yum"
+  PKG_EXTRA="yum-utils epel-release"
+  BUILDDEP="yum-builddep"
+  PYTHON="python"
+  PYTEST="py.test"
+fi
+# Create container if needed
+if [[ $(docker ps -q -f name=$CONTAINER_NAME | wc -l) -eq 0 ]]; then
+  docker run --name $CONTAINER_NAME -d -v $PWD:$PWD -w $PWD -ti $IMAGE sleep infinity
+fi
+
+# Install dependencies
+$RUN $PKG install -y $PKG_EXTRA
+$RUN $BUILDDEP -y osbs-client.spec
+if [[ $OS != "fedora" ]]; then
+  # Install dependecies for test, as check is disabled for rhel
+  $RUN yum install -y python-flexmock python-six python-dockerfile-parse python-requests python-requests-kerberos
+fi
+
+# Install package
+$RUN $PKG install -y $PIP_PKG
+if [[ $PYTHON_VERSION == 3 && $OS_VERSION == rawhide ]]; then
+  # https://fedoraproject.org/wiki/Changes/Making_sudo_pip_safe
+  $RUN mkdir -p /usr/local/lib/python3.6/site-packages/
+fi
+$RUN $PYTHON setup.py install
+
+# Install packages for tests
+$RUN $PIP install -r tests/requirements.txt
+if [[ $PYTHON_VERSION -gt 2 ]]; then $RUN $PIP install -r requirements-py3.txt; fi
+
+# Run tests
+$RUN $PIP install pytest-cov
+if [[ $OS != "fedora" ]]; then $RUN $PIP install -U pytest-cov; fi
+$RUN $PYTEST -vv tests --cov osbs

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -42,7 +42,8 @@ def has_connection():
 @pytest.mark.skipif(not has_connection(),
                     reason="requires internet connection")
 class TestHttpSession(object):
-    if requests.__version__.startswith('2.6.'):
+    major, minor, patch = requests.__version__.split('.')
+    if int(minor) < 11:
         retry_method_name = 'is_forced_retry'
     else:
         retry_method_name = 'is_retry'


### PR DESCRIPTION
Benefits of this approach:
 * Travis failures can be reproduced locally: `sudo env OS=centos OS_VERSION=7 ./test.sh` or `sudo env OS=fedora OS_VERSION=26 PYTHON_VERSION=3 ./test.sh`. By default it would run tests on CentOS 6
 * Tests would run against actual packages in distributions, not latest from pypi
 * Spec files dependencies are tested as well, so less surprises for Fedora packagers during `%check` phase