### PR TITLE
Fix name of 'running order' test

### DIFF
--- a/tests/build_/test_arrangements.py
+++ b/tests/build_/test_arrangements.py
@@ -56,7 +56,7 @@ class ArrangementBase(object):
         ORCHESTRATOR_INNER_TEMPLATE,
         WORKER_INNER_TEMPLATE,
     ])
-    def test_orchestrator_running_order(self, osbs, template):
+    def test_running_order(self, osbs, template):
         """
         Verify the plugin running order.
 


### PR DESCRIPTION
This tests both worker and orchestrator running orders.

Signed-off-by: Tim Waugh <twaugh@redhat.com>