### PR TITLE
plugins: Move delete_from_registry from worker to orchestrator

### DIFF
--- a/inputs/worker_inner:3.json
+++ b/inputs/worker_inner:3.json
@@ -136,12 +136,6 @@
   ],
   "exit_plugins": [
     {
-      "name": "delete_from_registry",
-      "args": {
-        "registries": {}
-     }
-    },
-    {
       "name": "store_metadata_in_osv3",
       "args": {
         "url": "{{OPENSHIFT_URI}}",

--- a/tests/build_/test_arrangements.py
+++ b/tests/build_/test_arrangements.py
@@ -570,7 +570,6 @@ class TestArrangementV3(TestArrangementV2):
             ],
 
             'exit_plugins': [
-                'delete_from_registry',
                 'store_metadata_in_osv3',
                 'remove_built_image',
             ],
@@ -667,3 +666,24 @@ class TestArrangementV3(TestArrangementV2):
 
         match_args = {}
         assert match_args == args
+
+    @pytest.mark.parametrize('scratch', [False, True])  # noqa:F811
+    @pytest.mark.parametrize('base_image', ['koji/image-build', 'foo'])
+    def test_delete_from_registry(self, osbs_with_pulp, base_image, scratch):
+        phase = 'exit_plugins'
+        plugin = 'delete_from_registry'
+        additional_params = {
+            'base_image': base_image,
+        }
+        if scratch:
+            additional_params['scratch'] = True
+
+        (params, build_json) = self.get_build_request('orchestrator',
+                                                      osbs_with_pulp,
+                                                      additional_params)
+        plugins = get_plugins_from_build_json(build_json)
+        args = plugin_value_get(plugins, phase, plugin, 'args')
+        allowed_args = set([
+            'registries',
+        ])
+        assert set(args.keys()) <= allowed_args


### PR DESCRIPTION
This needs the corresponding atomic_reactor change first.

For arrangement version 3, the delete_from_registry will move from the worker
node to the orchestrator node.  This is to allow the orchestrator to do some
post-processing of the registries before they are deleted.

In order to make this work successfully, the render_pulp_sync needed to split
out the delete_from_registry pieces into its own render_delete_from_registry().

This would allow the rendering to happen regardless of which node the plugin
actually ran in.  Further some tweaks were added to the render function based
on which arrangement version was being used.  This is for backwards compatibility.

Finally the worker_inner json file for inputs and tests were updated to remove
the delete_from_registry plugin on the worker node in arrangement version 3 as
everything should be working correctly now.