### PR TITLE
Remove pulp_pull from scratch build request or when kojhub is not specified

### DIFF
--- a/osbs/build/build_request.py
+++ b/osbs/build/build_request.py
@@ -548,7 +548,8 @@ class BuildRequest(object):
         if self.scratch:
             remove_plugins = [
                 ("prebuild_plugins", "koji_parent"),
-                ("postbuild_plugins", "compress"),  # only for Koji
+                ("postbuild_plugins", "compress"),  # required only to make an archive for Koji
+                ("postbuild_plugins", "pulp_pull"),  # required only to make an archive for Koji
                 ("postbuild_plugins", "koji_upload"),
                 ("postbuild_plugins", "fetch_worker_metadata"),
                 ("exit_plugins", "koji_promote"),
@@ -909,6 +910,11 @@ class BuildRequest(object):
         if not pulp_registry:
             logger.info("removing %s from request, requires pulp_registry", pulp_registry)
             self.dj.remove_plugin(phase, plugin)
+
+        if not self.spec.kojihub.value:
+            logger.info('Removing %s because no kojihub was specified', plugin)
+            self.dj.remove_plugin(phase, plugin)
+            return
 
     def render_pulp_push(self):
         """

--- a/tests/build_/test_build_request.py
+++ b/tests/build_/test_build_request.py
@@ -1060,6 +1060,9 @@ class TestBuildRequest(object):
                 get_plugin(plugins, "postbuild_plugins", "tag_from_config")
 
             with pytest.raises(NoSuchPluginException):
+                get_plugin(plugins, "postbuild_plugins", "pulp_pull")
+
+            with pytest.raises(NoSuchPluginException):
                 get_plugin(plugins, "exit_plugins", "koji_promote")
 
             with pytest.raises(NoSuchPluginException):
@@ -1068,12 +1071,13 @@ class TestBuildRequest(object):
         else:
             assert get_plugin(plugins, "postbuild_plugins", "compress")
             assert get_plugin(plugins, "postbuild_plugins", "tag_from_config")
+            assert get_plugin(plugins, "postbuild_plugins", "pulp_pull")
             assert get_plugin(plugins, "exit_plugins", "koji_promote")
             assert get_plugin(plugins, "exit_plugins", "koji_tag_build")
 
         assert (get_plugin(plugins, "postbuild_plugins", "tag_by_labels")
                 .get('args', {}).get('unique_tag_only', False) == scratch)
-        assert get_plugin(plugins, "postbuild_plugins", "pulp_pull")
+
 
     def test_render_with_yum_repourls(self):
         kwargs = {
@@ -1845,7 +1849,6 @@ class TestBuildRequest(object):
             plugins = get_plugins_from_build_json(build_json)
             assert plugin_value_get(plugins, 'postbuild_plugins', 'pulp_push',
                                     'args', 'pulp_secret_path') == mount_path
-        assert get_plugin(plugins, "postbuild_plugins", "pulp_pull")
 
     def test_render_prod_request_with_koji_secret(self, tmpdir):
         self.create_image_change_trigger_json(str(tmpdir))


### PR DESCRIPTION
pulp_pull is required to set koji metadata only