### PR TITLE
conf: add support for "platform:..." sections

### DIFF
--- a/osbs/api.py
+++ b/osbs/api.py
@@ -469,7 +469,7 @@ class OSBS(object):
             registry_uris=self.build_conf.get_registry_uris(),
             registry_secrets=self.build_conf.get_registry_secrets(),
             source_registry_uri=self.build_conf.get_source_registry_uri(),
-            registry_api_versions=self.build_conf.get_registry_api_versions(),
+            registry_api_versions=self.build_conf.get_registry_api_versions(platform),
             openshift_uri=self.os_conf.get_openshift_base_uri(),
             builder_openshift_url=self.os_conf.get_builder_openshift_url(),
             kojiroot=self.build_conf.get_kojiroot(),
@@ -515,6 +515,7 @@ class OSBS(object):
             platform_node_selector=self.build_conf.get_platform_node_selector(platform),
             filesystem_koji_task_id=filesystem_koji_task_id,
             koji_upload_dir=koji_upload_dir,
+            platform_descriptors=self.build_conf.get_platform_descriptors(),
         )
         build_request.set_openshift_required_version(self.os_conf.get_openshift_required_version())
         build_request.set_repo_info(repo_info)

--- a/osbs/build/build_request.py
+++ b/osbs/build/build_request.py
@@ -64,6 +64,7 @@ class BuildRequest(object):
         self.low_priority_node_selector = None
         # forward reference
         self.platform_node_selector = None
+        self.platform_descriptors = None
 
     def set_params(self, **kwargs):
         """
@@ -91,6 +92,7 @@ class BuildRequest(object):
         :param use_auth: bool, use auth from atomic-reactor?
         :param low_priority_node_selector: dict, a nodeselector for builds with lower priority
         :param platform_node_selector: dict, a nodeselector for a specific platform
+        :param platform_descriptors: dict, platforms and their archiectures and enable_v1 settings
         """
 
         # Here we cater to the koji "scratch" build type, this will disable
@@ -103,6 +105,7 @@ class BuildRequest(object):
         self.base_image = kwargs.get('base_image')
         self.low_priority_node_selector = kwargs.get('low_priority_node_selector')
         self.platform_node_selector = kwargs.get('platform_node_selector', {})
+        self.platform_descriptors = kwargs.get('platform_descriptors', {})
 
         logger.debug("setting params '%s' for %s", kwargs, self.spec)
         self.spec.set_params(**kwargs)
@@ -962,6 +965,42 @@ class BuildRequest(object):
             self.dj.remove_plugin("postbuild_plugins", "pulp_sync")
             self.dj.remove_plugin("exit_plugins", "delete_from_registry")
 
+    def render_group_manifests(self):
+        """
+        Configure the group_manifests plugin. Group is always set to false for now.
+        """
+        if not self.dj.dock_json_has_plugin_conf('postbuild_plugins',
+                                                 'group_manifests'):
+            return
+
+        pulp_registry = self.spec.pulp_registry.value
+        if pulp_registry:
+            self.dj.dock_json_set_arg('postbuild_plugins', 'group_manifests',
+                                      'pulp_registry_name', pulp_registry)
+
+            # Verify we have either a secret or username/password
+            if self.spec.pulp_secret.value is None:
+                conf = self.dj.dock_json_get_plugin_conf('postbuild_plugins',
+                                                         'group_manifests')
+                args = conf.get('args', {})
+                if 'username' not in args:
+                    raise OsbsValidationException("Pulp registry specified "
+                                                  "but no auth config")
+
+            self.dj.dock_json_set_arg('postbuild_plugins', 'group_manifests',
+                                      'group', False)
+            goarch = {}
+            for platform in self.platform_descriptors:
+                goarch[platform] = self.platform_descriptors[platform]['architecture']
+            self.dj.dock_json_set_arg('postbuild_plugins', 'group_manifests',
+                                      'goarch', goarch)
+
+        else:
+            # If no pulp registry is specified, don't run the pulp plugin
+            logger.info("removing group_manifests from request, "
+                        "requires pulp_registry")
+            self.dj.remove_plugin("postbuild_plugins", "group_manifests")
+
     def render_import_image(self, use_auth=None):
         """
         Configure the import_image plugin
@@ -1226,6 +1265,7 @@ class BuildRequest(object):
         self.render_pulp_pull()
         self.render_pulp_push()
         self.render_pulp_sync()
+        self.render_group_manifests()
         self.render_koji_promote(use_auth=use_auth)
         self.render_koji_upload(use_auth=use_auth)
         self.render_koji_import(use_auth=use_auth)


### PR DESCRIPTION
add support to Configuration to parse platform: sections, as described at
http://osbs.readthedocs.io/en/latest/multiarch.html#platform-description.

change get_registry_api_versions to take a platform argument. If there
is a platform argument, only return 'v1' if the configured api version
supports it and that platform value has enable_v1 set to True. Otherwise,
return v2. If the platform doesn't enable v1 and the registry is v1 only,
raise an exception.

Also raise an exception if two platforms have enable_v1 set to true.

A stub instance of render_group_manifests() is included, but since
group_manifests isn't in any of the existing arrangements, it will do
nothing for now in practice.

Signed-off-by: Mark Langsdorf <mlangsdo@redhat.com>