### PR TITLE
osbs/api: add decode parameter to get_build_logs

### DIFF
--- a/osbs/cli/main.py
+++ b/osbs/cli/main.py
@@ -389,7 +389,7 @@ def cmd_build(args, osbs):
     # we need to wait for kubelet to schedule the build, otherwise it's 500
     build = osbs.wait_for_build_to_get_scheduled(build_id)
     if not args.no_logs:
-        build_logs = osbs.get_build_logs(build_id, follow=True)
+        build_logs = osbs.get_build_logs(build_id, follow=True, decode=True)
         if not isinstance(build_logs, collections.Iterable):
             logger.error("'%s' is not iterable; can't display logs", build_logs)
             return
@@ -442,7 +442,8 @@ def cmd_build_logs(args, osbs):
         logs = osbs.get_docker_build_logs(build_id)
     else:
         logs = osbs.get_build_logs(build_id, follow=follow,
-                                   wait_if_missing=args.wait_if_missing)
+                                   wait_if_missing=args.wait_if_missing,
+                                   decode=True)
         if follow:
             for line in logs:
                 print(line)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -820,18 +820,29 @@ class TestOSBS(object):
             osbs.login("", "", "")
 
     # osbs is a fixture here
-    def test_build_logs_api(self, osbs):  # noqa
-        logs = osbs.get_build_logs(TEST_BUILD)
-        assert isinstance(logs, six.binary_type)
-        assert logs == u"líne 1".encode('utf-8')
+    @pytest.mark.parametrize('decode', [True, False])  # noqa
+    def test_build_logs_api(self, osbs, decode):
+        logs = osbs.get_build_logs(TEST_BUILD, decode=decode)
+        if decode:
+            assert isinstance(logs, six.string_types)
+            assert logs == u"líne 1"
+        else:
+            assert isinstance(logs, six.binary_type)
+            assert logs == u"líne 1".encode('utf-8')
 
     # osbs is a fixture here
-    def test_build_logs_api_follow(self, osbs):  # noqa
-        logs = osbs.get_build_logs(TEST_BUILD, follow=True)
+    @pytest.mark.parametrize('decode', [True, False])  # noqa
+    def test_build_logs_api_follow(self, osbs, decode):
+        # decode is actually ignored in the follow=True case
+        logs = osbs.get_build_logs(TEST_BUILD, follow=True, decode=decode)
         assert isinstance(logs, GeneratorType)
         content = next(logs)
-        assert isinstance(content, six.binary_type)
-        assert content == u"líne 1".encode('utf-8')
+        if decode:
+            assert isinstance(content, six.string_types)
+            assert content == u"líne 1"
+        else:
+            assert isinstance(content, six.binary_type)
+            assert content == u"líne 1".encode('utf-8')
         with pytest.raises(StopIteration):
             assert next(logs)
 


### PR DESCRIPTION
This adds support for (utf-8 only) log decoding within the
get_build_logs() api method. Ideally, we would clean up the return types
to be more consistent (None or iterable bytes), but for interoperability
with current atomic-reactor, we'll continue to return either None, bytes,
or an iterable of bytes, entirely dependent on what we're fed by the
self.os.logs() call within get_build_logs().

Note: osbs/cli/main.py's calls to get_build_logs have also been updated to
use decode=True, which is a bit of a behavioral change for end-users, but
probably for the better, since the caller mostly just print out whatever
they're handed back, which should look better if fully decoded. The
behavior of any external caller should remain the same.

Signed-off-by: Jarod Wilson <jarod@redhat.com>