### PR TITLE
conf: fix get_registry_api_version for orchestrator

### DIFF
--- a/osbs/conf.py
+++ b/osbs/conf.py
@@ -272,6 +272,9 @@ class Configuration(object):
                                 "registry_api_versions",
                                 default='v1,v2')
         versions = value.split(',')
+        if platform is None:
+            return versions
+
         section = 'platform:{0}'.format(platform)
         enable_v1 = self._get_value("enable_v1", section, "enable_v1",
                                     default=False, is_bool_val=True)

--- a/tests/build_/test_build_request.py
+++ b/tests/build_/test_build_request.py
@@ -1506,8 +1506,7 @@ class TestBuildRequest(object):
             assert kwargs.get('kojihub') == worker_config.get_kojihub()
             assert kwargs.get('kojiroot') == worker_config.get_kojiroot()
             assert kwargs.get('pulp_registry') == worker_config.get_pulp_registry()
-            # get_registry_api_versions() is not a passthrough of kwargs['registry_api_versions']
-            assert ['v2'] == worker_config.get_registry_api_versions()
+            assert ['v1', 'v2'] == worker_config.get_registry_api_versions()
             assert (kwargs.get('smtp_additional_addresses', []) ==
                     worker_config.get_smtp_additional_addresses())
             assert kwargs.get('smtp_email_domain') == worker_config.get_smtp_email_domain()

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -474,12 +474,12 @@ class TestConfiguration(object):
                     conf.get_platform_descriptors()
 
     @pytest.mark.parametrize(('platform', 'config', 'expected', 'valid'), [
-        (None, {}, ['v2'], True),
-        (None, {'default': {'registry_api_versions': 'v1'}}, ['v1'], False),
+        (None, {}, ['v1', 'v2'], True),
+        (None, {'default': {'registry_api_versions': 'v1'}}, ['v1'], True),
         (None, {'default': {'registry_api_versions': 'v2'}}, ['v2'], True),
-        (None, {'default': {'registry_api_versions': 'v1,v2'}}, ['v2'], True),
+        (None, {'default': {'registry_api_versions': 'v1,v2'}}, ['v1', 'v2'], True),
         ('ham', {'default': {'registry_api_versions': 'v1,v2'}}, ['v2'], True),
-        (None, {'platform:ham': {}}, ['v2'], True),
+        (None, {'platform:ham': {}}, ['v1', 'v2'], True),
         ('ham', {'platform:ham': {}}, ['v2'], True),
         ('ham', {'platform:ham': {'enable_v1': 'true'}}, ['v1', 'v2'], True),
         ('ham', {'default': {'registry_api_versions': 'v1'},


### PR DESCRIPTION
orchestrator builds never have platforms, but should always return the
registry_api_versions values from their config file, or ['v1', 'v2'] if
that is undefined.

Signed-off-by: Mark Langsdorf <mlangsdo@redhat.com>