### PR TITLE
pulp_sync: Update delete_from_registry plugin with new args

### DIFF
--- a/inputs/orchestrator_inner:4.json
+++ b/inputs/orchestrator_inner:4.json
@@ -108,7 +108,9 @@
     {
       "name": "delete_from_registry",
       "args": {
-        "registries": {}
+        "registries": {
+          "{{REGISTRY_URI}}": { "insecure": true }
+        }
       }
     },
     {

--- a/tests/build_/test_arrangements.py
+++ b/tests/build_/test_arrangements.py
@@ -988,7 +988,7 @@ class TestArrangementV4(TestArrangementV3):
         args = plugin_value_get(plugins, phase, plugin, 'args')
 
         docker_registry = self.get_pulp_sync_registry(osbs_with_pulp.build_conf)
-        assert args == {'registries': {docker_registry: {}}}
+        assert args == {'registries': {docker_registry: {'insecure': True}}}
 
     def test_group_manifests(self, openshift):  # noqa:F811
         platform_descriptors = {'x86_64': {'architecture': 'amd64'}}


### PR DESCRIPTION
Moving the delete_from_registry plugin from worker to orchestrator
invovles adding a new arg, 'insecure', to pass in.

The reason is on the worker node, add_docker_registry sets the 'insecure'
flag from another plugin and delete_from_registry just leverages that.

But on the orchestrator, the workflow.push_conf docker registries are
not defined and instead are passed through worker annotations.  Those
annotations do not set 'insecure'.  Change the json file to include
it during 'render'.

The plugin is still backwards compatible with previous arrangement
versions.