### PR TITLE
Fix rendering for Pulp plugins in arrangement version 4

### DIFF
--- a/inputs/orchestrator_inner:4.json
+++ b/inputs/orchestrator_inner:4.json
@@ -109,6 +109,8 @@
     {
       "name": "pulp_publish",
       "args": {
+        "pulp_registry_name": "{{PULP_REGISTRY_NAME}}",
+        "dockpulp_loglevel": "INFO"
       }
     },
     {

--- a/inputs/orchestrator_inner:4.json
+++ b/inputs/orchestrator_inner:4.json
@@ -90,6 +90,8 @@
     {
       "name": "pulp_tag",
       "args": {
+        "pulp_registry_name": "{{PULP_REGISTRY_NAME}}",
+        "dockpulp_loglevel": "INFO"
       }
     },
     {

--- a/inputs/orchestrator_inner:4.json
+++ b/inputs/orchestrator_inner:4.json
@@ -82,6 +82,9 @@
     {
       "name": "group_manifests",
       "args": {
+        "registries": {
+          "{{REGISTRY_URI}}": { "insecure": true }
+        }
       }
     },
     {

--- a/tests/build_/test_arrangements.py
+++ b/tests/build_/test_arrangements.py
@@ -970,7 +970,16 @@ class TestArrangementV4(TestArrangementV3):
         plugins = get_plugins_from_build_json(build_json)
 
         args = plugin_value_get(plugins, 'exit_plugins', 'pulp_publish', 'args')
-        expected_args = {}
+        build_conf = osbs_with_pulp.build_conf
+        pulp_registry_name = build_conf.get_pulp_registry()
+        pulp_secret_path = '/'.join([SECRETS_PATH, build_conf.get_pulp_secret()])
+
+        expected_args = {
+            'pulp_registry_name': pulp_registry_name,
+            'pulp_secret_path': pulp_secret_path,
+            'dockpulp_loglevel': 'INFO',
+        }
+
         assert args == expected_args
 
     def test_pulp_pull(self, osbs_with_pulp):  # noqa:F811

--- a/tests/build_/test_arrangements.py
+++ b/tests/build_/test_arrangements.py
@@ -743,6 +743,7 @@ class TestArrangementV3(TestArrangementV2):
         }
         assert match_args == args
 
+
 class TestArrangementV4(TestArrangementV3):
     """
     Orchestrator build differences from arrangement version 3:
@@ -1002,10 +1003,12 @@ class TestArrangementV4(TestArrangementV3):
         plugins = get_plugins_from_build_json(build_json)
 
         args = plugin_value_get(plugins, 'postbuild_plugins', 'group_manifests', 'args')
+        docker_registry = self.get_pulp_sync_registry(osbs_api.build_conf)
+
         expected_args = {
             'goarch': {'x86_64': 'amd64'},
             'group': False,
-            'pulp_registry_name': osbs_api.build_conf.get_pulp_registry()
+            'registries': {docker_registry: {'insecure': True, 'version': 'v2'}}
         }
         assert args == expected_args
 

--- a/tests/build_/test_arrangements.py
+++ b/tests/build_/test_arrangements.py
@@ -927,8 +927,17 @@ class TestArrangementV4(TestArrangementV3):
         plugins = get_plugins_from_build_json(build_json)
 
         args = plugin_value_get(plugins, 'postbuild_plugins', 'pulp_tag', 'args')
+        build_conf = osbs_with_pulp.build_conf
+        pulp_registry_name = build_conf.get_pulp_registry()
+        pulp_secret_path = '/'.join([SECRETS_PATH, build_conf.get_pulp_secret()])
 
-        assert args == {}
+        expected_args = {
+            'pulp_registry_name': pulp_registry_name,
+            'pulp_secret_path': pulp_secret_path,
+            'dockpulp_loglevel': 'INFO',
+        }
+
+        assert args == expected_args
 
     def test_pulp_sync(self, osbs_with_pulp):  # noqa:F811
         additional_params = {

--- a/tests/build_/test_build_request.py
+++ b/tests/build_/test_build_request.py
@@ -2408,3 +2408,38 @@ class TestBuildRequest(object):
             assert build_json['spec']['nodeSelector'] == expected
         else:
             assert 'nodeSelector' not in build_json['spec']
+
+    @pytest.mark.parametrize(('pulp_registry', 'pulp_secret'), [
+        (True, True),
+        (True, False),
+        (False, True),
+        (False, False),
+    ])
+    def test_render_pulp_tag(self, pulp_registry, pulp_secret):
+        plugin_type = "postbuild_plugins"
+        plugin_name = "pulp_tag"
+
+        br = BuildRequest(INPUTS_PATH)
+        kwargs = get_sample_prod_params()
+        if pulp_registry:
+            kwargs['pulp_registry'] = "registry.example.com"
+        if pulp_secret:
+            kwargs['pulp_secret'] = "pulp_secret"
+        br.set_params(**kwargs)
+
+        br.dj.dock_json_set_param(plugin_type, [])
+        br.dj.add_plugin(plugin_type, plugin_name, {})
+
+        if pulp_registry and not pulp_secret:
+            with pytest.raises(OsbsValidationException):
+                br.render()
+            return
+
+        build_json = br.render()
+        plugins = get_plugins_from_build_json(build_json)
+
+        if pulp_registry:
+            assert get_plugin(plugins, plugin_type, plugin_name)
+        else:
+            with pytest.raises(NoSuchPluginException):
+                get_plugin(plugins, plugin_type, plugin_name)

--- a/tests/build_/test_build_request.py
+++ b/tests/build_/test_build_request.py
@@ -2247,50 +2247,37 @@ class TestBuildRequest(object):
                                 'add_labels_in_dockerfile', 'args',
                                 'info_url_format') == info_url_format
 
-    @pytest.mark.parametrize(('platform_descriptors', 'goarch',
-                              'pulp_registry', 'pulp_secret'), [
-        ({}, {}, True, True),
-        ({}, {}, True, False),
-        ({}, {}, False, True),
-        ({}, {}, False, False),
-        ({'ham': {'architecture': 'ham'}}, {'ham': 'ham'}, True, True),
+    @pytest.mark.parametrize(('platform_descriptors', 'goarch'), [
+        ({}, {}),
+        ({'ham': {'architecture': 'ham'}}, {'ham': 'ham'}),
         ({'ham': {'architecture': 'bacon'}, 'eggs': {'architecture': 'eggs'}},
-         {'ham': 'bacon', 'eggs': 'eggs'}, True, True),
+         {'ham': 'bacon', 'eggs': 'eggs'}),
     ])
-    def test_render_group_manifest(self, platform_descriptors, goarch,
-                                   pulp_registry, pulp_secret):
+    def test_render_group_manifest(self, platform_descriptors, goarch):
         plugin_type = "postbuild_plugins"
         plugin_name = "group_manifests"
 
         br = BuildRequest(INPUTS_PATH)
         kwargs = get_sample_prod_params()
-        if pulp_registry:
-            kwargs['pulp_registry'] = "registry.example.com"
-        if pulp_secret:
-            kwargs['pulp_secret'] = "pulp_secret"
         kwargs['platform_descriptors'] = platform_descriptors
         br.set_params(**kwargs)
+        args = {
+            "registries": {
+                "registry.example.com": {"insecure": True}
+            }
+        }
 
         br.dj.dock_json_set_param(plugin_type, [])
-        br.dj.add_plugin(plugin_type, plugin_name, {})
-
-        if pulp_registry and not pulp_secret:
-            with pytest.raises(OsbsValidationException):
-                br.render()
-            return
+        br.dj.add_plugin(plugin_type, plugin_name, args)
 
         build_json = br.render()
         plugins = get_plugins_from_build_json(build_json)
 
-        if pulp_registry:
-            assert get_plugin(plugins, plugin_type, plugin_name)
-            assert plugin_value_get(plugins, plugin_type, plugin_name, 'args',
-                                    'pulp_registry_name')
-            assert plugin_value_get(plugins, plugin_type, plugin_name, 'args',
-                                    'goarch') == goarch
-        else:
-            with pytest.raises(NoSuchPluginException):
-                get_plugin(plugins, plugin_type, plugin_name)
+        assert get_plugin(plugins, plugin_type, plugin_name)
+        assert plugin_value_get(plugins, plugin_type, plugin_name, 'args',
+                                'registries')
+        assert plugin_value_get(plugins, plugin_type, plugin_name, 'args',
+                                'goarch') == goarch
 
     @pytest.mark.parametrize(('koji_parent_build', 'koji_hub', 'plugin_enabled'), (
         ('fedora-26-9', 'http://hub/', True),

--- a/tests/build_/test_build_request.py
+++ b/tests/build_/test_build_request.py
@@ -1079,7 +1079,6 @@ class TestBuildRequest(object):
         assert (get_plugin(plugins, "postbuild_plugins", "tag_by_labels")
                 .get('args', {}).get('unique_tag_only', False) == scratch)
 
-
     def test_render_with_yum_repourls(self):
         kwargs = {
             'git_uri': TEST_GIT_URI,
@@ -2418,6 +2417,41 @@ class TestBuildRequest(object):
     def test_render_pulp_tag(self, pulp_registry, pulp_secret):
         plugin_type = "postbuild_plugins"
         plugin_name = "pulp_tag"
+
+        br = BuildRequest(INPUTS_PATH)
+        kwargs = get_sample_prod_params()
+        if pulp_registry:
+            kwargs['pulp_registry'] = "registry.example.com"
+        if pulp_secret:
+            kwargs['pulp_secret'] = "pulp_secret"
+        br.set_params(**kwargs)
+
+        br.dj.dock_json_set_param(plugin_type, [])
+        br.dj.add_plugin(plugin_type, plugin_name, {})
+
+        if pulp_registry and not pulp_secret:
+            with pytest.raises(OsbsValidationException):
+                br.render()
+            return
+
+        build_json = br.render()
+        plugins = get_plugins_from_build_json(build_json)
+
+        if pulp_registry:
+            assert get_plugin(plugins, plugin_type, plugin_name)
+        else:
+            with pytest.raises(NoSuchPluginException):
+                get_plugin(plugins, plugin_type, plugin_name)
+
+    @pytest.mark.parametrize(('pulp_registry', 'pulp_secret'), [
+        (True, True),
+        (True, False),
+        (False, True),
+        (False, False),
+    ])
+    def test_render_pulp_publish(self, pulp_registry, pulp_secret):
+        plugin_type = "exit_plugins"
+        plugin_name = "pulp_publish"
 
         br = BuildRequest(INPUTS_PATH)
         kwargs = get_sample_prod_params()


### PR DESCRIPTION
commits to enable group_manifests, pulp_tag, and pulp_publish in arrangement 4.

tested with brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888/mlangsdo/buildroot:eng-rhel-7-docker-candidate-94693-20170816174925, which is a build of pkgs.devel.redhat.com/rpms/osbs-buildroot-docker@private-mlangsdorf-incremental

that uses:
https://github.com/mlangsdorf/atomic-reactor.git@arrangement4
https://github.com/mlangsdorf/osbs-client.git@arrangement4

build logs are here:
https://osbs.qa.engineering.redhat.com:8443/console/project/osbs-stage/browse/builds/helloworld-container-master-9bc2a/helloworld-container-master-9bc2a-77?tab=logs