### PR TITLE
build_request: render_group_manifests now supports true grouping

### DIFF
--- a/docs/configuration_file.md
+++ b/docs/configuration_file.md
@@ -151,6 +151,9 @@ Some options are also mandatory.
 
 * `equal_labels` (*optional*, `string`) — list of equal-preference label groups; if any of each set is missing, aliases will be added to complete the set; label delimiter ':', group delimiter ',' (e.g. `name1:name2:name3, release1:release2, version1:version2`)
 
+* `group_manifests` (*optional*, `boolean`) — whether Atomic Reactor should create manifest lists, default is false
+
+
 ## Build JSON Templates
 
 In the `build_json_dir` there must be `prod.json` and `prod_inner.json` which

--- a/osbs/api.py
+++ b/osbs/api.py
@@ -520,6 +520,7 @@ class OSBS(object):
             koji_upload_dir=koji_upload_dir,
             platform_descriptors=self.build_conf.get_platform_descriptors(),
             koji_parent_build=koji_parent_build,
+            group_manifests=self.os_conf.get_group_manifests(),
         )
         build_request.set_openshift_required_version(self.os_conf.get_openshift_required_version())
         build_request.set_repo_info(repo_info)

--- a/osbs/build/build_request.py
+++ b/osbs/build/build_request.py
@@ -1104,7 +1104,7 @@ class BuildRequest(object):
             del registries[placeholder]
 
         self.dj.dock_json_set_arg('postbuild_plugins', 'group_manifests',
-                                  'group', False)
+                                  'group', self.spec.group_manifests.value)
         goarch = {}
         for platform in self.platform_descriptors:
             goarch[platform] = self.platform_descriptors[platform]['architecture']

--- a/osbs/build/spec.py
+++ b/osbs/build/spec.py
@@ -178,6 +178,7 @@ class BuildSpec(object):
     koji_upload_dir = BuildParam("koji_upload_dir", allow_none=True)
     yum_proxy = BuildParam("yum_proxy", allow_none=True)
     koji_parent_build = BuildParam("koji_parent_build", allow_none=True)
+    group_manifests = BuildParam("group_manifests", allow_none=True)
 
     def __init__(self):
         self.required_params = [
@@ -229,7 +230,7 @@ class BuildSpec(object):
                    token_secrets=None, arrangement_version=None,
                    info_url_format=None, artifacts_allowed_domains=None,
                    equal_labels=None, koji_upload_dir=None, yum_proxy=None,
-                   koji_parent_build=None,
+                   koji_parent_build=None, group_manifests=None,
                    **kwargs):
         self.git_uri.value = git_uri
         self.git_ref.value = git_ref
@@ -286,6 +287,7 @@ class BuildSpec(object):
         self.nfs_dest_dir.value = nfs_dest_dir
         self.git_branch.value = git_branch
         self.name.value = make_name_from_git(self.git_uri.value, self.git_branch.value)
+        self.group_manifests.value = group_manifests or False
         if not base_image:
             raise OsbsValidationException("base_image must be provided")
         self.trigger_imagestreamtag.value = get_imagestreamtag_from_image(base_image)

--- a/osbs/conf.py
+++ b/osbs/conf.py
@@ -286,6 +286,10 @@ class Configuration(object):
     def get_pulp_registry(self):
         return self._get_value("pulp_registry_name", self.conf_section, "pulp_registry_name")
 
+    def get_group_manifests(self):
+        return self._get_value("group_manifests", self.conf_section,
+                               "group_manifests", is_bool_val=True)
+
     def get_build_json_store(self):
         return self._get_value("build_json_dir", GENERAL_CONFIGURATION_SECTION, "build_json_dir")
 

--- a/tests/build_/test_arrangements.py
+++ b/tests/build_/test_arrangements.py
@@ -1011,9 +1011,14 @@ class TestArrangementV4(TestArrangementV3):
         docker_registry = self.get_pulp_sync_registry(osbs_with_pulp.build_conf)
         assert args == {'registries': {docker_registry: {'insecure': True}}}
 
-    def test_group_manifests(self, openshift):  # noqa:F811
+    @pytest.mark.parametrize('group', (  # noqa:F811
+        True,
+        False,
+    ))
+    def test_group_manifests(self, openshift, group):
         platform_descriptors = {'x86_64': {'architecture': 'amd64'}}
-        osbs_api = osbs_with_pulp(openshift, platform_descriptors=platform_descriptors)
+        osbs_api = osbs_with_pulp(openshift, platform_descriptors=platform_descriptors,
+                                  group_manifests=group)
         additional_params = {
             'base_image': 'fedora:latest',
         }
@@ -1025,7 +1030,7 @@ class TestArrangementV4(TestArrangementV3):
 
         expected_args = {
             'goarch': {'x86_64': 'amd64'},
-            'group': False,
+            'group': group,
             'registries': {docker_registry: {'insecure': True, 'version': 'v2'}}
         }
         assert args == expected_args

--- a/tests/fake_api.py
+++ b/tests/fake_api.py
@@ -423,10 +423,16 @@ def osbs(openshift, kwargs=None, additional_config=None, platform_descriptors=No
 
 
 @pytest.fixture
-def osbs_with_pulp(openshift, platform_descriptors=None):
-    additional_config = dedent("""\
-        pulp_registry_name = pulp
-        pulp_secret = secret""")
+def osbs_with_pulp(openshift, platform_descriptors=None, group_manifests=False):
+    if group_manifests:
+        additional_config = dedent("""\
+            pulp_registry_name = pulp
+            pulp_secret = secret
+            group_manifests = true""")
+    else:
+        additional_config = dedent("""\
+            pulp_registry_name = pulp
+            pulp_secret = secret""")
     kwargs = {'registry_uri': 'registry.example.com/v2'}
     return osbs(openshift, kwargs=kwargs,
                 additional_config=additional_config,


### PR DESCRIPTION
set group for post_group_manifests to true when the configuration file
has the pulp_manifest_lists value set to true to indicate the pulp
repository supports manifests lists.

Signed-off-by: Mark Langsdorf <mlangsdo@redhat.com>