### PR TITLE
Add prefer_schema1_digest configuration option

### DIFF
--- a/docs/configuration_file.md
+++ b/docs/configuration_file.md
@@ -153,6 +153,7 @@ Some options are also mandatory.
 
 * `group_manifests` (*optional*, `boolean`) — whether Atomic Reactor should create manifest lists, default is false
 
+* `prefer_schema1_digest` (*optional*, `boolean`) — used by Atomic Reactor's koji_upload plugin when deciding which digest should be used in the image output files for a Koji build
 
 ## Build JSON Templates
 

--- a/osbs/api.py
+++ b/osbs/api.py
@@ -548,6 +548,7 @@ class OSBS(object):
             koji_parent_build=koji_parent_build,
             group_manifests=self.os_conf.get_group_manifests(),
             isolated=isolated,
+            prefer_schema1_digest=self.build_conf.get_prefer_schema1_digest(),
         )
         build_request.set_openshift_required_version(self.os_conf.get_openshift_required_version())
         build_request.set_repo_info(repo_info)

--- a/osbs/build/spec.py
+++ b/osbs/build/spec.py
@@ -179,6 +179,7 @@ class BuildSpec(object):
     yum_proxy = BuildParam("yum_proxy", allow_none=True)
     koji_parent_build = BuildParam("koji_parent_build", allow_none=True)
     group_manifests = BuildParam("group_manifests", allow_none=True)
+    prefer_schema1_digest = BuildParam("prefer_schema1_digest", allow_none=True)
 
     def __init__(self):
         self.required_params = [
@@ -230,7 +231,7 @@ class BuildSpec(object):
                    token_secrets=None, arrangement_version=None,
                    info_url_format=None, artifacts_allowed_domains=None,
                    equal_labels=None, koji_upload_dir=None, yum_proxy=None,
-                   koji_parent_build=None, group_manifests=None,
+                   koji_parent_build=None, group_manifests=None, prefer_schema1_digest=None,
                    **kwargs):
         self.git_uri.value = git_uri
         self.git_ref.value = git_ref
@@ -288,6 +289,7 @@ class BuildSpec(object):
         self.git_branch.value = git_branch
         self.name.value = make_name_from_git(self.git_uri.value, self.git_branch.value)
         self.group_manifests.value = group_manifests or False
+        self.prefer_schema1_digest.value = prefer_schema1_digest
         if not base_image:
             raise OsbsValidationException("base_image must be provided")
         self.trigger_imagestreamtag.value = get_imagestreamtag_from_image(base_image)

--- a/osbs/conf.py
+++ b/osbs/conf.py
@@ -286,6 +286,10 @@ class Configuration(object):
     def get_pulp_registry(self):
         return self._get_value("pulp_registry_name", self.conf_section, "pulp_registry_name")
 
+    def get_prefer_schema1_digest(self):
+        return self._get_value("prefer_schema1_digest", self.conf_section, "prefer_schema1_digest",
+                               is_bool_val=True)
+
     def get_group_manifests(self):
         return self._get_value("group_manifests", self.conf_section,
                                "group_manifests", is_bool_val=True)


### PR DESCRIPTION
When defined, this configuration option is passed to koji_upload
plugin so it can be used in deciding which manifest should be
used in the build output files.
This option is also forwarded to worker builds.

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>