### PR TITLE
Perform stricter validation of additional tags

### DIFF
--- a/osbs/repo_utils.py
+++ b/osbs/repo_utils.py
@@ -14,6 +14,7 @@ from textwrap import dedent
 
 import logging
 import os
+import re
 
 
 logger = logging.getLogger(__name__)
@@ -60,7 +61,7 @@ class AdditionalTagsConfig(object):
     Read specified additional tags from repository.
     """
 
-    INVALID_CHARS = ('-', '{', '}')
+    VALID_TAG_REGEX = re.compile(r'^[\w]{0,127}$')
 
     def __init__(self, dir_path='', file_name=ADDITIONAL_TAGS_FILE):
         self._tags = set()
@@ -83,10 +84,10 @@ class AdditionalTagsConfig(object):
         if not tag:
             return False
 
-        for char in self.INVALID_CHARS:
-            if char in tag:
-                logger.warning('Invalid character, "%s", in additional tag "%s"', char, tag)
-                return False
+        if not self.VALID_TAG_REGEX.match(tag):
+            logger.warning('Invalid additional tag "%s", must match pattern %s',
+                           tag, self.VALID_TAG_REGEX.pattern)
+            return False
 
         return True
 

--- a/tests/test_repo_utils.py
+++ b/tests/test_repo_utils.py
@@ -72,7 +72,7 @@ class TestAdditionalTagsConfig(object):
         assert set(conf.tags) == set(tags)
 
     @pytest.mark.parametrize('bad_tag', [
-        '{bad', 'bad}', '{bad}', 'ba-d', '-bad', 'bad-'
+        '{bad', 'bad}', '{bad}', 'ba-d', '-bad', 'bad-', 'b@d',
     ])
     def test_invalid_tags(self, tmpdir, bad_tag):
         tags = [bad_tag, 'good']


### PR DESCRIPTION
When processing of additional-tags file was moved to
osbs-client from atomic-reactor, the validation check
became more permissive. This commit ports the validation
algorithm from atomic-reactor's tag_from_config plugin.

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>