### PR TITLE
Make import_image remove dockerRepositoryCheck

### DIFF
--- a/osbs/core.py
+++ b/osbs/core.py
@@ -830,7 +830,7 @@ class Openshift(object):
         # Mark it as needing import
         imagestream_json['metadata'].setdefault('annotations', {})
         check_annotation = "openshift.io/image.dockerRepositoryCheck"
-        imagestream_json['metadata']['annotations'][check_annotation] = ''
+        imagestream_json['metadata']['annotations'].pop(check_annotation, None)
         response = self._put(url, data=json.dumps(imagestream_json),
                              use_json=True)
         check_response(response)


### PR DESCRIPTION
The API method import_image is used to force OpenShift to
update the tags tracked in the corresponding ImageStream
object. To do so, the following annotation is cleared:
    "openshift.io/image.dockerRepositoryCheck"
The problem addressed by this commit is that in the case
an ImageStream does not pick up new tags, the API method
may hang indefinitely. Removing this annotation causes
OpenShift to actually "force" the import and reset the
annotation.