### PR TITLE
tests: update has_connection detecting

### DIFF
--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -33,9 +33,9 @@ def has_connection():
         return False
 
     try:
-        HttpStream("https://httpbin.org/get", "get")
+        HttpStream("https://httpbin.org/get", "get", retries_enabled=False)
         return True
-    except OsbsNetworkException:
+    except (OsbsNetworkException, requests.exceptions.ConnectionError):
         return False
 
 

--- a/tests/test_retries.py
+++ b/tests/test_retries.py
@@ -38,9 +38,9 @@ def has_connection():
         return False
 
     try:
-        HttpStream("https://httpbin.org/get", "get")
+        HttpStream("https://httpbin.org/get", "get", retries_enabled=False)
         return True
-    except OsbsNetworkException:
+    except (OsbsNetworkException, requests.exceptions.ConnectionError):
         return False
 
 


### PR DESCRIPTION
This breaks tests on Fedora's koji, as tests are being run there
without network access.

This PR does the following:
* Don't retry when detecting if network connection is available
* Trap `requests.exceptions.ConnectionError` as its being thrown too.

Test build in Fedora: https://koji.fedoraproject.org/koji/taskinfo?taskID=22993054

Signed-off-by: Vadim Rutkovsky <vrutkovs@redhat.com>