### PR TITLE
Convert the value of --compose-id to int

### DIFF
--- a/osbs/cli/main.py
+++ b/osbs/cli/main.py
@@ -723,7 +723,7 @@ def cli():
     build_parser.add_argument('--signing-intent', action='store', required=False,
                               help='override signing intent of ODCS composes')
     build_parser.add_argument("--compose-id", action='append', required=False,
-                              dest="compose_ids", help="ODCS compose"
+                              dest="compose_ids", type=int, help="ODCS compose"
                               "used, may be used multiple times")
 
     worker_group = build_parser.add_argument_group(title='arguments for --worker',


### PR DESCRIPTION
When triggering builds with osbs-client cli and using the
--compose-id option to specify composes to be used,
the following TypeError is raised when logging the ID of
a compose which is going to be renewed:

TypeError: %d format: a number is required, not unicode

This is due to the compose IDs being received as unicode
strings from the cli.

Setting the type for the argument to int solves this issue.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>