### PR TITLE
Added possibility to override image tags via container.yaml file.

### DIFF
--- a/osbs/api.py
+++ b/osbs/api.py
@@ -496,7 +496,7 @@ class OSBS(object):
         return req_labels, df_parser.baseimage
 
     def _get_flatpak_labels(self, repo_info):
-        modules = repo_info.configuration.compose_data.get('modules', [])
+        modules = repo_info.configuration.container.get('compose', {}).get('modules', [])
 
         if modules:
             source_spec = modules[0]

--- a/osbs/build/build_request.py
+++ b/osbs/build/build_request.py
@@ -1072,6 +1072,8 @@ class BuildRequest(object):
             elif self.isolated:
                 tag_suffixes['primary'].extend(['{version}-{release}'])
             elif tags:
+                assert '{version}-{release}' in tags, \
+                    'Unable to find {version}-{release} in tags from container.yaml'
                 tag_suffixes['primary'].extend(tags)
             else:
                 tag_suffixes['primary'].extend(['latest', '{version}', '{version}-{release}'])

--- a/osbs/build/build_request.py
+++ b/osbs/build/build_request.py
@@ -1060,25 +1060,14 @@ class BuildRequest(object):
         unique_tag = self.spec.image_tag.value.split(':')[-1]
         tag_suffixes = {'unique': [unique_tag], 'primary': []}
 
-        # this part is very ugly but otherwise ~900 tests will fail
-        # as self.repo_info object is not injected properly
-        tags = []
-        if self._repo_info:
-            tags = self._repo_info.configuration.container.get('tags', [])
-
         if self.spec.build_type.value == BUILD_TYPE_ORCHESTRATOR:
             if self.scratch:
                 pass
             elif self.isolated:
                 tag_suffixes['primary'].extend(['{version}-{release}'])
-            elif tags:
+            elif self._repo_info.additional_tags.from_container_yaml:
                 tag_suffixes['primary'].extend(['{version}-{release}'])
-                for tag in tags:
-                    assert '-' not in tag, \
-                        'Tag from container.yaml cannot contain "-" character. ' \
-                        'Provided tag was "%s"' % tag
-
-                tag_suffixes['primary'].extend(tags)
+                tag_suffixes['primary'].extend(self._repo_info.additional_tags.tags)
             else:
                 tag_suffixes['primary'].extend(['latest', '{version}', '{version}-{release}'])
                 tag_suffixes['primary'].extend(self._repo_info.additional_tags.tags)

--- a/osbs/build/build_request.py
+++ b/osbs/build/build_request.py
@@ -1072,8 +1072,12 @@ class BuildRequest(object):
             elif self.isolated:
                 tag_suffixes['primary'].extend(['{version}-{release}'])
             elif tags:
-                assert '{version}-{release}' in tags, \
-                    'Unable to find {version}-{release} in tags from container.yaml'
+                tag_suffixes['primary'].extend(['{version}-{release}'])
+                for tag in tags:
+                    assert '-' not in tag, \
+                        'Tag from container.yaml cannot contain "-" character. ' \
+                        'Provided tag was "%s"' % tag
+
                 tag_suffixes['primary'].extend(tags)
             else:
                 tag_suffixes['primary'].extend(['latest', '{version}', '{version}-{release}'])

--- a/osbs/build/build_request.py
+++ b/osbs/build/build_request.py
@@ -1060,11 +1060,19 @@ class BuildRequest(object):
         unique_tag = self.spec.image_tag.value.split(':')[-1]
         tag_suffixes = {'unique': [unique_tag], 'primary': []}
 
+        # this part is very ugly but otherwise ~900 tests will fail
+        # as self.repo_info object is not injected properly
+        tags = []
+        if self._repo_info:
+            tags = self._repo_info.configuration.container.get('tags', [])
+
         if self.spec.build_type.value == BUILD_TYPE_ORCHESTRATOR:
             if self.scratch:
                 pass
             elif self.isolated:
                 tag_suffixes['primary'].extend(['{version}-{release}'])
+            elif tags:
+                tag_suffixes['primary'].extend(tags)
             else:
                 tag_suffixes['primary'].extend(['latest', '{version}', '{version}-{release}'])
                 tag_suffixes['primary'].extend(self._repo_info.additional_tags.tags)

--- a/osbs/repo_utils.py
+++ b/osbs/repo_utils.py
@@ -45,7 +45,7 @@ class RepoConfiguration(object):
     def __init__(self, dir_path='', file_name=REPO_CONFIG_FILE):
 
         self._config_parser = ConfigParser()
-        self.compose_data = {}
+        self.container = {}
 
         # Set default options
         self._config_parser.readfp(StringIO(self.DEFAULT_CONFIG))
@@ -57,7 +57,7 @@ class RepoConfiguration(object):
         file_path = os.path.join(dir_path, REPO_CONTAINER_CONFIG)
         if os.path.exists(file_path):
             with open(file_path) as f:
-                self.compose_data = (yaml.load(f) or {}).get('compose')
+                self.container = (yaml.load(f) or {})
 
     def is_autorebuild_enabled(self):
         return self._config_parser.getboolean('autorebuild', 'enabled')

--- a/osbs/utils.py
+++ b/osbs/utils.py
@@ -247,7 +247,8 @@ def get_repo_info(git_uri, git_ref, git_branch=None):
     with checkout_git_repo(git_uri, git_ref, git_branch) as code_dir:
         dfp = DockerfileParser(os.path.join(code_dir), cache_content=True)
         config = RepoConfiguration(dir_path=code_dir)
-        tags_config = AdditionalTagsConfig(dir_path=code_dir)
+        tags_config = AdditionalTagsConfig(dir_path=code_dir,
+                                           tags=config.container.get('tags', set()))
     return RepoInfo(dfp, config, tags_config)
 
 

--- a/tests/build_/test_arrangements.py
+++ b/tests/build_/test_arrangements.py
@@ -52,8 +52,10 @@ class ArrangementBase(object):
             baseimage = base_image
 
         class MockConfiguration(object):
-            compose_data = {
-                'modules': ['mod_name:mod_stream:mod_version']
+            container = {
+                'compose': {
+                    'modules': ['mod_name:mod_stream:mod_version']
+                }
             }
 
             def is_autorebuild_enabled(self):

--- a/tests/build_/test_build_request.py
+++ b/tests/build_/test_build_request.py
@@ -1457,6 +1457,33 @@ class TestBuildRequest(object):
         assert len(tag_suffixes['primary']) == len(expected_primary)
         assert set(tag_suffixes['primary']) == expected_primary
 
+    def test_render_tag_from_container_yaml(self):
+        kwargs = get_sample_prod_params()
+        kwargs.pop('platform', None)
+
+        kwargs['platforms'] = ['x86_64', 'ppc64le']
+        kwargs['build_type'] = BUILD_TYPE_ORCHESTRATOR
+        kwargs['arrangement_version'] = 3
+
+        expected_primary = set(['spam', 'bacon', 'eggs'])
+
+        class MockDfParser(object):
+            labels = {'label': 'foo'}
+
+        repo_info = RepoInfo(MockDfParser)
+
+        repo_info.configuration = flexmock(
+            is_autorebuild_enabled=lambda: True)
+        repo_info.configuration.container = {'tags': ['spam', 'bacon', 'eggs']}
+
+        build_json = self._render_tag_from_config_build_request(kwargs, repo_info=repo_info)
+        plugins = get_plugins_from_build_json(build_json)
+
+        tag_suffixes = plugin_value_get(plugins, 'postbuild_plugins', 'tag_from_config',
+                                        'args', 'tag_suffixes')
+        assert len(tag_suffixes['primary']) == len(expected_primary)
+        assert set(tag_suffixes['primary']) == expected_primary
+
     def test_render_tag_from_config_unmodified(self):
         kwargs = get_sample_prod_params()
         kwargs.pop('platform', None)

--- a/tests/build_/test_build_request.py
+++ b/tests/build_/test_build_request.py
@@ -1465,6 +1465,7 @@ class TestBuildRequest(object):
         kwargs['build_type'] = BUILD_TYPE_ORCHESTRATOR
         kwargs['arrangement_version'] = 3
 
+        tags = set(['spam', 'bacon', 'eggs'])
         expected_primary = set(['{version}-{release}', 'spam', 'bacon', 'eggs'])
 
         class MockDfParser(object):
@@ -1474,7 +1475,7 @@ class TestBuildRequest(object):
 
         repo_info.configuration = flexmock(
             is_autorebuild_enabled=lambda: True)
-        repo_info.configuration.container = {'tags': expected_primary}
+        repo_info.configuration.container = {'tags': tags}
 
         build_json = self._render_tag_from_config_build_request(kwargs, repo_info=repo_info)
         plugins = get_plugins_from_build_json(build_json)
@@ -1484,7 +1485,7 @@ class TestBuildRequest(object):
         assert len(tag_suffixes['primary']) == len(expected_primary)
         assert set(tag_suffixes['primary']) == expected_primary
 
-    def test_render_tag_from_container_yaml_missing_version_release(self):
+    def test_render_tag_from_container_yaml_contains_hyphen(self):
         kwargs = get_sample_prod_params()
         kwargs.pop('platform', None)
 
@@ -1492,7 +1493,7 @@ class TestBuildRequest(object):
         kwargs['build_type'] = BUILD_TYPE_ORCHESTRATOR
         kwargs['arrangement_version'] = 3
 
-        expected_primary = set(['spam', 'bacon', 'eggs'])
+        expected_primary = set(['sp-am', 'bacon', 'eggs'])
 
         class MockDfParser(object):
             labels = {'label': 'foo'}
@@ -1503,9 +1504,8 @@ class TestBuildRequest(object):
             is_autorebuild_enabled=lambda: True)
         repo_info.configuration.container = {'tags': expected_primary}
 
-        with pytest.raises(AssertionError) as ex:
+        with pytest.raises(AssertionError):
             self._render_tag_from_config_build_request(kwargs, repo_info=repo_info)
-            assert ex.value == 'Unable to find {version}-{release} in tags from container.yaml'
 
     def test_render_tag_from_config_unmodified(self):
         kwargs = get_sample_prod_params()

--- a/tests/build_/test_build_request.py
+++ b/tests/build_/test_build_request.py
@@ -1465,6 +1465,33 @@ class TestBuildRequest(object):
         kwargs['build_type'] = BUILD_TYPE_ORCHESTRATOR
         kwargs['arrangement_version'] = 3
 
+        expected_primary = set(['{version}-{release}', 'spam', 'bacon', 'eggs'])
+
+        class MockDfParser(object):
+            labels = {'label': 'foo'}
+
+        repo_info = RepoInfo(MockDfParser)
+
+        repo_info.configuration = flexmock(
+            is_autorebuild_enabled=lambda: True)
+        repo_info.configuration.container = {'tags': expected_primary}
+
+        build_json = self._render_tag_from_config_build_request(kwargs, repo_info=repo_info)
+        plugins = get_plugins_from_build_json(build_json)
+
+        tag_suffixes = plugin_value_get(plugins, 'postbuild_plugins', 'tag_from_config',
+                                        'args', 'tag_suffixes')
+        assert len(tag_suffixes['primary']) == len(expected_primary)
+        assert set(tag_suffixes['primary']) == expected_primary
+
+    def test_render_tag_from_container_yaml_missing_version_release(self):
+        kwargs = get_sample_prod_params()
+        kwargs.pop('platform', None)
+
+        kwargs['platforms'] = ['x86_64', 'ppc64le']
+        kwargs['build_type'] = BUILD_TYPE_ORCHESTRATOR
+        kwargs['arrangement_version'] = 3
+
         expected_primary = set(['spam', 'bacon', 'eggs'])
 
         class MockDfParser(object):
@@ -1474,15 +1501,11 @@ class TestBuildRequest(object):
 
         repo_info.configuration = flexmock(
             is_autorebuild_enabled=lambda: True)
-        repo_info.configuration.container = {'tags': ['spam', 'bacon', 'eggs']}
+        repo_info.configuration.container = {'tags': expected_primary}
 
-        build_json = self._render_tag_from_config_build_request(kwargs, repo_info=repo_info)
-        plugins = get_plugins_from_build_json(build_json)
-
-        tag_suffixes = plugin_value_get(plugins, 'postbuild_plugins', 'tag_from_config',
-                                        'args', 'tag_suffixes')
-        assert len(tag_suffixes['primary']) == len(expected_primary)
-        assert set(tag_suffixes['primary']) == expected_primary
+        with pytest.raises(AssertionError) as ex:
+            self._render_tag_from_config_build_request(kwargs, repo_info=repo_info)
+            assert ex.value == 'Unable to find {version}-{release} in tags from container.yaml'
 
     def test_render_tag_from_config_unmodified(self):
         kwargs = get_sample_prod_params()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1689,8 +1689,10 @@ class TestOSBS(object):
     ))
     def test_create_build_flatpak(self, osbs, modules):
         class MockConfiguration(object):
-            compose_data = {
-                'modules': modules
+            container = {
+                'compose': {
+                    'modules': modules
+                }
             }
 
             def is_autorebuild_enabled(self):
@@ -2108,8 +2110,10 @@ class TestOSBS(object):
         }
 
         class MockConfiguration(object):
-            compose_data = {
-                'modules': ['mod_name:mod_stream:mod_version']
+            container = {
+                'compose': {
+                    'modules': ['mod_name:mod_stream:mod_version']
+                }
             }
 
             def is_autorebuild_enabled(self):


### PR DESCRIPTION
If container.yaml file in the git repository contains tags section,
resulting image is created with these tags only.

Signed-off-by: David Becvarik <dbecvari@redhat.com>

As this is working, if the tags are missing image-version tag it will die in this [this assertion](https://github.com/projectatomic/atomic-reactor/blob/56299e323d9904248746282569a9c32f5353c547/atomic_reactor/plugins/exit_koji_import.py#L294).
I don't have a deep understanding how to solve this issue, because I'm missing bigger picture how whole OSBS/koji works inside. 
I've noticed that for scratch build this plugin is not used? 
Can we also disable it for this custom tags builds (but this feels very weird)?

@goldmann Or maybe, we can add this tag as always present ? 