### PR TITLE
render_import_image: fix logic for checking imagestream_name/url

### DIFF
--- a/osbs/build/build_request.py
+++ b/osbs/build/build_request.py
@@ -1303,7 +1303,7 @@ class BuildRequest(object):
         plugin = 'import_image'
 
         for phase in phases:
-            if self.spec.imagestream_name is None or self.spec.imagestream_url is None:
+            if self.spec.imagestream_name.value is None or self.spec.imagestream_url.value is None:
                 logger.info("removing %s from request, "
                             "registry or repo url is not defined", plugin)
                 self.dj.remove_plugin(phase, plugin)

--- a/tests/build_/test_arrangements.py
+++ b/tests/build_/test_arrangements.py
@@ -1140,6 +1140,11 @@ class TestArrangementV4(TestArrangementV3):
         assert config_kwargs['pdc_url'] == pdc_url
         assert config_kwargs['pdc_insecure'] == str(pdc_insecure)
 
+        with pytest.raises(NoSuchPluginException):
+            get_plugin(plugins, "postbuild_plugins", "import_image")
+        with pytest.raises(NoSuchPluginException):
+            get_plugin(plugins, "exit_plugins", "import_image")
+
     @pytest.mark.parametrize('worker', [True, False])  # noqa:F811
     def test_not_flatpak(self, osbs, worker):
         additional_params = {

--- a/tests/build_/test_build_request.py
+++ b/tests/build_/test_build_request.py
@@ -1245,6 +1245,8 @@ class TestBuildRequest(object):
         assert get_plugin(plugins, "prepublish_plugins", "flatpak_create_oci")
         with pytest.raises(NoSuchPluginException):
             assert get_plugin(plugins, "prepublish_plugins", "squash")
+        with pytest.raises(NoSuchPluginException):
+            assert get_plugin(plugins, "postbuild_plugins", "import_image")
 
     def test_render_prod_not_flatpak(self):
         build_request = BuildRequest(INPUTS_PATH)
@@ -1283,6 +1285,7 @@ class TestBuildRequest(object):
         with pytest.raises(NoSuchPluginException):
             get_plugin(plugins, "prepublish_plugins", "flatpak_create_oci")
         assert get_plugin(plugins, "prepublish_plugins", "squash")
+        assert get_plugin(plugins, "postbuild_plugins", "import_image")
 
     @pytest.mark.parametrize(('hub', 'disabled', 'release'), (
         ('http://hub/', False, None),


### PR DESCRIPTION
The code was checking for spec.imagestream_name is None not
spec.imagestream_name.value is None - this was never noticed because
spec.imagestream_name is now always set except for Flatpak builds and
previously, a different check was removing the plugin first.

Check in tests that the plugin is properly removed for Flatpak builds.