### PR TITLE
 Don't exclude the 'koji' plugin for Flatpaks

### DIFF
--- a/inputs/worker_inner:4.json
+++ b/inputs/worker_inner:4.json
@@ -6,7 +6,6 @@
       "args": {
         "module_name": "{{MODULE_NAME}}",
         "module_stream": "{{MODULE_STREAM}}",
-        "compose_id": "{{COMPOSE_ID}}",
         "odcs_url": "{{ODCS_URL}}",
         "odcs_insecure": "{{ODCS_INSECURE}}",
         "pdc_url": "{{PDC_URL}}",

--- a/osbs/build/build_request.py
+++ b/osbs/build/build_request.py
@@ -818,10 +818,6 @@ class BuildRequest(object):
             logger.info("removing koji from request "
                         "because there is yum repo specified")
             self.dj.remove_plugin(phase, plugin)
-        elif self.spec.flatpak.value:
-            logger.info("removing koji from request "
-                        "because this is a Flatpak built from a module")
-            self.dj.remove_plugin(phase, plugin)
         elif not (self.spec.koji_target.value and
                   self.spec.kojiroot.value and
                   self.spec.kojihub.value):

--- a/tests/build_/test_build_request.py
+++ b/tests/build_/test_build_request.py
@@ -1236,6 +1236,12 @@ class TestBuildRequest(object):
         args = plugin['args']
         assert args['base_image'] == TEST_FLATPAK_BASE_IMAGE
 
+        plugin = get_plugin(plugins, "prebuild_plugins", "koji")
+        assert plugin
+
+        args = plugin['args']
+        assert args['target'] == "koji-target"
+
         plugin = get_plugin(plugins, "prebuild_plugins", "bump_release")
         assert plugin
 


### PR DESCRIPTION
With the switch to "hybrid" modularity in Fedora, modules typically need
to pull packages from a base package set as well. The build tag of the
Koji target provides a way to pass in an appropriate base package set, so
we'll use the 'koji' plugin for that.
