### PR TITLE
Arrangement 6: Add support for BuildUserParams, BuildRequestV2, and PluginsConfiguration

### DIFF
--- a/inputs/orchestrator_inner:7.json
+++ b/inputs/orchestrator_inner:7.json
@@ -1,0 +1,154 @@
+{
+  "client_version": "{{VERSION}}",
+  "prebuild_plugins": [
+    {
+      "name": "reactor_config"
+    },
+    {
+      "name": "resolve_module_compose"
+    },
+    {
+      "name": "flatpak_create_dockerfile",
+      "args": {
+        "base_image": "{{BASE_IMAGE}}"
+      }
+    },
+    {
+      "name": "add_filesystem",
+      "args": {
+        "repos": []
+      }
+    },
+    {
+      "name": "inject_parent_image",
+      "args": {
+        "koji_parent_build": "{{KOJI_PARENT_BUILD}}"
+      }
+    },
+    {
+      "name": "pull_base_image",
+      "args": {
+        "parent_registry_insecure": true
+      }
+    },
+    {
+      "name": "bump_release"
+    },
+    {
+      "name": "add_labels_in_dockerfile",
+      "args": {
+        "labels": "{{IMPLICIT_LABELS}}"
+      }
+    },
+    {
+      "name": "koji_parent",
+      "required": false
+    },
+    {
+      "name": "check_and_set_rebuild",
+      "args": {
+        "label_key": "is_autorebuild",
+        "label_value": "true",
+        "verify_ssl": false
+      }
+    },
+    {
+      "name": "resolve_composes",
+      "required": false
+    }
+  ],
+  "buildstep_plugins": [
+    {
+      "name": "orchestrate_build",
+      "args": {
+        "platforms": "{{PLATFORMS}}",
+        "build_kwargs": "{{BUILD_KWARGS}}",
+        "osbs_client_config": "{{OSBS_CLIENT_CONFIG}}"
+      }
+    }
+  ],
+  "postbuild_plugins": [
+    {
+      "name": "fetch_worker_metadata"
+    },
+    {
+      "name": "compare_components"
+    },
+    {
+      "name": "tag_from_config",
+      "args": {
+        "tag_suffixes": "{{TAG_SUFFIXES}}"
+      }
+    },
+    {
+      "name": "group_manifests"
+    },
+    {
+      "name": "pulp_tag"
+    },
+    {
+      "name": "pulp_sync",
+      "args": {
+        "dockpulp_loglevel": "INFO",
+        "publish": false
+      }
+    }
+  ],
+  "prepublish_plugins": [],
+  "exit_plugins": [
+    {
+      "name": "pulp_publish",
+      "args": {
+        "dockpulp_loglevel": "INFO"
+      }
+    },
+    {
+      "name": "pulp_pull",
+      "args": {
+        "insecure": true
+      }
+    },
+    {
+      "name": "import_image",
+      "args": {
+        "imagestream": "{{IMAGESTREAM}}",
+        "verify_ssl": false,
+        "build_json_dir": "{{PATH}}"
+      },
+      "required": false
+    },
+    {
+      "name": "delete_from_registry"
+    },
+    {
+      "name": "koji_import",
+      "args": {
+        "verify_ssl": false,
+        "koji_keytab": false
+      }
+    },
+    {
+      "name": "koji_tag_build",
+      "args": {
+        "koji_keytab": false,
+        "koji_principal": false
+      }
+    },
+    {
+      "name": "store_metadata_in_osv3",
+      "args": {
+        "verify_ssl": false
+      }
+    },
+    {
+      "name": "sendmail"
+    },
+    {
+      "name": "remove_built_image"
+    },
+    {
+      "name": "remove_worker_metadata",
+      "required": false
+    }
+  ]
+}

--- a/inputs/worker_inner:7.json
+++ b/inputs/worker_inner:7.json
@@ -1,0 +1,123 @@
+{
+  "prebuild_plugins": [
+    {
+      "name": "resolve_module_compose"
+    },
+    {
+      "name": "flatpak_create_dockerfile",
+      "args": {
+        "base_image": "{{BASE_IMAGE}}"
+      }
+    },
+    {
+      "name": "add_filesystem",
+      "args": {
+        "repos": [],
+        "from_task_id": "{{FROM_TASK_ID}}"
+      }
+    },
+    {
+      "name": "inject_parent_image",
+      "args": {
+        "koji_parent_build": "{{KOJI_PARENT_BUILD}}"
+      }
+    },
+    {
+      "name": "pull_base_image"
+    },
+    {
+      "name": "add_labels_in_dockerfile",
+      "args": {
+        "labels": "{{IMPLICIT_LABELS}}"
+      }
+    },
+    {
+      "name": "change_from_in_dockerfile"
+    },
+    {
+      "name": "add_help"
+    },
+    {
+      "name": "add_dockerfile"
+    },
+    {
+      "name": "distgit_fetch_artefacts"
+    },
+    {
+      "name": "fetch_maven_artifacts"
+    },
+    {
+      "name": "koji",
+      "args": {
+        "target": "{{KOJI_TARGET}}"
+      }
+    },
+    {
+      "name": "add_yum_repo_by_url",
+      "args": {
+        "repourls": []
+      }
+    },
+    {
+      "name": "inject_yum_repo"
+    },
+    {
+      "name": "distribution_scope"
+    }
+  ],
+  "prepublish_plugins": [
+    {
+      "name": "squash"
+    },
+    {
+      "name": "flatpak_create_oci"
+    }
+  ],
+  "postbuild_plugins": [
+    {
+      "name": "all_rpm_packages",
+      "args": {
+        "image_id": "BUILT_IMAGE_ID"
+      }
+    },
+    {
+      "name": "tag_from_config",
+      "args": {
+        "tag_suffixes": "{{TAG_SUFFIXES}}"
+      }
+    },
+    {
+      "name": "tag_and_push"
+    },
+    {
+      "name": "pulp_push"
+    },
+    {
+      "name": "compress",
+      "args": {
+        "load_exported_image": true,
+        "method": "gzip"
+      }
+    },
+    {
+      "name": "koji_upload",
+      "args": {
+        "verify_ssl": false,
+        "blocksize": 10485760,
+        "koji_keytab": false,
+        "koji_principal": false
+      }
+    }
+  ],
+  "exit_plugins": [
+    {
+      "name": "store_metadata_in_osv3",
+      "args": {
+        "verify_ssl": false
+      }
+    },
+    {
+      "name": "remove_built_image"
+    }
+  ]
+}

--- a/osbs/api.py
+++ b/osbs/api.py
@@ -22,6 +22,8 @@ from types import GeneratorType
 
 from osbs.build.build_request import BuildRequest
 from osbs.build.build_requestv2 import BuildRequestV2
+from osbs.build.user_params import BuildUserParams
+from osbs.build.plugins_configuration import PluginsConfiguration
 from osbs.build.build_response import BuildResponse
 from osbs.build.pod_response import PodResponse
 from osbs.build.config_map_response import ConfigMapResponse
@@ -1218,3 +1220,9 @@ class OSBS(object):
         self.os.retries_enabled = False
         yield
         self.os.retries_enabled = True
+
+    @osbsapi
+    def render_plugins_configuration(self, user_params_json):
+        user_params = BuildUserParams.from_json(user_params_json)
+
+        return PluginsConfiguration(user_params).render()

--- a/osbs/build/build_request.py
+++ b/osbs/build/build_request.py
@@ -291,8 +291,8 @@ class BuildRequest(object):
             'pulp_registry_name': self.spec.pulp_registry.value,
             'prefer_schema1_digest': self.spec.prefer_schema1_digest.value,
             'registry_api_versions': ','.join(self.spec.registry_api_versions.value or []) or None,
-            'smtp_additional_addresses': ','.join(self.spec.smtp_additional_addresses.value or [])
-                                         or None,
+            'smtp_additional_addresses': ','.join(self.spec.smtp_additional_addresses.value or
+                                                  []) or None,
             'smtp_email_domain': self.spec.smtp_email_domain.value,
             'smtp_error_addresses': ','.join(self.spec.smtp_error_addresses.value or []) or None,
             'smtp_from': self.spec.smtp_from.value,
@@ -303,8 +303,8 @@ class BuildRequest(object):
             'sources_command': self.spec.sources_command.value,
             'vendor': self.spec.vendor.value,
             'equal_labels': equal_labels_string,
-            'artifacts_allowed_domains': ','.join(self.spec.artifacts_allowed_domains.value or [])
-                                         or None,
+            'artifacts_allowed_domains': ','.join(self.spec.artifacts_allowed_domains.value or
+                                                  []) or None,
             'yum_proxy': self.spec.yum_proxy.value,
         }
 
@@ -514,7 +514,6 @@ class BuildRequest(object):
             required_secrets = config_map.get_data_by_key('config.yaml').get(req_secrets_key, [])
             token_secrets = config_map.get_data_by_key('config.yaml').get(token_secrets_key, [])
 
-        logger.debug("config_map %s, required %s, token %s", config_map.get_data_by_key('config.yaml'), required_secrets, token_secrets)
         if platforms is not None:
             required_secrets += token_secrets
 
@@ -1477,11 +1476,9 @@ class BuildRequest(object):
 
     def render_name(self, name, image_tag, platform):
         """Sets the Build/BuildConfig object name"""
-        name = name.value
 
         if self.scratch or self.isolated:
-            name = image_tag.value
-            platform = platform.value
+            name = image_tag
             # Platform name may contain characters not allowed by OpenShift.
             if platform:
                 platform_suffix = '-{0}'.format(platform)
@@ -1524,7 +1521,8 @@ class BuildRequest(object):
             self.spec.validate()
 
         self.render_customizations()
-        self.render_name(self.spec.name, self.spec.image_tag, self.spec.platform)
+        self.render_name(self.spec.name.value, self.spec.image_tag.value,
+                         self.spec.platform.value)
         self.render_resource_limits()
 
         self.template['spec']['source']['git']['uri'] = self.spec.git_uri.value
@@ -1729,10 +1727,10 @@ class BuildRequest(object):
         self.render_tag_from_config()
         self.render_inject_parent_image()
         self.render_version()
-        self.render_node_selectors()
+        platforms = self.spec.platforms.value
+        self.render_node_selectors(platforms)
         reactor_config_map = self.spec.reactor_config_map.value
         reactor_config_override = self.spec.reactor_config_override.value
-        platforms = self.spec.platforms.value
         self.set_reactor_config(reactor_config_map=reactor_config_map,
                                 reactor_config_override=reactor_config_override)
         self.set_required_secrets(reactor_config_map=reactor_config_map,

--- a/osbs/build/build_requestv2.py
+++ b/osbs/build/build_requestv2.py
@@ -1,0 +1,187 @@
+"""
+Copyright (c) 2018 Red Hat, Inc
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+"""
+from __future__ import print_function, absolute_import, unicode_literals
+
+import logging
+import os
+
+from osbs.build.build_request import BuildRequest
+from osbs.build.user_params import BuildUserParams
+from osbs.exceptions import OsbsValidationException
+from osbs.constants import SECRETS_PATH
+from osbs.utils import git_repo_humanish_part_from_uri
+
+logger = logging.getLogger(__name__)
+
+
+class BuildRequestV2(BuildRequest):
+    """
+    Wraps logic for creating build inputs
+    """
+
+    def __init__(self, build_json_store, customize_conf=None):
+        """
+        :param build_json_store: str, path to directory with JSON build files
+        :param customize_conf: str, path to customize configuration JSON
+        """
+        super(BuildRequestV2, self).__init__(build_json_store=build_json_store,
+                                             customize_conf=customize_conf)
+        self.spec = None
+        self.user_params = BuildUserParams(build_json_store)
+        self.osbs_api = None
+
+    # Override
+    def set_params(self, **kwargs):
+        """
+        set parameters in the user parameters
+
+        these parameters are accepted:
+        :param git_uri: str, uri of the git repository for the source
+        :param git_ref: str, commit ID of the branch to be pulled
+        :param git_branch: str, branch name of the branch to be pulled
+        :param base_image: str, name of the parent image
+        :param name_label: str, label of the parent image
+        :param user: str, name of the user requesting the build
+        :param component: str, name of the component
+        :param release: str,
+        :param build_image: str,
+        :param build_imagestream: str,
+        :param build_from: str,
+        :param build_type: str, orchestrator or worker
+        :param platforms: list of str, platforms to build on
+        :param platform: str, platform
+        :param koji_target: str, koji tag with packages used to build the image
+        :param koji_task_id: str, koji ID
+        :param koji_parent_build: str,
+        :param flatpak: if we should build a Flatpak OCI Image
+        :param flatpak_base_image: str, name of the Flatpack OCI Image
+        :param reactor_config_map: str, name of the config map containing the reactor environment
+        :param yum_repourls: list of str, uris of the yum repos to pull from
+        :param signing_intent: bool, True to sign the resulting image
+        :param compose_ids: list of str,
+        :param filesystem_koji_task_id: int, Koji Task that created the base filesystem
+        :param platform_node_selector: dict, a nodeselector for a user_paramsific platform
+        :param scratch_build_node_selector: dict, a nodeselector for scratch builds
+        :param explicit_build_node_selector: dict, a nodeselector for explicit builds
+        :param auto_build_node_selector: dict, a nodeselector for auto builds
+        :param isolated_build_node_selector: dict, a nodeselector for isolated builds
+        :param additional_tag_data: dict, str of dir path and filename of additional tags
+                                    and set of str of tags
+        """
+
+        # Here we cater to the koji "scratch" build type, this will disable
+        # all plugins that might cause importing of data to koji
+        self.scratch = kwargs.get('scratch')
+        # When true, it indicates build was automatically started by
+        # OpenShift via a trigger, for instance ImageChangeTrigger
+        self.is_auto = kwargs.pop('is_auto', False)
+        # An isolated build is meant to patch a certain release and not
+        # update transient tags in container registry
+        self.isolated = kwargs.get('isolated')
+
+        self.osbs_api = kwargs.pop('osbs_api', None)
+        self.validate_build_variation()
+
+        self.base_image = kwargs.get('base_image')
+        self.platform_node_selector = kwargs.get('platform_node_selector', {})
+        self.scratch_build_node_selector = kwargs.get('scratch_build_node_selector', {})
+        self.explicit_build_node_selector = kwargs.get('explicit_build_node_selector', {})
+        self.auto_build_node_selector = kwargs.get('auto_build_node_selector', {})
+        self.isolated_build_node_selector = kwargs.get('isolated_build_node_selector', {})
+
+        logger.debug("setting params '%s' for %s", kwargs, self.user_params)
+        self.user_params.set_params(**kwargs)
+
+    # Override
+    @property
+    def inner_template(self):
+        raise RuntimeError('inner_template not supported in BuildRequestV2')
+
+    # Override
+    @property
+    def customize_conf(self):
+        raise RuntimeError('customize_conf not supported in BuildRequestV2')
+
+    # Override
+    @property
+    def dj(self):
+        raise RuntimeError('DockJson not supported in BuildRequestV2')
+
+    def adjust_for_scratch(self):
+        """
+        Scratch builds must not affect subsequent builds,
+        and should not be imported into Koji.
+        """
+        if self.scratch:
+            self.template['spec'].pop('triggers', None)
+            self.set_label('scratch', 'true')
+
+    def render(self, validate=True):
+        # the api is required for BuildRequestV2
+        # can't check that its an OSBS object because of the circular import
+        if not self.osbs_api:
+            raise OsbsValidationException
+
+        # Validate BuildUserParams
+        if validate:
+            self.user_params.validate()
+
+        self.render_name(self.user_params.name, self.user_params.image_tag,
+                         self.user_params.platform)
+        self.render_resource_limits()
+
+        self.template['spec']['source']['git']['uri'] = self.user_params.git_uri.value
+        self.template['spec']['source']['git']['ref'] = self.user_params.git_ref.value
+
+        self.template['spec']['output']['to']['name'] = self.user_params.image_tag.value
+
+        if self.has_ist_trigger():
+            imagechange = self.template['spec']['triggers'][0]['imageChange']
+            imagechange['from']['name'] = self.user_params.trigger_imagestreamtag.value
+
+        custom_strategy = self.template['spec']['strategy']['customStrategy']
+        if self.user_params.build_imagestream.value:
+            custom_strategy['from']['kind'] = 'ImageStreamTag'
+            custom_strategy['from']['name'] = self.user_params.build_imagestream.value
+        else:
+            custom_strategy['from']['name'] = self.user_params.build_image.value
+
+        # Set git-repo-name label
+        # NOTE: Since only the repo name is used, a forked repos will have
+        # the same git-repo-name tag. This is a known limitation. If this
+        # use case must be handled properly, the git URI must be taken into
+        # account.
+        repo_name = git_repo_humanish_part_from_uri(self.user_params.git_uri.value)
+        self.set_label('git-repo-name', repo_name)
+        self.set_label('git-branch', self.user_params.git_branch.value)
+        koji_task_id = self.user_params.koji_task_id.value
+        if koji_task_id is not None:
+            self.set_label('koji-task-id', str(koji_task_id))
+
+        # Set template.spec.strategy.customStrategy.env[] USER_PARAMS
+        # Set required_secrets based on reactor_config
+        # Set worker_token_secrets based on reactor_config, if any
+        logger.debug('calling reactor config with %s',self.user_params.reactor_config_map.value)
+        self.set_reactor_config(reactor_config_map=self.user_params.reactor_config_map.value)
+        self.set_required_secrets(reactor_config_map=self.user_params.reactor_config_map.value,
+                                  platforms=self.user_params.platforms.value)
+
+        # Adjust triggers for custom base image
+        if self.template['spec'].get('triggers', []) and self.is_custom_base_image():
+            del self.template['spec']['triggers']
+
+        self.adjust_for_repo_info()
+        self.adjust_for_scratch()
+        self.adjust_for_isolated(self.user_params.release)
+        self.render_node_selectors(self.user_params.platforms.value)
+
+        # Log build json
+        # Return build json
+        self.build_json = self.template
+        logger.debug(self.build_json)
+        return self.build_json

--- a/osbs/build/plugins_configuration.py
+++ b/osbs/build/plugins_configuration.py
@@ -1,0 +1,539 @@
+"""
+Copyright (c) 2018 Red Hat, Inc
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+"""
+from __future__ import print_function, absolute_import, unicode_literals
+
+import logging
+import os
+import json
+import copy
+import re
+
+from osbs.constants import BUILD_TYPE_ORCHESTRATOR
+from osbs.exceptions import OsbsException
+
+logger = logging.getLogger(__name__)
+
+
+class PluginsTemplate(object):
+    def __init__(self, build_json_dir, template_path, customize_conf_path):
+        self._template = None
+        self._customize_conf = None
+        self._build_json_dir = build_json_dir
+        self._template_path = template_path
+        self._customize_conf_path = customize_conf_path
+
+    @property
+    def template(self):
+        if self._template is None:
+            path = os.path.join(self._build_json_dir, self._template_path)
+            logger.debug("loading template from path %s", path)
+            try:
+                with open(path, "r") as fp:
+                    self._template = json.load(fp)
+            except (IOError, OSError) as ex:
+                raise OsbsException("Can't open template '%s': %s" %
+                                    (path, repr(ex)))
+        return self._template
+
+    @property
+    def customize_conf(self):
+        if self._customize_conf is None:
+            path = os.path.join(self._build_json_dir, self._customize_conf_path)
+            logger.info('loading customize conf from path %s', path)
+            try:
+                with open(path, "r") as fp:
+                    self._customize_conf = json.load(fp)
+            except IOError:
+                # File not found, which is perfectly fine. Set to empty dict
+                logger.info('failed to find customize conf from path %s', path)
+                self._customize_conf = {}
+        return self._customize_conf
+
+    def remove_plugin(self, phase, name, reason=None):
+        """
+        if config contains plugin, remove it
+        """
+        for p in self.template[phase]:
+            if p.get('name') == name:
+                self.template[phase].remove(p)
+                if reason:
+                    logger.info('Removing {0}:{1}, {2}'.format(phase, name, reason))
+                break
+
+    def add_plugin(self, phase, name, args, reason=None):
+        """
+        if config has plugin, override it, else add it
+        """
+        plugin_modified = False
+
+        for plugin in self.template[phase]:
+            if plugin['name'] == name:
+                plugin['args'] = args
+                plugin_modified = True
+
+        if not plugin_modified:
+            self.template[phase].append({"name": name, "args": args})
+            if reason:
+                logger.info('{0}:{1} with args {2}, {3}'.format(phase, name, args, reason))
+
+    def get_plugin_conf(self, phase, name):
+        """
+        Return the configuration for a plugin.
+
+        Raises KeyError if there are no plugins of that type.
+        Raises IndexError if the named plugin is not listed.
+        """
+        match = [x for x in self.template[phase] if x.get('name') == name]
+        return match[0]
+
+    def has_plugin_conf(self, phase, name):
+        """
+        Check whether a plugin is configured.
+        """
+        try:
+            self.get_plugin_conf(phase, name)
+            return True
+        except (KeyError, IndexError):
+            return False
+
+    def _get_plugin_conf_or_fail(self, phase, name):
+        try:
+            conf = self.get_plugin_conf(phase, name)
+        except KeyError:
+            raise RuntimeError("Invalid template: plugin phase '%s' misses" % phase)
+        except IndexError:
+            raise RuntimeError("no such plugin in template: \"%s\"" % name)
+        return conf
+
+    def set_param(self, param, value):
+        self.template[param] = value
+
+    def merge_plugin_arg(self, phase, name, arg_key, arg_dict):
+        plugin_conf = self._get_plugin_conf_or_fail(phase, name)
+
+        # Values supplied by the caller override those from the template JSON
+        template_value = plugin_conf['args'].get(arg_key, {})
+        if not isinstance(template_value, dict):
+            template_value = {}
+
+        value = copy.deepcopy(template_value)
+        value.update(arg_dict)
+        plugin_conf['args'][arg_key] = value
+
+    def set_plugin_arg(self, phase, name, arg_key, arg_value):
+        plugin_conf = self._get_plugin_conf_or_fail(phase, name)
+        plugin_conf.setdefault("args", {})
+        plugin_conf['args'][arg_key] = arg_value
+
+    def set_plugin_arg_valid(self, phase, plugin, name, value):
+        if value is not None:
+            self.set_plugin_arg(phase, plugin, name, value)
+            return True
+        return False
+
+    def to_json(self):
+        return json.dumps(self.template)
+
+
+class PluginsConfiguration(object):
+    def __init__(self, user_params):
+        # Figure out inner template to use from user_params:
+        self.user_params = user_params
+
+        #    <build_type>_inner:<arrangement_version>.json
+        arrangement_version = self.user_params.arrangement_version.value
+        build_type = self.user_params.build_type.value
+        pt_path = '{0}_inner:{1}.json'.format(build_type, arrangement_version)
+        self.pt = PluginsTemplate(self.user_params.build_json_dir.value, pt_path,
+                                  self.user_params.customize_conf_path.value)
+
+    def has_tag_suffixes_placeholder(self):
+        phase = 'postbuild_plugins'
+        plugin = 'tag_from_config'
+        if not self.pt.has_plugin_conf(phase, plugin):
+            return False
+
+        placeholder = '{{TAG_SUFFIXES}}'
+        plugin_conf = self.pt.get_plugin_conf('postbuild_plugins', 'tag_from_config')
+        return plugin_conf.get('args', {}).get('tag_suffixes') == placeholder
+
+    def adjust_for_scratch(self):
+        """
+        Remove certain plugins in order to handle the "scratch build"
+        scenario. Scratch builds must not affect subsequent builds,
+        and should not be imported into Koji.
+        """
+        if self.user_params.scratch.value:
+            remove_plugins = [
+                ("prebuild_plugins", "koji_parent"),
+                ("postbuild_plugins", "compress"),  # required only to make an archive for Koji
+                ("postbuild_plugins", "pulp_pull"),  # required only to make an archive for Koji
+                ("postbuild_plugins", "koji_upload"),
+                ("postbuild_plugins", "fetch_worker_metadata"),
+                ("postbuild_plugins", "compare_components"),
+                ("postbuild_plugins", "import_image"),
+                ("exit_plugins", "koji_promote"),
+                ("exit_plugins", "koji_import"),
+                ("exit_plugins", "koji_tag_build"),
+                ("exit_plugins", "remove_worker_metadata"),
+                ("exit_plugins", "import_image"),
+            ]
+
+            if not self.has_tag_suffixes_placeholder():
+                remove_plugins.append(("postbuild_plugins", "tag_from_config"))
+
+            for when, which in remove_plugins:
+                self.pt.remove_plugin(when, which, 'removed from scratch build request')
+
+            if self.pt.has_plugin_conf('postbuild_plugins', 'tag_by_labels'):
+                self.pt.set_plugin_arg('postbuild_plugins', 'tag_by_labels',
+                                       'unique_tag_only', True)
+
+    def is_custom_base_image(self):
+        return bool(re.match('^koji/image-build(:.*)?$',
+                             self.user_params.base_image.value or ''))
+
+    def adjust_for_custom_base_image(self):
+        """
+        Disable plugins to handle builds depending on whether
+        or not this is a build from a custom base image.
+        """
+        plugins = []
+        if self.is_custom_base_image():
+            # Plugins irrelevant to building base images.
+            plugins.append(("prebuild_plugins", "pull_base_image"))
+            plugins.append(("prebuild_plugins", "koji_parent"))
+            plugins.append(("prebuild_plugins", "inject_parent_image"))
+            msg = 'removed from custom image build request'
+
+        else:
+            # Plugins not needed for building non base images.
+            plugins.append(("prebuild_plugins", "add_filesystem"))
+            msg = 'removed from non custom image build request'
+
+        for when, which in plugins:
+            self.pt.remove_plugin(when, which, msg)
+
+    def render_add_filesystem(self):
+        phase = 'prebuild_plugins'
+        plugin = 'add_filesystem'
+
+        if self.pt.has_plugin_conf(phase, plugin):
+            self.pt.set_plugin_arg_valid(phase, plugin, 'repos',
+                                         self.user_params.yum_repourls.value)
+            self.pt.set_plugin_arg_valid(phase, plugin, 'from_task_id',
+                                         self.user_params.filesystem_koji_task_id.value)
+
+    def render_add_labels_in_dockerfile(self):
+        phase = 'prebuild_plugins'
+        plugin = 'add_labels_in_dockerfile'
+        if not self.pt.has_plugin_conf(phase, plugin):
+            return
+
+        implicit_labels = {}
+        label_user_params = {
+            'release': self.user_params.release,
+        }
+
+        for label, user_params in label_user_params.items():
+            if user_params.value is not None:
+                implicit_labels[label] = user_params.value
+
+        self.pt.merge_plugin_arg(phase, plugin, 'labels', implicit_labels)
+
+    def render_add_yum_repo_by_url(self):
+        if (self.user_params.yum_repourls.value is not None and
+                self.pt.has_plugin_conf('prebuild_plugins', "add_yum_repo_by_url")):
+            self.pt.set_plugin_arg('prebuild_plugins', "add_yum_repo_by_url", "repourls",
+                                   self.user_params.yum_repourls.value)
+
+    def render_customizations(self):
+        """
+        Customize template for site user specified customizations
+        """
+        if self.user_params.customize_conf_path is None:
+            return
+
+        disable_plugins = self.pt.customize_conf.get('disable_plugins', [])
+        if not disable_plugins:
+            logger.debug('No site-user specified plugins to disable')
+        else:
+            for plugin in disable_plugins:
+                try:
+                    self.pt.remove_plugin(plugin['plugin_type'], plugin['plugin_name'],
+                                          'disabled at user request')
+                except KeyError:
+                    # Malformed config
+                    logger.info('Invalid custom configuration found for disable_plugins')
+
+        enable_plugins = self.pt.customize_conf.get('enable_plugins', [])
+        if not enable_plugins:
+            logger.debug('No site-user specified plugins to enable"')
+        else:
+            for plugin in enable_plugins:
+                try:
+                    msg = 'enabled at user request'
+                    self.pt.add_plugin(plugin['plugin_type'], plugin['plugin_name'],
+                                       plugin['plugin_args'], msg)
+                except KeyError:
+                    # Malformed config
+                    logger.info('Invalid custom configuration found for enable_plugins')
+
+    def render_flatpak_create_dockerfile(self):
+        phase = 'prebuild_plugins'
+        plugin = 'flatpak_create_dockerfile'
+
+        if self.pt.has_plugin_conf(phase, plugin):
+            if not self.pt.set_plugin_arg_valid(phase, plugin, 'base_image',
+                                                self.user_params.flatpak_base_image.value):
+                self.pt.remove_plugin(phase, plugin, 'unable to set flatpak base image')
+
+    def render_flatpak_create_oci(self):
+        phase = 'prepublish_plugins'
+        plugin = 'flatpak_create_oci'
+
+        if not self.user_params.flatpak.value:
+            self.pt.remove_plugin(phase, plugin)
+
+    def render_koji(self):
+        """
+        if there is yum repo user_paramsified, don't pick stuff from koji
+        """
+        phase = 'prebuild_plugins'
+        plugin = 'koji'
+        if not self.pt.has_plugin_conf(phase, plugin):
+            return
+
+        if self.user_params.yum_repourls.value:
+            self.pt.remove_plugin(phase, plugin, 'there is a yum repo user parameter')
+        elif self.user_params.flatpak.value:
+            self.pt.remove_plugin(phase, plugin, 'flatpak build requested')
+        elif not self.pt.set_plugin_arg_valid(phase, plugin, "target",
+                                              self.user_params.koji_target.value):
+            self.pt.remove_plugin(phase, plugin, 'no koji target supplied in user parameters')
+
+    def render_bump_release(self):
+        """
+        If the bump_release plugin is present, configure it
+        """
+        phase = 'prebuild_plugins'
+        plugin = 'bump_release'
+        if not self.pt.has_plugin_conf(phase, plugin):
+            return
+
+        if self.user_params.release.value:
+            self.pt.remove_plugin(phase, plugin, 'release value supplied as user parameter')
+            return
+
+        # For flatpak, we want a name-version-release of
+        # <name>-<stream>-<module_build_version>.<n>, where the .<n> makes
+        # sure that the build is unique in Koji
+        if self.user_params.flatpak.value:
+            self.pt.set_plugin_arg(phase, plugin, 'append', True)
+
+    def render_import_image(self, use_auth=None):
+        """
+        Configure the import_image plugin
+        """
+        # import_image is a multi-phase plugin
+        if self.user_params.imagestream_name.value is None:
+            self.pt.remove_plugin('exit_plugins', 'import_image',
+                                  'imagestream not in user parameters')
+        elif self.pt.has_plugin_conf('exit_plugins', 'import_image'):
+            self.pt.set_plugin_arg('exit_plugins', 'import_image', 'imagestream',
+                                   self.user_params.imagestream_name.value)
+            self.pt.set_plugin_arg('exit_plugins', 'import_image', 'build_json_dir',
+                                   self.user_params.build_json_dir.value)
+
+    def render_inject_parent_image(self):
+        phase = 'prebuild_plugins'
+        plugin = 'inject_parent_image'
+        if not self.pt.has_plugin_conf(phase, plugin):
+            return
+
+        koji_parent_build = self.user_params.koji_parent_build.value
+
+        if not koji_parent_build:
+            self.pt.remove_plugin(phase, plugin, 'no koji parent build in user parameters')
+            return
+
+        self.pt.set_plugin_arg(phase, plugin, 'koji_parent_build', koji_parent_build)
+
+    def render_koji_promote(self, use_auth=None):
+        if not self.pt.has_plugin_conf('exit_plugins', 'koji_promote'):
+            return
+
+        koji_target = self.user_params.koji_target.value
+        if not self.pt.set_plugin_arg_valid('exit_plugins', 'koji_promote',
+                                            'target', koji_target):
+            self.pt.remove_plugin("exit_plugins", "koji_promote",
+                                  'no koji target in user parameters')
+
+    def render_koji_upload(self, use_auth=None):
+        phase = 'postbuild_plugins'
+        name = 'koji_upload'
+        if not self.pt.has_plugin_conf(phase, name):
+            return
+
+        def set_arg(arg, value):
+            self.pt.set_plugin_arg(phase, name, arg, value)
+
+        set_arg('build_json_dir', self.user_params.build_json_dir.value)
+        set_arg('platform', self.user_params.platform.value)
+        set_arg('report_multiple_digests', True)
+
+    def render_koji_import(self, use_auth=None):
+        if not self.pt.has_plugin_conf('exit_plugins', 'koji_import'):
+            return
+
+        koji_target = self.user_params.koji_target.value
+        if not self.pt.set_plugin_arg_valid('exit_plugins', 'koji_import', 'target', koji_target):
+            self.pt.remove_plugin("exit_plugins", "koji_import",
+                                  'no koji target in user parameters')
+
+    def render_koji_tag_build(self):
+        phase = 'exit_plugins'
+        plugin = 'koji_tag_build'
+        if not self.pt.has_plugin_conf(phase, plugin):
+            return
+
+        if not self.user_params.koji_target.value:
+            self.pt.remove_plugin(phase, plugin, 'no koji target in user parameters')
+            return
+
+        self.pt.set_plugin_arg(phase, plugin, 'target', self.user_params.koji_target.value)
+
+    def render_orchestrate_build(self):
+        phase = 'buildstep_plugins'
+        plugin = 'orchestrate_build'
+        if not self.pt.has_plugin_conf(phase, plugin):
+            return
+
+        if self.user_params.platforms.value is None:
+            self.pt.remove_plugin(phase, plugin, 'no platforms in user parameters')
+            return
+
+        # Parameters to be used in call to create_worker_build
+        worker_params = [
+            'component', 'git_branch', 'git_ref', 'git_uri', 'koji_task_id',
+            'filesystem_koji_task_id', 'scratch', 'koji_target', 'user', 'yum_repourls',
+            'arrangement_version', 'koji_parent_build', 'isolated',
+        ]
+
+        build_kwargs = self.user_params.to_dict(worker_params)
+        # koji_target is passed as target for some reason
+        build_kwargs['target'] = build_kwargs.pop('koji_target', None)
+
+        if self.user_params.flatpak.value:
+            build_kwargs['flatpak'] = True
+
+        self.pt.set_plugin_arg(phase, plugin, 'platforms', self.user_params.platforms.value)
+        self.pt.set_plugin_arg(phase, plugin, 'build_kwargs', build_kwargs)
+
+        # Parameters to be used as Configuration overrides for each worker
+        config_kwargs = {
+            'flatpak_base_image': self.user_params.flatpak_base_image.value,
+        }
+
+        # Remove empty values, and always convert to string for better interaction
+        # with Configuration class and JSON encoding
+        config_kwargs = dict((k, str(v)) for k, v in config_kwargs.items() if v is not None)
+
+        if not self.user_params.build_imagestream.value:
+            config_kwargs['build_image'] = self.user_params.build_image.value
+
+        self.pt.set_plugin_arg(phase, plugin, 'config_kwargs', config_kwargs)
+
+    def render_resolve_composes(self):
+        phase = 'prebuild_plugins'
+        plugin = 'resolve_composes'
+
+        if not self.pt.has_plugin_conf(phase, plugin):
+            return
+
+        if self.user_params.yum_repourls.value:
+            self.pt.remove_plugin(phase, plugin, 'yum repourls specified in user parameters')
+            return
+
+        self.pt.set_plugin_arg_valid(phase, plugin, 'compose_ids',
+                                     self.user_params.compose_ids.value)
+
+        self.pt.set_plugin_arg_valid(phase, plugin, 'signing_intent',
+                                     self.user_params.signing_intent.value)
+
+    def render_resolve_module_compose(self):
+        phase = 'prebuild_plugins'
+        plugin = 'resolve_module_compose'
+
+        if self.pt.has_plugin_conf(phase, plugin):
+            if not self.user_params.flatpak.value:
+                self.pt.remove_plugin(phase, plugin)
+                return
+
+            self.pt.set_plugin_arg_valid(phase, plugin, 'compose_ids',
+                                         self.user_params.compose_ids.value)
+
+    def render_squash(self):
+        phase = 'prepublish_plugins'
+        plugin = 'squash'
+
+        if self.user_params.flatpak.value:
+            # We'll extract the filesystem anyways for a Flatpak instead of exporting
+            # the docker image directly, so squash just slows things down.
+            self.pt.remove_plugin(phase, plugin, 'flatpak build requested')
+            return
+
+    def render_tag_from_config(self):
+        """Configure tag_from_config plugin"""
+        phase = 'postbuild_plugins'
+        plugin = 'tag_from_config'
+        if not self.has_tag_suffixes_placeholder():
+            return
+
+        unique_tag = self.user_params.image_tag.value.split(':')[-1]
+        tag_suffixes = {'unique': [unique_tag], 'primary': []}
+
+        if self.user_params.build_type.value == BUILD_TYPE_ORCHESTRATOR:
+            if self.user_params.scratch.value:
+                pass
+            elif self.user_params.isolated.value:
+                tag_suffixes['primary'].extend(['{version}-{release}'])
+            else:
+                tag_suffixes['primary'].extend(['latest', '{version}', '{version}-{release}'])
+                if self.user_params.additional_tags:
+                    tag_suffixes['primary'].extend(self.user_params.additional_tags.tags)
+
+        self.pt.set_plugin_arg(phase, plugin, 'tag_suffixes', tag_suffixes)
+
+    def render(self):
+        self.user_params.validate()
+
+        self.adjust_for_scratch()
+        self.adjust_for_custom_base_image()
+
+        # Set parameters on each plugin as needed
+        self.render_add_filesystem()
+        self.render_add_labels_in_dockerfile()
+        self.render_add_yum_repo_by_url()
+        self.render_bump_release()
+        self.render_customizations()
+        self.render_flatpak_create_dockerfile()
+        self.render_flatpak_create_oci()
+        self.render_import_image()
+        self.render_inject_parent_image()
+        self.render_koji()
+        self.render_koji_import()
+        self.render_koji_promote()
+        self.render_koji_tag_build()
+        self.render_koji_upload()
+        self.render_orchestrate_build()
+        self.render_resolve_composes()
+        self.render_resolve_module_compose()
+        self.render_squash()
+        self.render_tag_from_config()
+        return self.pt.to_json()

--- a/osbs/build/user_params.py
+++ b/osbs/build/user_params.py
@@ -1,0 +1,191 @@
+"""
+Copyright (c) 2018 Red Hat, Inc
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+"""
+from __future__ import print_function, absolute_import, unicode_literals
+
+import logging
+import json
+
+from osbs.build.spec import BuildParam, BuildIDParam, UserParam, BuildCommon
+from osbs.constants import (DEFAULT_GIT_REF, REACTOR_CONFIG_ARRANGEMENT_VERSION,
+                            DEFAULT_CUSTOMIZE_CONF)
+from osbs.exceptions import OsbsValidationException
+from osbs.utils import get_imagestreamtag_from_image, make_name_from_git
+from osbs.repo_utils import AdditionalTagsConfig
+
+
+logger = logging.getLogger(__name__)
+
+
+class BuildUserParams(BuildCommon):
+    def __init__(self, build_json_dir=None, customize_conf=None):
+        # defines image_tag, koji_target, filesystem_koji_task_id, platform, arrangement_version
+        super(BuildUserParams, self).__init__()
+        self.additional_tags = None
+        self.arrangement_version.value = REACTOR_CONFIG_ARRANGEMENT_VERSION
+        self.base_image = BuildParam('base_image', allow_none=True)
+        self.build_from = BuildParam('build_from')
+        self.build_image = BuildParam('build_image')
+        self.build_imagestream = BuildParam('build_imagestream')
+        self.build_json_dir = BuildParam('build_json_dir', default=build_json_dir)
+        self.build_type = BuildParam('build_type')
+        self.component = BuildParam('component')
+        self.compose_ids = BuildParam("compose_ids", allow_none=True)
+        self.customize_conf_path = BuildParam("customize_conf", allow_none=True,
+                                              default=customize_conf or DEFAULT_CUSTOMIZE_CONF)
+        self.flatpak = BuildParam('flatpak', default=False)
+        self.flatpak_base_image = BuildParam("flatpak_base_image", allow_none=True)
+        self.git_branch = BuildParam('git_branch')
+        self.git_ref = BuildParam('git_ref', default=DEFAULT_GIT_REF)
+        self.git_uri = BuildParam('git_uri')
+        self.imagestream_name = BuildParam('imagestream_name')
+        self.isolated = BuildParam('isolated', allow_none=True)
+        self.koji_parent_build = BuildParam('koji_parent_build', allow_none=True)
+        self.koji_task_id = BuildParam('koji_task_id', allow_none=True)
+        self.name = BuildIDParam()
+        self.platforms = BuildParam('platforms', allow_none=True)
+        self.reactor_config_map = BuildParam("reactor_config_map", allow_none=True)
+        self.release = BuildParam('release', allow_none=True)
+        self.scratch = BuildParam('scratch', allow_none=True)
+        self.signing_intent = BuildParam('signing_intent', allow_none=True)
+        self.trigger_imagestreamtag = BuildParam('trigger_imagestreamtag')
+        self.user = UserParam()
+        self.yum_repourls = BuildParam("yum_repourls")
+        self.required_params = [
+            self.build_json_dir,
+            self.build_type,
+            self.git_ref,
+            self.git_uri,
+            self.koji_target,
+            self.user,
+        ]
+        self.convert_dict = {}
+        for _, param in self.__dict__.items():
+            if isinstance(param, BuildParam):
+                # check that every parameter has a unique name
+                if param.name in self.convert_dict:
+                    raise OsbsValidationException('Two user params with the same name')
+                self.convert_dict[param.name] = param
+
+    def set_params(self,
+                   git_uri=None, git_ref=None, git_branch=None,
+                   base_image=None, name_label=None,
+                   user=None, additional_tag_data=None,
+                   component=None, release=None,
+                   build_image=None, build_imagestream=None, build_from=None,
+                   platforms=None, platform=None, build_type=None,
+                   koji_target=None, koji_task_id=None, filesystem_koji_task_id=None,
+                   koji_parent_build=None,
+                   flatpak=None, flatpak_base_image=None,
+                   reactor_config_map=None,
+                   yum_repourls=None, signing_intent=None, compose_ids=None,
+                   isolated=None, scratch=None,
+                   **kwargs):
+        self.git_uri.value = git_uri
+        self.git_ref.value = git_ref
+        self.git_branch.value = git_branch
+        self.user.value = user
+        self.component.value = component
+        self.release.value = release
+        self.build_type.value = build_type
+        self.base_image.value = base_image
+
+        self.name.value = make_name_from_git(self.git_uri.value, self.git_branch.value)
+        self.reactor_config_map.value = reactor_config_map
+
+        unique_build_args = (build_imagestream, build_image, build_from)
+        if sum(bool(a) for a in unique_build_args) != 1:
+            raise OsbsValidationException(
+                'Please only define one of build_from, build_image, build_imagestream')
+        self.build_image.value = build_image
+        self.build_imagestream.value = build_imagestream
+        if self.build_image.value or self.build_imagestream.value:
+            logger.warning("build_image or build_imagestream is defined, they are deprecated,"
+                           "use build_from instead")
+
+        if build_from:
+            source_type, source_value = build_from.split(':', 1)
+            if source_type not in ('image', 'imagestream'):
+                raise OsbsValidationException(
+                    'first part in build_from, may be only image or imagestream')
+            if source_type == 'image':
+                self.build_image.value = source_value
+            else:
+                self.build_imagestream.value = source_value
+
+        self.platforms.value = platforms
+        self.platform.value = platform
+        self.koji_target.value = koji_target
+        self.koji_task_id.value = koji_task_id
+        self.filesystem_koji_task_id.value = filesystem_koji_task_id
+        self.koji_parent_build.value = koji_parent_build
+        self.flatpak.value = flatpak
+        self.flatpak_base_image.value = flatpak_base_image
+        self.isolated.value = isolated
+        self.scratch.value = scratch
+
+        if not flatpak:
+            if not base_image:
+                raise OsbsValidationException("base_image must be provided")
+            self.trigger_imagestreamtag.value = get_imagestreamtag_from_image(base_image)
+
+            if not name_label:
+                raise OsbsValidationException("name_label must be provided")
+            self.imagestream_name.value = name_label.replace('/', '-')
+
+        if signing_intent and compose_ids:
+            raise OsbsValidationException(
+                'Please only define signing_intent -OR- compose_ids, not both')
+        if compose_ids and yum_repourls:
+            raise OsbsValidationException(
+                'Please only define yum_repourls -OR- compose_ids, not both')
+        if not (compose_ids is None or isinstance(compose_ids, list)):
+            raise OsbsValidationException("compose_ids must be a list")
+        if not (yum_repourls is None or isinstance(yum_repourls, list)):
+            raise OsbsValidationException("yum_repourls must be a list")
+        self.yum_repourls.value = yum_repourls or []
+        self.signing_intent.value = signing_intent
+        self.compose_ids.value = compose_ids or []
+
+        if additional_tag_data:
+            self.additional_tags = AdditionalTagsConfig(additional_tag_data['dir_path'],
+                                                        additional_tag_data['file_name'],
+                                                        additional_tag_data['tags'])
+        self._populate_image_tag()
+
+    def __repr__(self):
+        return "UserParams(%s)" % self.__dict__
+
+    def from_json(self, user_params_json):
+        if not user_params_json:
+            return
+        json_dict = json.loads(user_params_json)
+        for key, value in json_dict.items():
+            try:
+                self.convert_dict[key].value = value
+            except KeyError:
+                continue
+        # Special cases
+        if 'additional_tags' in json_dict.keys():
+            self.additional_tags = AdditionalTagsConfig(tags=json_dict['additional_tags'])
+
+    def set_if_exists(self, json_dict, param):
+        if self.convert_dict[param].value:
+            json_dict[param] = self.convert_dict[param].value
+
+    def to_dict(self, keys):
+        retdict = {}
+        for key in keys:
+            self.set_if_exists(retdict, key)
+        return retdict
+
+    def to_json(self):
+        json_dict = self.to_dict(self.convert_dict.keys())
+        # Special cases
+        if self.additional_tags:
+            json_dict['additional_tags'] = sorted(self.additional_tags.tags)
+        return json.dumps(json_dict, sort_keys=True)

--- a/osbs/constants.py
+++ b/osbs/constants.py
@@ -97,7 +97,7 @@ OS_CONFLICT_MAX_RETRIES = 8
 # number of seconds to wait, before retrying on openshift conflict
 OS_CONFLICT_WAIT = 5
 
-BUILD_TYPE_ORCHESTRATOR = object()
-BUILD_TYPE_WORKER = object()
+BUILD_TYPE_ORCHESTRATOR = "orchestrator"
+BUILD_TYPE_WORKER = "worker"
 
 ISOLATED_RELEASE_FORMAT = re.compile(r'^\d+\.\d+(\..+)?$')

--- a/osbs/constants.py
+++ b/osbs/constants.py
@@ -23,6 +23,7 @@ DEFAULT_INNER_TEMPLATE = "prod_inner.json"
 WORKER_INNER_TEMPLATE = "worker_inner:{arrangement_version}.json"
 ORCHESTRATOR_INNER_TEMPLATE = "orchestrator_inner:{arrangement_version}.json"
 DEFAULT_ARRANGEMENT_VERSION = 5  # this should be the highest-numbered version
+REACTOR_CONFIG_ARRANGEMENT_VERSION = 7
 DEFAULT_CUSTOMIZE_CONF = "prod_customize.json"
 WORKER_CUSTOMIZE_CONF = "worker_customize.json"
 ORCHESTRATOR_CUSTOMIZE_CONF = "orchestrator_customize.json"

--- a/tests/build_/test_build_requestv2.py
+++ b/tests/build_/test_build_requestv2.py
@@ -1,0 +1,705 @@
+"""
+Copyright (c) 2018 Red Hat, Inc
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+"""
+import copy
+import glob
+import json
+import os
+import fnmatch
+from pkg_resources import parse_version
+import shutil
+import six
+import sys
+
+from osbs.build.build_requestv2 import BuildRequestV2
+from osbs.constants import DEFAULT_OUTER_TEMPLATE, BUILD_TYPE_WORKER
+from osbs.exceptions import OsbsValidationException
+from osbs.repo_utils import RepoInfo, RepoConfiguration
+from osbs.api import OSBS
+
+from flexmock import flexmock
+import pytest
+
+from tests.constants import (INPUTS_PATH, TEST_BUILD_CONFIG, TEST_BUILD_JSON,
+                             TEST_COMPONENT, TEST_GIT_BRANCH, TEST_GIT_REF,
+                             TEST_GIT_URI, TEST_GIT_URI_HUMAN_NAME,
+                             TEST_FILESYSTEM_KOJI_TASK_ID, TEST_SCRATCH_BUILD_NAME,
+                             TEST_ISOLATED_BUILD_NAME)
+# These are used as fixtures
+from tests.fake_api import openshift  # noqa
+
+USE_DEFAULT_TRIGGERS = object()
+
+
+class NoSuchPluginException(Exception):
+    pass
+
+
+def MockOSBSApi(config_map_data=None):
+    class MockConfigMap(object):
+        def __init__(self, data):
+            self.data = data or {}
+
+        def get_data_by_key(self, key=None):
+            return self.data
+
+    mock_osbs = flexmock(OSBS)
+    flexmock(mock_osbs).should_receive('get_config_map').and_return(MockConfigMap(config_map_data))
+    return mock_osbs
+
+
+def get_sample_prod_params(osbs_api=MockOSBSApi()):
+    return {
+        'git_uri': TEST_GIT_URI,
+        'git_ref': TEST_GIT_REF,
+        'git_branch': TEST_GIT_BRANCH,
+        'user': 'john-foo',
+        'component': TEST_COMPONENT,
+        'base_image': 'fedora:latest',
+        'name_label': 'fedora/resultingimage',
+        'koji_target': 'koji-target',
+        'platforms': ['x86_64'],
+        'filesystem_koji_task_id': TEST_FILESYSTEM_KOJI_TASK_ID,
+        'build_from': 'image:buildroot:latest',
+        'build_type': BUILD_TYPE_WORKER,
+        'osbs_api': osbs_api,
+    }
+
+
+class TestBuildRequestV2(object):
+    def test_inner_template(self):
+        br = BuildRequestV2('something')
+        with pytest.raises(RuntimeError):
+            br.inner_template
+
+    def test_customize_conf(self):
+        br = BuildRequestV2('something')
+        with pytest.raises(RuntimeError):
+            br.customize_conf
+
+    def test_dock_json(self):
+        br = BuildRequestV2('something')
+        with pytest.raises(RuntimeError):
+            br.dj
+
+    def test_build_request_has_ist_trigger(self):
+        build_json = copy.deepcopy(TEST_BUILD_JSON)
+        br = BuildRequestV2('something')
+        flexmock(br).should_receive('template').and_return(build_json)
+        assert br.has_ist_trigger() is True
+
+    def test_build_request_isnt_auto_instantiated(self):
+        build_json = copy.deepcopy(TEST_BUILD_JSON)
+        build_json['spec']['triggers'] = []
+        br = BuildRequestV2('something')
+        flexmock(br).should_receive('template').and_return(build_json)
+        assert br.has_ist_trigger() is False
+
+    def test_set_label(self):
+        build_json = copy.deepcopy(TEST_BUILD_JSON)
+        br = BuildRequestV2('something')
+        flexmock(br).should_receive('template').and_return(build_json)
+        assert br.template['metadata'].get('labels') is None
+
+        br.set_label('label-1', 'value-1')
+        br.set_label('label-2', 'value-2')
+        br.set_label('label-3', 'value-3')
+        assert br.template['metadata']['labels'] == {
+            'label-1': 'value-1',
+            'label-2': 'value-2',
+            'label-3': 'value-3',
+        }
+
+    def test_render_no_api(self):
+        build_request = BuildRequestV2('something')
+        kwargs = get_sample_prod_params(osbs_api=None)
+        build_request.set_params(**kwargs)
+        with pytest.raises(OsbsValidationException):
+            build_request.render()
+
+    @pytest.mark.parametrize(('extra_kwargs', 'valid'), (  # noqa:F811
+        ({'scratch': True}, True),
+        ({'is_auto': True}, True),
+        ({'isolated': True, 'release': '1.0'}, True),
+        ({'scratch': True, 'isolated': True, 'release': '1.0'}, False),
+        ({'scratch': True, 'is_auto': True}, False),
+        ({'is_auto': True, 'isolated': True, 'release': '1.0'}, False),
+    ))
+    def test_mutually_exclusive_build_variation(self, extra_kwargs, valid):  # noqa:F811
+        kwargs = get_sample_prod_params()
+        kwargs.update(extra_kwargs)
+        build_request = BuildRequestV2(INPUTS_PATH)
+
+        if valid:
+            build_request.set_params(**kwargs)
+            build_request.render()
+        else:
+            with pytest.raises(OsbsValidationException) as exc_info:
+                build_request.set_params(**kwargs)
+            assert 'mutually exclusive' in str(exc_info.value)
+
+    def test_render_simple_request(self):
+        build_request = BuildRequestV2(INPUTS_PATH)
+        kwargs = {
+            'git_uri': TEST_GIT_URI,
+            'git_ref': TEST_GIT_REF,
+            'user': "john-foo",
+            'component': TEST_COMPONENT,
+            'build_image': 'fancy_buildroot:latestest',
+            'base_image': 'fedora:latest',
+            'name_label': 'fedora/resultingimage',
+            'build_type': BUILD_TYPE_WORKER,
+            'osbs_api': MockOSBSApi(),
+        }
+        build_request.set_params(**kwargs)
+        build_json = build_request.render()
+
+        assert build_json["metadata"]["name"] is not None
+        assert "triggers" not in build_json["spec"]
+        assert build_json["spec"]["source"]["git"]["uri"] == TEST_GIT_URI
+        assert build_json["spec"]["source"]["git"]["ref"] == TEST_GIT_REF
+
+        expected_output = "john-foo/component:none-"
+        assert build_json["spec"]["output"]["to"]["name"].startswith(expected_output)
+
+        rendered_build_image = build_json["spec"]["strategy"]["customStrategy"]["from"]["name"]
+        assert rendered_build_image == 'fancy_buildroot:latestest'
+
+    @pytest.mark.parametrize('proxy', [  # noqa:F811
+        None,
+        'http://proxy.example.com',
+    ])
+    @pytest.mark.parametrize(('build_image', 'build_imagestream', 'valid'), (
+        (None, None, False),
+        ('ultimate-buildroot:v1.0', None, True),
+        (None, 'buildroot-stream:v1.0', True),
+        ('ultimate-buildroot:v1.0', 'buildroot-stream:v1.0', False)
+    ))
+    def test_render_prod_request_with_repo(self, build_image, build_imagestream,
+                                           proxy, valid):
+        build_request = BuildRequestV2(INPUTS_PATH)
+        name_label = "fedora/resultingimage"
+        koji_task_id = 4756
+        assert isinstance(build_request, BuildRequestV2)
+        kwargs = {
+            'git_uri': TEST_GIT_URI,
+            'git_ref': TEST_GIT_REF,
+            'git_branch': TEST_GIT_BRANCH,
+            'user': "john-foo",
+            'component': TEST_COMPONENT,
+            'base_image': 'fedora:latest',
+            'name_label': name_label,
+            'koji_target': "koji-target",
+            'koji_task_id': koji_task_id,
+            'sources_command': "make",
+            'yum_repourls': ["http://example.com/my.repo"],
+            'build_image': build_image,
+            'build_imagestream': build_imagestream,
+            'build_type': BUILD_TYPE_WORKER,
+            'osbs_api': MockOSBSApi(),
+        }
+
+        if valid:
+            build_request.set_params(**kwargs)
+        else:
+            with pytest.raises(OsbsValidationException):
+                build_request.set_params(**kwargs)
+            return
+
+        build_json = build_request.render()
+
+        assert fnmatch.fnmatch(build_json["metadata"]["name"], TEST_BUILD_CONFIG)
+        assert build_json["metadata"]["labels"]["koji-task-id"] == str(koji_task_id)
+        assert "triggers" not in build_json["spec"]
+        assert build_json["spec"]["source"]["git"]["uri"] == TEST_GIT_URI
+        assert build_json["spec"]["source"]["git"]["ref"] == TEST_GIT_REF
+        assert build_json["spec"]["output"]["to"]["name"].startswith(
+            "john-foo/component:"
+        )
+
+        rendered_build_image = build_json["spec"]["strategy"]["customStrategy"]["from"]["name"]
+        if not build_imagestream:
+            assert rendered_build_image == build_image
+        else:
+            assert rendered_build_image == build_imagestream
+            assert build_json["spec"]["strategy"]["customStrategy"]["from"]["kind"] == \
+                "ImageStreamTag"
+
+    def test_render_prod_request(self):
+        build_request = BuildRequestV2(INPUTS_PATH)
+        kwargs = get_sample_prod_params()
+        build_request.set_params(**kwargs)
+        build_json = build_request.render()
+
+        assert fnmatch.fnmatch(build_json["metadata"]["name"], TEST_BUILD_CONFIG)
+        assert "triggers" not in build_json["spec"]
+        assert build_json["spec"]["source"]["git"]["uri"] == TEST_GIT_URI
+        assert build_json["spec"]["source"]["git"]["ref"] == TEST_GIT_REF
+        assert build_json["spec"]["output"]["to"]["name"].startswith(
+            "john-foo/component:"
+        )
+        assert build_json["metadata"]["labels"]["git-repo-name"] == TEST_GIT_URI_HUMAN_NAME
+        assert build_json["metadata"]["labels"]["git-branch"] == TEST_GIT_BRANCH
+
+    def test_render_prod_without_koji_request(self):
+        build_request = BuildRequestV2(INPUTS_PATH)
+        name_label = "fedora/resultingimage"
+        assert isinstance(build_request, BuildRequestV2)
+        kwargs = {
+            'git_uri': TEST_GIT_URI,
+            'git_ref': TEST_GIT_REF,
+            'git_branch': TEST_GIT_BRANCH,
+            'user': "john-foo",
+            'component': TEST_COMPONENT,
+            'base_image': 'fedora:latest',
+            'name_label': name_label,
+            'sources_command': "make",
+            'build_from': 'image:buildroot:latest',
+            'build_type': BUILD_TYPE_WORKER,
+            'osbs_api': MockOSBSApi(),
+        }
+        build_request.set_params(**kwargs)
+        build_json = build_request.render()
+
+        assert fnmatch.fnmatch(build_json["metadata"]["name"], TEST_BUILD_CONFIG)
+        assert "triggers" not in build_json["spec"]
+        assert build_json["spec"]["source"]["git"]["uri"] == TEST_GIT_URI
+        assert build_json["spec"]["source"]["git"]["ref"] == TEST_GIT_REF
+        assert build_json["spec"]["output"]["to"]["name"].startswith(
+            "john-foo/component:none-"
+        )
+
+    @pytest.mark.parametrize('platform', [None, 'x86_64'])
+    @pytest.mark.parametrize('scratch', [False, True])
+    def test_render_prod_request_v1_v2(self, platform, scratch): 
+        build_request = BuildRequestV2(INPUTS_PATH)
+        name_label = "fedora/resultingimage"
+        kwargs = {
+            'build_from': 'image:buildroot:latest',
+            'git_uri': TEST_GIT_URI,
+            'git_ref': TEST_GIT_REF,
+            'git_branch': TEST_GIT_BRANCH,
+            'user': "john-foo",
+            'component': TEST_COMPONENT,
+            'base_image': 'fedora:latest',
+            'name_label': name_label,
+            'koji_target': "koji-target",
+            'scratch': scratch,
+            'platform': platform,
+            'build_type': BUILD_TYPE_WORKER,
+            'osbs_api': MockOSBSApi(),
+        }
+        build_request.set_params(**kwargs)
+        build_json = build_request.render()
+
+        expected_name = TEST_SCRATCH_BUILD_NAME if scratch else TEST_BUILD_CONFIG
+        assert fnmatch.fnmatch(build_json["metadata"]["name"], expected_name)
+        assert "triggers" not in build_json["spec"]
+        assert build_json["spec"]["source"]["git"]["uri"] == TEST_GIT_URI
+        assert build_json["spec"]["source"]["git"]["ref"] == TEST_GIT_REF
+
+        assert build_json["spec"]["output"]["to"]["name"].startswith(
+            "john-foo/component:"
+        )
+
+    @pytest.mark.parametrize(('extra_kwargs', 'expected_name'), (
+        ({'isolated': True, 'release': '1.1'}, TEST_ISOLATED_BUILD_NAME),
+        ({'scratch': True}, TEST_SCRATCH_BUILD_NAME),
+        ({}, TEST_BUILD_CONFIG),
+    ))
+    def test_render_build_name(self, tmpdir, extra_kwargs, expected_name):
+        build_request = BuildRequestV2(INPUTS_PATH)
+
+        kwargs = get_sample_prod_params()
+        kwargs.update(extra_kwargs)
+        build_request.set_params(**kwargs)
+
+        build_json = build_request.render()
+        assert fnmatch.fnmatch(build_json['metadata']['name'], expected_name)
+
+    def test_render_with_yum_repourls(self):
+        kwargs = get_sample_prod_params()
+        build_request = BuildRequestV2(INPUTS_PATH)
+
+        # Test validation for yum_repourls parameter
+        kwargs['yum_repourls'] = 'should be a list'
+        with pytest.raises(OsbsValidationException):
+            build_request.set_params(**kwargs)
+
+    @pytest.mark.parametrize('triggers', [  # noqa:F811
+        None,
+        [],
+        [{
+            "type": "Generic",
+            "generic": {
+                "secret": "secret101",
+                "allowEnv": True
+            }
+        }]
+    ])
+    def test_render_prod_with_falsey_triggers(self, tmpdir, triggers):
+
+        self.create_image_change_trigger_json(str(tmpdir), custom_triggers=triggers)
+        build_request = BuildRequestV2(str(tmpdir))
+        kwargs = get_sample_prod_params()
+        build_request.set_params(**kwargs)
+        build_request.render()
+
+    @staticmethod
+    def create_image_change_trigger_json(outdir, custom_triggers=USE_DEFAULT_TRIGGERS):
+        """
+        Create JSON templates with an image change trigger added.
+
+        :param outdir: str, path to store modified templates
+        """
+
+        triggers = custom_triggers if custom_triggers is not USE_DEFAULT_TRIGGERS else [
+            {
+                "type": "ImageChange",
+                "imageChange": {
+                    "from": {
+                        "kind": "ImageStreamTag",
+                        "name": "{{BASE_IMAGE_STREAM}}"
+                    }
+                }
+            }
+        ]
+
+        # Make temporary copies of all the JSON files
+        for json_file_path in glob.glob(os.path.join(INPUTS_PATH, '*.json')):
+            basename = os.path.basename(json_file_path)
+            shutil.copy(json_file_path,
+                        os.path.join(outdir, basename))
+
+        # Create a build JSON description with an image change trigger
+        with open(os.path.join(outdir, DEFAULT_OUTER_TEMPLATE), 'r+') as prod_json:
+            build_json = json.load(prod_json)
+
+            # Add the image change trigger
+            build_json['spec']['triggers'] = triggers
+
+            prod_json.seek(0)
+            json.dump(build_json, prod_json)
+            prod_json.truncate()
+
+    @pytest.mark.parametrize('use_auth', (True, False, None))
+    @pytest.mark.parametrize(('scratch', 'isolated'), (
+        (True, False),
+        (False, True),
+        (False, False),
+    ))
+    def test_render_prod_request_with_trigger(self, tmpdir, use_auth, scratch, isolated):
+        self.create_image_change_trigger_json(str(tmpdir))
+        build_request = BuildRequestV2(str(tmpdir))
+        kwargs = get_sample_prod_params()
+        if use_auth is not None:
+            kwargs['use_auth'] = use_auth
+        if scratch:
+            kwargs['scratch'] = scratch
+        if isolated:
+            kwargs['isolated'] = isolated
+            kwargs['release'] = '1.1'
+
+        build_request.set_params(**kwargs)
+        build_json = build_request.render()
+
+        if scratch or isolated:
+            assert "triggers" not in build_json["spec"]
+        else:
+            assert "triggers" in build_json["spec"]
+            assert (build_json["spec"]["triggers"][0]["imageChange"]["from"]["name"] ==
+                    'fedora:latest')
+
+    @pytest.mark.parametrize('use_auth', (True, False, None))
+    @pytest.mark.parametrize('koji_parent_build', ('fedora-26-9', None))
+    def test_render_custom_base_image_with_trigger(self, tmpdir,  use_auth, koji_parent_build):
+        # name_label = "fedora/resultingimage"
+        self.create_image_change_trigger_json(str(tmpdir))
+        build_request = BuildRequestV2(str(tmpdir))
+
+        kwargs = get_sample_prod_params()
+        kwargs['base_image'] = 'koji/image-build'
+        if use_auth is not None:
+            kwargs['use_auth'] = use_auth
+        if koji_parent_build:
+            kwargs['koji_parent_build'] = koji_parent_build
+
+        build_request.set_params(**kwargs)
+        build_json = build_request.render()
+
+        assert build_request.is_custom_base_image() is True
+
+        # Verify the triggers are now disabled
+        assert "triggers" not in build_json["spec"]
+
+    @pytest.mark.parametrize(('extra_kwargs', 'expected_error'), (  
+        ({'isolated': True}, 'release parameter is required'),
+        ({'isolated': True, 'release': '1'}, 'must be in the format'),
+        ({'isolated': True, 'release': '1.1'}, None),
+    ))
+    def test_adjust_for_isolated(self, tmpdir, extra_kwargs, expected_error):  
+        self.create_image_change_trigger_json(str(tmpdir))
+        build_request = BuildRequestV2(str(tmpdir))
+
+        kwargs = get_sample_prod_params()
+        kwargs.update(extra_kwargs)
+        build_request.set_params(**kwargs)
+
+        if expected_error:
+            with pytest.raises(OsbsValidationException) as exc_info:
+                build_request.render()
+            assert expected_error in str(exc_info.value)
+
+        else:
+            build_json = build_request.render()
+
+            assert 'triggers' not in build_json['spec']
+            assert build_json['metadata']['labels']['isolated'] == 'true'
+            assert build_json['metadata']['labels']['isolated-release'] == extra_kwargs['release']
+
+    @pytest.mark.parametrize(('autorebuild_enabled', 'release_label', 'expected'), (
+        (True, None, True),
+        (True, 'release', RuntimeError),
+        (True, 'Release', RuntimeError),
+        (False, 'release', False),
+        (False, 'Release', False),
+    ))
+    def test_render_prod_request_with_repo_info(self, tmpdir,
+                                                autorebuild_enabled, release_label,
+                                                expected):
+        self.create_image_change_trigger_json(str(tmpdir))
+
+        class MockDfParser(object):
+            labels = {release_label: '13'} if release_label else {}
+
+        (flexmock(RepoConfiguration)
+            .should_receive('is_autorebuild_enabled')
+            .and_return(autorebuild_enabled))
+
+        repo_info = RepoInfo(MockDfParser())
+
+        build_request_kwargs = get_sample_prod_params()
+        base_image = build_request_kwargs['base_image']
+        build_request = BuildRequestV2(str(tmpdir))
+        build_request.set_params(**build_request_kwargs)
+        build_request.set_repo_info(repo_info)
+        if isinstance(expected, type):
+            with pytest.raises(expected):
+                build_json = build_request.render()
+            return
+
+        build_json = build_request.render()
+
+        if expected:
+            assert build_json["spec"]["triggers"][0]["imageChange"]["from"]["name"] == base_image
+
+        else:
+            assert 'triggers' not in build_json['spec']
+
+    @pytest.mark.parametrize(('base_image', 'is_custom'), [
+        ('fedora', False),
+        ('fedora:latest', False),
+        ('koji/image-build', True),
+        ('koji/image-build:spam.conf', True),
+    ])
+    def test_prod_is_custom_base_image(self, tmpdir, base_image, is_custom):
+        build_request = BuildRequestV2(INPUTS_PATH)
+        # Safe to call prior to build image being set
+        assert build_request.is_custom_base_image() is False
+
+        kwargs = get_sample_prod_params()
+        kwargs['base_image'] = base_image
+        build_request.set_params(**kwargs)
+        build_request.render()
+
+        assert build_request.is_custom_base_image() == is_custom
+
+    @pytest.mark.parametrize(('platform', 'platforms', 'is_auto', 'scratch',
+                              'isolated', 'expected'), [
+        (None, None, False, False, False, {'explicit1': 'yes',
+                                           'explicit2': 'yes'}),
+        (None, None, False, True, False, {'scratch1': 'yes',
+                                          'scratch2': 'yes'}),
+        (None, None, True, False, False, {'auto1': 'yes',
+                                          'auto2': 'yes'}),
+        (None, None, False, False, True, {'isolated1': 'yes',
+                                          'isolated2': 'yes'}),
+        (None, ["x86"], False, False, False, {}),
+        (None, ["ppc"], False, False, False, {}),
+        (None, ["x86"], True, False, False, {}),
+        (None, ["ppc"], False, True, False, {}),
+        (None, ["ppc"], False, False, True, {}),
+        ("x86", None, False, False, False, {'explicit1': 'yes',
+                                            'explicit2': 'yes',
+                                            'plx86a': 'yes',
+                                            'plx86b': 'yes'}),
+        ("x86", None, False, True, False, {'scratch1': 'yes',
+                                           'scratch2': 'yes',
+                                           'plx86a': 'yes',
+                                           'plx86b': 'yes'}),
+        ("x86", None, True, False, False, {'auto1': 'yes',
+                                           'auto2': 'yes',
+                                           'plx86a': 'yes',
+                                           'plx86b': 'yes'}),
+        ("x86", None, False, False, True, {'isolated1': 'yes',
+                                           'isolated2': 'yes',
+                                           'plx86a': 'yes',
+                                           'plx86b': 'yes'}),
+        ("ppc", None, False, False, False, {'explicit1': 'yes',
+                                            'explicit2': 'yes',
+                                            'plppc1': 'yes',
+                                            'plppc2': 'yes'}),
+        ("ppc", None, False, True, False, {'scratch1': 'yes',
+                                           'scratch2': 'yes',
+                                           'plppc1': 'yes',
+                                           'plppc2': 'yes'}),
+        ("ppc", None, True, False, False, {'auto1': 'yes',
+                                           'auto2': 'yes',
+                                           'plppc1': 'yes',
+                                           'plppc2': 'yes'}),
+        ("ppc", None, False, False, True, {'isolated1': 'yes',
+                                           'isolated2': 'yes',
+                                           'plppc1': 'yes',
+                                           'plppc2': 'yes'}),
+    ])
+    def test_check_set_nodeselectors(self, platform, platforms, is_auto, scratch,
+                                     isolated, expected):
+        platform_nodeselectors = {
+            'x86': {
+                'plx86a': 'yes',
+                'plx86b': 'yes'
+            },
+            'ppc': {
+                'plppc1': 'yes',
+                'plppc2': 'yes'
+            }
+        }
+        built_type_nodeselectors = {
+            'auto': {
+                'auto1': 'yes',
+                'auto2': 'yes'
+            },
+            'explicit': {
+                'explicit1': 'yes',
+                'explicit2': 'yes'
+            },
+            'scratch': {
+                'scratch1': 'yes',
+                'scratch2': 'yes'
+            },
+            'isolated': {
+                'isolated1': 'yes',
+                'isolated2': 'yes'
+            }
+        }
+
+        br = BuildRequestV2(INPUTS_PATH)
+        kwargs = get_sample_prod_params()
+        if platforms:
+            kwargs['platforms'] = [platforms]
+        else:
+            kwargs['platforms'] = None
+
+        if platform:
+            kwargs['platform_node_selector'] = platform_nodeselectors[platform]
+
+        kwargs['is_auto'] = is_auto
+        kwargs['scratch'] = scratch
+        kwargs['isolated'] = isolated
+        if isolated:
+            kwargs['release'] = '1.0'
+        kwargs['scratch_build_node_selector'] = built_type_nodeselectors['scratch']
+        kwargs['explicit_build_node_selector'] = built_type_nodeselectors['explicit']
+        kwargs['auto_build_node_selector'] = built_type_nodeselectors['auto']
+        kwargs['isolated_build_node_selector'] = built_type_nodeselectors['isolated']
+        br.set_params(**kwargs)
+        build_json = br.render()
+
+        if expected:
+            assert build_json['spec']['nodeSelector'] == expected
+        else:
+            assert 'nodeSelector' not in build_json['spec']
+
+    @pytest.mark.parametrize('reactor_config_map', [
+        None,
+        'reactor-config-map',
+    ])
+    def test_set_config_map(self, reactor_config_map):
+        br = BuildRequestV2(INPUTS_PATH)
+        kwargs = get_sample_prod_params()
+        kwargs['reactor_config_map'] = reactor_config_map
+        br.set_params(**kwargs)
+        build_json = br.render()
+
+        json_env = build_json['spec']['strategy']['customStrategy']['env']
+        envs = {}
+        for env in json_env:
+            envs[env['name']] = (env.get('valueFrom', None), env.get('value', None))
+
+        if reactor_config_map:
+            configmapkeyref = {
+                'name': reactor_config_map,
+                'key': 'config.yaml'
+            }
+            assert 'REACTOR_CONFIG' in envs
+            assert 'configMapKeyRef' in envs['REACTOR_CONFIG'][0]
+            assert envs['REACTOR_CONFIG'][0]['configMapKeyRef'] == configmapkeyref
+
+        else:
+            assert 'REACTOR_CONFIG' not in envs
+
+    @pytest.mark.parametrize('platforms', [
+        None,
+        ['some'],
+    ])
+    @pytest.mark.parametrize('reactor_config_map', [
+        None,
+        {},
+        {'required_secrets': ['secret4', 'secret5']},
+        {'required_secrets': ['secret4', 'secret5', 'reactor_secret']},
+        {'required_secrets': ['secret4', 'secret5'],
+         'worker_token_secrets': []},
+        {'required_secrets': ['secret4', 'secret5', 'reactor_secret'],
+         'worker_token_secrets': []},
+        {'required_secrets': ['secret4', 'secret5'],
+         'worker_token_secrets': ['secret7', 'secret8']},
+        {'required_secrets': ['secret4', 'secret5'],
+         'worker_token_secrets': ['secret4', 'secret5', 'secret9']},
+        {'required_secrets': ['secret4', 'secret5', 'reactor_secret'],
+         'worker_token_secrets': ['secret7', 'secret8']},
+    ])
+    def test_set_required_secrets(self, platforms, reactor_config_map):
+        reactor_config_name = 'REACTOR_CONFIG'
+        all_secrets = deepcopy(reactor_config_map)
+
+        br = BuildRequestV2(INPUTS_PATH)
+        mock_api = MockOSBSApi(all_secrets)
+        kwargs = get_sample_prod_params(osbs_api=mock_api)
+        kwargs['reactor_config_map'] = reactor_config_map
+        br.set_params(**kwargs)
+        build_json = br.render()
+
+        json_custom = build_json['spec']['strategy']['customStrategy']
+
+        if not reactor_config_map:
+            assert not json_custom['secrets']
+            return
+
+        expect_secrets = {}
+
+        if reactor_config_map:
+            for secret in reactor_config_map['required_secrets']:
+                expect_secrets[secret] = os.path.join(SECRETS_PATH, secret)
+            if platforms and 'worker_token_secrets' in reactor_config_map:
+                for secret in reactor_config_map['worker_token_secrets']:
+                    expect_secrets[secret] = os.path.join(SECRETS_PATH, secret)
+
+        got_secrets = {}
+        for secret in json_custom['secrets']:
+            got_secrets[secret['secretSource']['name']] = secret['mountPath']
+
+        assert expect_secrets == got_secrets

--- a/tests/build_/test_plugins_configuration.py
+++ b/tests/build_/test_plugins_configuration.py
@@ -1,0 +1,668 @@
+"""
+Copyright (c) 2018 Red Hat, Inc
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+"""
+import json
+import os
+
+from osbs.build.user_params import BuildUserParams
+from osbs.build.plugins_configuration import PluginsConfiguration
+from osbs.constants import (BUILD_TYPE_WORKER, BUILD_TYPE_ORCHESTRATOR,
+                            ADDITIONAL_TAGS_FILE, REACTOR_CONFIG_ARRANGEMENT_VERSION)
+from osbs.exceptions import OsbsValidationException
+from osbs.conf import Configuration
+
+import pytest
+
+from tests.constants import (INPUTS_PATH, TEST_BUILD_CONFIG,
+                             TEST_COMPONENT, TEST_FLATPAK_BASE_IMAGE,
+                             TEST_GIT_BRANCH, TEST_GIT_REF, TEST_GIT_URI,
+                             TEST_FILESYSTEM_KOJI_TASK_ID, TEST_SCRATCH_BUILD_NAME,
+                             TEST_ISOLATED_BUILD_NAME, TEST_USER)
+# These are used as fixtures
+from tests.fake_api import openshift, osbs  # noqa
+
+
+USE_DEFAULT_TRIGGERS = object()
+
+
+class NoSuchPluginException(Exception):
+    pass
+
+
+def get_sample_prod_params(build_type=BUILD_TYPE_ORCHESTRATOR):
+    return {
+        'git_uri': TEST_GIT_URI,
+        'git_ref': TEST_GIT_REF,
+        'git_branch': TEST_GIT_BRANCH,
+        'user': TEST_USER,
+        'component': TEST_COMPONENT,
+        'base_image': 'fedora:latest',
+        'name_label': 'fedora/resultingimage',
+        'koji_target': 'koji-target',
+        'platforms': ['x86_64'],
+        'filesystem_koji_task_id': TEST_FILESYSTEM_KOJI_TASK_ID,
+        'build_from': 'image:buildroot:latest',
+        'build_type': build_type,
+    }
+
+
+def get_sample_user_params(extra_args=None, build_type=BUILD_TYPE_ORCHESTRATOR):
+    sample_params = get_sample_prod_params(build_type)
+    if extra_args:
+        sample_params.update(extra_args)
+    user_params = BuildUserParams(INPUTS_PATH)
+    user_params.set_params(**sample_params)
+    return user_params
+
+
+def get_plugins_from_build_json(build_json):
+    return json.loads(build_json)
+
+
+def get_plugin(plugins, plugin_type, plugin_name):
+    plugins = plugins[plugin_type]
+    for plugin in plugins:
+        if plugin["name"] == plugin_name:
+            return plugin
+    else:
+        raise NoSuchPluginException()
+
+
+def has_plugin(plugins, plugin_type, plugin_name):
+    try:
+        get_plugin(plugins, plugin_type, plugin_name)
+    except NoSuchPluginException:
+        return False
+    return True
+
+
+def plugin_value_get(plugins, plugin_type, plugin_name, *args):
+    result = get_plugin(plugins, plugin_type, plugin_name)
+    for arg in args:
+        result = result[arg]
+    return result
+
+
+class TestPluginsConfiguration(object):
+
+    def assert_import_image_plugin(self, plugins, name_label):
+        phase = 'postbuild_plugins'
+        plugin = 'import_image'
+
+        assert get_plugin(plugins, phase, plugin)
+        plugin_args = plugin_value_get(plugins, phase, plugin, 'args')
+
+        assert plugin_args['imagestream'] == name_label.replace('/', '-')
+
+    def assert_koji_upload_plugin(self, plugins):
+        phase = 'postbuild_plugins'
+        name = 'koji_upload'
+
+        assert get_plugin(plugins, phase, name)
+        plugin_args = plugin_value_get(plugins, phase, name, 'args')
+        assert plugin_args.get('build_json_dir')
+
+    @pytest.mark.parametrize('build_type', (BUILD_TYPE_ORCHESTRATOR, BUILD_TYPE_WORKER))
+    def test_render_koji_upload(self, build_type):
+        user_params = get_sample_user_params(build_type=build_type)
+        build_json = PluginsConfiguration(user_params).render()
+        plugins = get_plugins_from_build_json(build_json)
+        if build_type == BUILD_TYPE_WORKER:
+            self.assert_koji_upload_plugin(plugins)
+        else:
+            with pytest.raises(NoSuchPluginException):
+                assert get_plugin(plugins, 'postbuild_plugins', 'koji_upload')
+
+    @pytest.mark.parametrize(('base_image', 'scratch', 'enabled'), (
+        ('fedora:latest', True, False),
+        ('fedora:latest', False, True),
+        ('fedora:latest', False, False),
+        ('koji/image-build', False, False),
+        ('koji/image-build', True, False),
+    ))
+    def test_render_koji_import(self, base_image, scratch, enabled):
+        plugin_type = 'exit_plugins'
+        plugin_name = 'koji_import'
+
+        extra_args = None
+        if not enabled:
+            extra_args = {'koji_target': None}
+
+        user_params = get_sample_user_params(extra_args)
+        build_json = PluginsConfiguration(user_params).render()
+        plugins = get_plugins_from_build_json(build_json)
+
+        if not enabled:
+            with pytest.raises(NoSuchPluginException):
+                get_plugin(plugins, plugin_type, plugin_name)
+            return
+
+        assert get_plugin(plugins, plugin_type, plugin_name)
+
+        actual_plugin_args = plugin_value_get(plugins, plugin_type, plugin_name, 'args')
+
+        expected_plugin_args = {'koji_keytab': False,
+                                'target': 'koji-target',
+                                'verify_ssl': False}
+
+        assert actual_plugin_args == expected_plugin_args
+
+    def test_render_simple_request(self):
+        user_params = get_sample_user_params()
+        build_json = PluginsConfiguration(user_params).render()
+        plugins = get_plugins_from_build_json(build_json)
+
+        pull_base_image = get_plugin(plugins, "prebuild_plugins", "pull_base_image")
+        assert pull_base_image is not None
+        assert ('args' not in pull_base_image or
+                'parent_registry' not in pull_base_image['args'] or
+                not pull_base_image['args']['parent_registry'])
+
+    @pytest.mark.parametrize('build_type', (BUILD_TYPE_ORCHESTRATOR, BUILD_TYPE_WORKER))
+    @pytest.mark.parametrize(('build_image', 'imagestream_name', 'valid'), (
+        (None, None, False),
+        ('ultimate-buildroot:v1.0', None, True),
+        (None, 'buildroot-stream:v1.0', True),
+        ('ultimate-buildroot:v1.0', 'buildroot-stream:v1.0', False)
+    ))
+    def test_render_request_with_yum(self, build_image, imagestream_name, valid, build_type):
+        extra_args = {
+            'build_image': build_image,
+            'build_imagestream': imagestream_name,
+            'name_label': "fedora/resultingimage",
+            'build_from': None,
+            'yum_repourls': ["http://example.com/my.repo"],
+            'build_type': build_type,
+        }
+
+        if valid:
+            user_params = get_sample_user_params(extra_args)
+            build_json = PluginsConfiguration(user_params).render()
+        else:
+            with pytest.raises(OsbsValidationException):
+                user_params = get_sample_user_params(extra_args)
+                build_json = PluginsConfiguration(user_params).render()
+            return
+
+        plugins = get_plugins_from_build_json(build_json)
+
+        with pytest.raises(NoSuchPluginException):
+            get_plugin(plugins, "prebuild_plugins",
+                       "stop_autorebuild_if_disabled")
+
+        with pytest.raises(NoSuchPluginException):
+            get_plugin(plugins, "prebuild_plugins", "koji")
+
+        if imagestream_name and build_type == BUILD_TYPE_ORCHESTRATOR:
+            assert get_plugin(plugins, "exit_plugins", "import_image")
+        else:
+            with pytest.raises(NoSuchPluginException):
+                get_plugin(plugins, "postbuild_plugins", "import_image")
+
+        if build_type == BUILD_TYPE_WORKER:
+            assert plugin_value_get(plugins, "prebuild_plugins", "add_yum_repo_by_url",
+                                    "args", "repourls") == ["http://example.com/my.repo"]
+        else:
+            with pytest.raises(NoSuchPluginException):
+                get_plugin(plugins, "prebuild_plugins", "add_yum_repo_by_url")
+
+        labels = plugin_value_get(plugins, "prebuild_plugins", "add_labels_in_dockerfile",
+                                  "args", "labels")
+
+        assert labels is not None
+        assert 'release' not in labels
+
+    # May be incomplete
+    @pytest.mark.parametrize(('extra_args', 'expected_name'), (
+        ({'isolated': True, 'release': '1.1'}, TEST_ISOLATED_BUILD_NAME),
+        ({'scratch': True}, TEST_SCRATCH_BUILD_NAME),
+        ({}, TEST_BUILD_CONFIG),
+    ))
+    def test_render_build_name(self, tmpdir, extra_args, expected_name):
+        user_params = get_sample_user_params(extra_args)
+        build_json = PluginsConfiguration(user_params).render()
+
+        assert get_plugins_from_build_json(build_json)
+
+    @pytest.mark.parametrize('build_type', (BUILD_TYPE_ORCHESTRATOR, BUILD_TYPE_WORKER))
+    @pytest.mark.parametrize('compose_ids', (None, [], [42], [42, 2]))
+    def test_render_flatpak(self, compose_ids, build_type):
+        extra_args = {
+            'flatpak': True,
+            'compose_ids': compose_ids,
+            'flatpak_base_image': TEST_FLATPAK_BASE_IMAGE,
+            'base_image': TEST_FLATPAK_BASE_IMAGE,
+            'build_type': build_type,
+        }
+
+        user_params = get_sample_user_params(extra_args)
+        build_json = PluginsConfiguration(user_params).render()
+
+        plugins = get_plugins_from_build_json(build_json)
+
+        plugin = get_plugin(plugins, "prebuild_plugins", "resolve_module_compose")
+        assert plugin
+
+        args = plugin['args']
+        # compose_ids will always have a value of at least []
+        if compose_ids is None:
+            assert args['compose_ids'] == []
+        else:
+            assert args['compose_ids'] == compose_ids
+
+        plugin = get_plugin(plugins, "prebuild_plugins", "flatpak_create_dockerfile")
+        assert plugin
+
+        args = plugin['args']
+        assert args['base_image'] == TEST_FLATPAK_BASE_IMAGE
+
+        if build_type == BUILD_TYPE_ORCHESTRATOR:
+            plugin = get_plugin(plugins, "prebuild_plugins", "bump_release")
+            assert plugin
+
+            args = plugin['args']
+            assert args['append'] is True
+            with pytest.raises(NoSuchPluginException):
+                get_plugin(plugins, "prepublish_plugins", "flatpak_create_oci")
+        else:
+            assert get_plugin(plugins, "prepublish_plugins", "flatpak_create_oci")
+            with pytest.raises(NoSuchPluginException):
+                plugin = get_plugin(plugins, "prebuild_plugins", "bump_release")
+
+        with pytest.raises(NoSuchPluginException):
+            assert get_plugin(plugins, "prepublish_plugins", "squash")
+        with pytest.raises(NoSuchPluginException):
+            assert get_plugin(plugins, "postbuild_plugins", "import_image")
+
+    @pytest.mark.parametrize('build_type', (BUILD_TYPE_ORCHESTRATOR, BUILD_TYPE_WORKER))
+    def test_render_prod_not_flatpak(self, build_type):
+        extra_args = {
+            'flatpak': False,
+            'build_type': build_type,
+        }
+        user_params = get_sample_user_params(extra_args)
+        build_json = PluginsConfiguration(user_params).render()
+
+        plugins = get_plugins_from_build_json(build_json)
+
+        with pytest.raises(NoSuchPluginException):
+            get_plugin(plugins, "prebuild_plugins", "resolve_module_compose")
+        with pytest.raises(NoSuchPluginException):
+            get_plugin(plugins, "prebuild_plugins", "flatpak_create_dockerfile")
+        with pytest.raises(NoSuchPluginException):
+            get_plugin(plugins, "prepublish_plugins", "flatpak_create_oci")
+        if build_type == BUILD_TYPE_ORCHESTRATOR:
+            with pytest.raises(NoSuchPluginException):
+                assert get_plugin(plugins, "prepublish_plugins", "squash")
+            assert get_plugin(plugins, "exit_plugins", "import_image")
+        else:
+            assert get_plugin(plugins, "prepublish_plugins", "squash")
+
+    @pytest.mark.parametrize(('disabled', 'release'), (
+        (False, None),
+        (True, '1.2.1'),
+        (False, None),
+    ))
+    @pytest.mark.parametrize('flatpak', (True, False))
+    def test_render_bump_release(self, disabled, release, flatpak):
+        extra_args = {
+            'release': release,
+            'flatpak': flatpak,
+            'build_type': BUILD_TYPE_ORCHESTRATOR,
+        }
+
+        user_params = get_sample_user_params(extra_args)
+        build_json = PluginsConfiguration(user_params).render()
+
+        plugins = get_plugins_from_build_json(build_json)
+
+        labels = plugin_value_get(plugins, "prebuild_plugins", "add_labels_in_dockerfile",
+                                  "args", "labels")
+        assert labels.get('release') == release
+
+        if disabled:
+            with pytest.raises(NoSuchPluginException):
+                get_plugin(plugins, "prebuild_plugins", "bump_release")
+            return
+
+        plugin = get_plugin(plugins, "prebuild_plugins", "bump_release")
+        assert plugin
+        if plugin.get('args'):
+            assert plugin['args'].get('append', False) == flatpak
+
+    @pytest.mark.parametrize(('extra_args', 'has_platform_tag', 'extra_tags', 'primary_tags'), (
+        # Worker build cases
+        ({'build_type': BUILD_TYPE_WORKER, 'platform': 'x86_64'}, True, (), ()),
+        ({'build_type': BUILD_TYPE_WORKER, 'platform': 'x86_64'}, True, ('tag1', 'tag2'), ()),
+        ({'build_type': BUILD_TYPE_WORKER, 'platform': 'x86_64', 'scratch': True}, True, (), ()),
+        ({'build_type': BUILD_TYPE_WORKER, 'platform': 'x86_64',
+          'isolated': True, 'release': '1.1'}, True, (), ()),
+        # Orchestrator build cases
+        ({'build_type': BUILD_TYPE_ORCHESTRATOR, 'platforms': ['x86_64']},
+         False, ('tag1', 'tag2'), ('latest', '{version}', '{version}-{release}', 'tag1', 'tag2')),
+        ({'build_type': BUILD_TYPE_ORCHESTRATOR, 'platforms': ['x86_64']},
+         False, (), ('latest', '{version}', '{version}-{release}')),
+        ({'build_type': BUILD_TYPE_ORCHESTRATOR, 'platforms': ['x86_64'], 'scratch': True},
+         False, ('tag1', 'tag2'), ()),
+        ({'build_type': BUILD_TYPE_ORCHESTRATOR, 'platforms': ['x86_64'], 'isolated': True,
+          'release': '1.1'},
+         False, ('tag1', 'tag2'), ('{version}-{release}',)),
+        # When build_type is not specified, no primary tags are set
+        ({}, False, (), ()),
+        ({}, False, ('tag1', 'tag2'), ()),
+        ({'scratch': True}, False, (), ()),
+        ({'isolated': True, 'release': '1.1'}, False, (), ()),
+    ))
+    def test_render_tag_from_config(self, tmpdir, extra_args, has_platform_tag, extra_tags,
+                                    primary_tags):
+        kwargs = get_sample_prod_params(BUILD_TYPE_WORKER)
+        kwargs.pop('platforms', None)
+        kwargs.pop('platform', None)
+        expected_primary = set(primary_tags)
+
+        if extra_tags:
+            with open(os.path.join(str(tmpdir), ADDITIONAL_TAGS_FILE), 'w') as f:
+                f.write('\n'.join(extra_tags))
+            extra_args['additional_tag_data'] = {
+                'dir_path': str(tmpdir),
+                'file_name': ADDITIONAL_TAGS_FILE,
+                'tags': set(),
+            }
+        kwargs.update(extra_args)
+        user_params = BuildUserParams(INPUTS_PATH)
+        user_params.set_params(**kwargs)
+        build_json = PluginsConfiguration(user_params).render()
+
+        plugins = get_plugins_from_build_json(build_json)
+
+        assert get_plugin(plugins, 'postbuild_plugins', 'tag_from_config')
+        tag_suffixes = plugin_value_get(plugins, 'postbuild_plugins', 'tag_from_config',
+                                        'args', 'tag_suffixes')
+        assert len(tag_suffixes['unique']) == 1
+        if has_platform_tag:
+            unique_tag_suffix = tag_suffixes['unique'][0]
+            assert unique_tag_suffix.endswith('-x86_64') == has_platform_tag
+        assert len(tag_suffixes['primary']) == len(expected_primary)
+        assert set(tag_suffixes['primary']) == expected_primary
+
+    @pytest.mark.parametrize(('platforms', 'disabled'), (
+        (['x86_64', 'ppc64le'], False),
+        (None, True),
+    ))
+    @pytest.mark.parametrize('koji_parent_build', ['fedora-26-9', None])
+    @pytest.mark.parametrize(('build_from', 'build_image', 'build_imagestream',
+                              'worker_build_image', 'valid'), (
+
+        ('image:fedora:latest', 'fedora:latest', None, 'fedora:latest', False),
+        ('image:fedora:latest', 'fedora:latest', 'buildroot-stream:v1.0', 'fedora:latest', False),
+        ('image:fedora:latest', None, 'buildroot-stream:v1.0', 'fedora:latest', False),
+        (None, 'fedora:latest', None, 'fedora:latest', True),
+        ('image:fedora:latest', None, None, 'fedora:latest', True),
+        ('wrong:fedora:latest', None, None, KeyError, False),
+        (None, None, 'buildroot-stream:v1.0', KeyError, True),
+        ('imagestream:buildroot-stream:v1.0', None, None, KeyError, True),
+        ('wrong:buildroot-stream:v1.0', None, None, KeyError, False),
+        (None, 'fedora:latest', 'buildroot-stream:v1.0', KeyError, False),
+    ))
+    @pytest.mark.parametrize('additional_kwargs', (
+        {
+            'flatpak': True,
+            'flatpak_base_image': "fedora:latest",
+        },
+        {},
+    ))
+    def test_render_orchestrate_build(self, tmpdir, platforms, disabled,
+                                      build_from, build_image,
+                                      build_imagestream, worker_build_image,
+                                      additional_kwargs, koji_parent_build, valid):
+        phase = 'buildstep_plugins'
+        plugin = 'orchestrate_build'
+
+        kwargs = {
+            'git_uri': TEST_GIT_URI,
+            'git_ref': TEST_GIT_REF,
+            'user': "john-foo",
+            'component': TEST_COMPONENT,
+            'base_image': 'fedora:latest',
+            'name_label': 'fedora/resultingimage',
+            'platforms': platforms,
+            'build_type': BUILD_TYPE_ORCHESTRATOR,
+        }
+        if build_image:
+            kwargs['build_image'] = build_image
+        if build_imagestream:
+            kwargs['build_imagestream'] = build_imagestream
+        if build_from:
+            kwargs['build_from'] = build_from
+        if koji_parent_build:
+            kwargs['koji_parent_build'] = koji_parent_build
+        kwargs.update(additional_kwargs)
+
+        user_params = BuildUserParams(INPUTS_PATH)
+
+        if valid:
+            user_params.set_params(**kwargs)
+            build_json = PluginsConfiguration(user_params).render()
+        else:
+            with pytest.raises(OsbsValidationException):
+                user_params.set_params(**kwargs)
+                build_json = PluginsConfiguration(user_params).render()
+            return
+
+        plugins = get_plugins_from_build_json(build_json)
+
+        if disabled:
+            with pytest.raises(NoSuchPluginException):
+                get_plugin(plugins, phase, plugin)
+
+        else:
+            assert plugin_value_get(plugins, phase, plugin, 'args', 'platforms') == platforms
+            build_kwargs = plugin_value_get(plugins, phase, plugin, 'args', 'build_kwargs')
+            assert build_kwargs['arrangement_version'] == REACTOR_CONFIG_ARRANGEMENT_VERSION
+            assert build_kwargs.get('koji_parent_build') == koji_parent_build
+
+            worker_config_kwargs = plugin_value_get(plugins, phase, plugin, 'args',
+                                                    'config_kwargs')
+
+            worker_config = Configuration(conf_file=None, **worker_config_kwargs)
+
+            if isinstance(worker_build_image, type):
+                with pytest.raises(worker_build_image):
+                    worker_config_kwargs['build_image']
+                assert not worker_config.get_build_image()
+            else:
+                assert worker_config_kwargs['build_image'] == worker_build_image
+                assert worker_config.get_build_image() == worker_build_image
+
+            if kwargs.get('flatpak', False):
+                assert kwargs.get('flatpak') is True
+                assert kwargs.get('flatpak_base_image') == worker_config.get_flatpak_base_image()
+
+    def test_prod_custom_base_image(self, tmpdir):
+        kwargs = get_sample_prod_params()
+        kwargs['base_image'] = 'koji/image-build'
+        kwargs['yum_repourls'] = ["http://example.com/my.repo"]
+
+        user_params = BuildUserParams(INPUTS_PATH)
+        user_params.set_params(**kwargs)
+        build_json = PluginsConfiguration(user_params).render()
+        plugins = get_plugins_from_build_json(build_json)
+
+        with pytest.raises(NoSuchPluginException):
+            get_plugin(plugins, 'prebuild_plugins', 'pull_base_image')
+
+        add_filesystem_args = plugin_value_get(
+            plugins, 'prebuild_plugins', 'add_filesystem', 'args')
+        assert add_filesystem_args['repos'] == kwargs['yum_repourls']
+        assert add_filesystem_args['from_task_id'] == kwargs['filesystem_koji_task_id']
+
+    def test_prod_non_custom_base_image(self, tmpdir):
+        user_params = get_sample_user_params()
+        build_json = PluginsConfiguration(user_params).render()
+        plugins = get_plugins_from_build_json(build_json)
+
+        with pytest.raises(NoSuchPluginException):
+            get_plugin(plugins, 'prebuild_plugins', 'add_filesystem')
+
+        pull_base_image_plugin = get_plugin(
+            plugins, 'prebuild_plugins', 'pull_base_image')
+        assert pull_base_image_plugin is not None
+
+    def test_render_prod_custom_site_plugin_enable(self, tmpdir):
+        # Test to make sure that when we attempt to enable a plugin, it is
+        # actually enabled in the JSON for the build_request after running
+        # build_request.render()
+        sample_params = get_sample_prod_params()
+        user_params = BuildUserParams(INPUTS_PATH)
+        user_params.set_params(**sample_params)
+        plugins_conf = PluginsConfiguration(user_params)
+
+        plugin_type = "exit_plugins"
+        plugin_name = "testing_exit_plugin"
+        plugin_args = {"foo": "bar"}
+
+        plugins_conf.pt.customize_conf['enable_plugins'].append({
+            "plugin_type": plugin_type,
+            "plugin_name": plugin_name,
+            "plugin_args": plugin_args})
+
+        build_json = plugins_conf.render()
+        plugins = get_plugins_from_build_json(build_json)
+
+        assert {
+                "name": plugin_name,
+                "args": plugin_args
+        } in plugins[plugin_type]
+
+    def test_render_prod_custom_site_plugin_disable(self):
+        # Test to make sure that when we attempt to disable a plugin, it is
+        # actually disabled in the JSON for the build_request after running
+        # build_request.render()
+        sample_params = get_sample_prod_params()
+        user_params = BuildUserParams(INPUTS_PATH)
+        user_params.set_params(**sample_params)
+        plugins_conf = PluginsConfiguration(user_params)
+
+        plugin_type = "postbuild_plugins"
+        plugin_name = "compress"
+
+        plugins_conf.pt.customize_conf['disable_plugins'].append(
+            {
+                "plugin_type": plugin_type,
+                "plugin_name": plugin_name
+            }
+        )
+        build_json = plugins_conf.render()
+        plugins = get_plugins_from_build_json(build_json)
+
+        for plugin in plugins[plugin_type]:
+            if plugin['name'] == plugin_name:
+                assert False
+
+    def test_render_prod_custom_site_plugin_override(self):
+        # Test to make sure that when we attempt to override a plugin's args,
+        # they are actually overridden in the JSON for the build_request
+        # after running build_request.render()
+        sample_params = get_sample_prod_params()
+        base_user_params = BuildUserParams(INPUTS_PATH)
+        base_user_params.set_params(**sample_params)
+        base_plugins_conf = PluginsConfiguration(base_user_params)
+        base_build_json = base_plugins_conf.render()
+        base_plugins = get_plugins_from_build_json(base_build_json)
+
+        plugin_type = "exit_plugins"
+        plugin_name = "koji_import"
+        plugin_args = {"foo": "bar"}
+
+        for plugin_dict in base_plugins[plugin_type]:
+            if plugin_dict['name'] == plugin_name:
+                plugin_index = base_plugins[plugin_type].index(plugin_dict)
+
+        user_params = BuildUserParams(INPUTS_PATH)
+        user_params.set_params(**sample_params)
+        plugins_conf = PluginsConfiguration(user_params)
+        plugins_conf.pt.customize_conf['enable_plugins'].append(
+            {
+                "plugin_type": plugin_type,
+                "plugin_name": plugin_name,
+                "plugin_args": plugin_args
+            }
+        )
+        build_json = plugins_conf.render()
+        plugins = get_plugins_from_build_json(build_json)
+
+        assert {
+                "name": plugin_name,
+                "args": plugin_args
+        } in plugins[plugin_type]
+
+        assert base_plugins[plugin_type][plugin_index]['name'] == \
+            plugin_name
+        assert plugins[plugin_type][plugin_index]['name'] == plugin_name
+
+    @pytest.mark.parametrize(('koji_parent_build'), (
+        ('fedora-26-9'),
+        (None),
+    ))
+    def test_render_inject_parent_image(self, koji_parent_build):
+        plugin_type = "prebuild_plugins"
+        plugin_name = "inject_parent_image"
+
+        extra_args = {
+            'koji_parent_build': koji_parent_build,
+        }
+
+        user_params = get_sample_user_params(extra_args)
+        build_json = PluginsConfiguration(user_params).render()
+        plugins = get_plugins_from_build_json(build_json)
+
+        if koji_parent_build:
+            assert get_plugin(plugins, plugin_type, plugin_name)
+            assert plugin_value_get(plugins, plugin_type, plugin_name, 'args',
+                                    'koji_parent_build') == koji_parent_build
+        else:
+            with pytest.raises(NoSuchPluginException):
+                get_plugin(plugins, plugin_type, plugin_name)
+
+    @pytest.mark.parametrize('additional_params', (
+        {'signing_intent': 'release'},
+        {'compose_ids': [1, ]},
+        {'compose_ids': [1, 2]},
+    ))
+    def test_render_resolve_composes(self, additional_params):
+        plugin_type = 'prebuild_plugins'
+        plugin_name = 'resolve_composes'
+
+        user_params = get_sample_user_params(additional_params)
+        build_json = PluginsConfiguration(user_params).render()
+        plugins = get_plugins_from_build_json(build_json)
+
+        assert get_plugin(plugins, plugin_type, plugin_name)
+        assert plugin_value_get(plugins, plugin_type, plugin_name, 'args')
+
+    @pytest.mark.parametrize('yum_repos', [
+        None,
+        [],
+        ["http://example.com/my.repo"],
+    ])
+    def test_remove_resolve_composes(self, yum_repos):
+        plugin_type = 'prebuild_plugins'
+        plugin_name = 'resolve_composes'
+
+        additional_params = {
+            'yum_repourls': yum_repos
+        }
+
+        user_params = get_sample_user_params(additional_params)
+        build_json = PluginsConfiguration(user_params).render()
+        plugins = get_plugins_from_build_json(build_json)
+
+        if yum_repos:
+            with pytest.raises(NoSuchPluginException):
+                get_plugin(plugins, plugin_type, plugin_name)
+        else:
+            assert get_plugin(plugins, plugin_type, plugin_name)

--- a/tests/build_/test_spec.py
+++ b/tests/build_/test_spec.py
@@ -1,19 +1,19 @@
 """
-Copyright (c) 2015 Red Hat, Inc
+Copyright (c) 2015-2018 Red Hat, Inc
 All rights reserved.
 
 This software may be modified and distributed under the terms
 of the BSD license. See the LICENSE file for details.
 """
 import pytest
+import datetime
+import random
+import sys
+
 from flexmock import flexmock
 
 from osbs.build.spec import BuildIDParam, RegistryURIsParam, BuildSpec
 from osbs.exceptions import OsbsValidationException
-
-import datetime
-import random
-import sys
 
 
 class TestBuildIDParam(object):

--- a/tests/build_/test_user_params.py
+++ b/tests/build_/test_user_params.py
@@ -1,0 +1,212 @@
+"""
+Copyright (c) 2015-2018 Red Hat, Inc
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+"""
+import pytest
+from flexmock import flexmock
+
+import datetime
+import random
+import sys
+import json
+
+from osbs.build.user_params import BuildUserParams
+from osbs.exceptions import OsbsValidationException
+from osbs.constants import BUILD_TYPE_WORKER, REACTOR_CONFIG_ARRANGEMENT_VERSION
+from tests.constants import (TEST_COMPONENT, TEST_FILESYSTEM_KOJI_TASK_ID,
+                             TEST_GIT_BRANCH, TEST_GIT_REF, TEST_GIT_URI,
+                             TEST_IMAGESTREAM, TEST_KOJI_TASK_ID, TEST_USER)
+
+
+class TestBuildUserParams(object):
+
+    def get_minimal_kwargs(self):
+        return {
+            # Params needed to avoid exceptions.
+            'user': TEST_USER,
+            'base_image': 'base_image',
+            'name_label': 'name_label',
+            'git_uri': TEST_GIT_URI,
+            'build_from': 'image:buildroot:latest',
+        }
+
+    def test_v2_spec_name2(self):
+        kwargs = self.get_minimal_kwargs()
+        kwargs.update({
+            'git_uri': TEST_GIT_URI,
+            'git_branch': TEST_GIT_BRANCH,
+        })
+
+        spec = BuildUserParams()
+        spec.set_params(**kwargs)
+
+        assert spec.name.value.startswith('path-master')
+
+    @pytest.mark.parametrize('rand,timestr', [
+        ('12345', '20170501123456'),
+        ('67890', '20170731111111'),
+    ])
+    @pytest.mark.parametrize(('platform'), (
+        ('x86_64'),
+        (None),
+    ))
+    def test_v2_image_tag(self, rand, timestr, platform):
+        kwargs = self.get_minimal_kwargs()
+        kwargs.update({
+            'component': 'foo',
+            'koji_target': 'tothepoint',
+        })
+        if platform:
+            kwargs['platform'] = platform
+
+        (flexmock(sys.modules['osbs.build.spec'])
+            .should_receive('utcnow').once()
+            .and_return(datetime.datetime.strptime(timestr, '%Y%m%d%H%M%S')))
+
+        (flexmock(random)
+            .should_receive('randrange').once()
+            .with_args(10**(len(rand) - 1), 10**len(rand))
+            .and_return(int(rand)))
+
+        spec = BuildUserParams()
+        spec.set_params(**kwargs)
+
+        img_tag = '{user}/{component}:{koji_target}-{random_number}-{time_string}'
+        if platform:
+            img_tag += '-{platform}'
+        img_tag = img_tag.format(random_number=rand, time_string=timestr, **kwargs)
+        assert spec.image_tag.value == img_tag
+
+    @pytest.mark.parametrize(('signing_intent', 'compose_ids', 'yum_repourls', 'exc'), (
+        ('release', [1, 2], ['http://example.com/my.repo'], OsbsValidationException),
+        ('release', [1, 2], None, OsbsValidationException),
+        (None, [1, 2], ['http://example.com/my.repo'], OsbsValidationException),
+        ('release', None, ['http://example.com/my.repo'], None),
+        ('release', None, None, None),
+        (None, [1, 2], None, None),
+        (None, None, ['http://example.com/my.repo'], None),
+        (None, None, None, None),
+    ))
+    def test_v2_compose_ids_and_signing_intent(self, signing_intent, compose_ids, yum_repourls,
+                                               exc):
+        kwargs = self.get_minimal_kwargs()
+        if signing_intent:
+            kwargs['signing_intent'] = signing_intent
+        if compose_ids:
+            kwargs['compose_ids'] = compose_ids
+        if yum_repourls:
+            kwargs['yum_repourls'] = yum_repourls
+
+        kwargs.update({
+            'git_uri': 'https://github.com/user/reponame.git',
+            'git_branch': 'master',
+        })
+
+        spec = BuildUserParams()
+
+        if exc:
+            with pytest.raises(exc):
+                spec.set_params(**kwargs)
+        else:
+            spec.set_params(**kwargs)
+
+            if yum_repourls:
+                assert spec.yum_repourls.value == yum_repourls
+            if signing_intent:
+                assert spec.signing_intent.value == signing_intent
+            if compose_ids:
+                assert spec.compose_ids.value == compose_ids
+
+    def test_v2_all_values_and_json(self):
+        # all values that BuildUserParams stores
+        param_kwargs = {
+            # 'arrangement_version': self.arrangement_version,  # calculated value
+            'base_image': 'buildroot:old',
+            # 'build_from': 'buildroot:old',  # only one of build_*
+            # 'build_json_dir': self.build_json_dir,  # init paramater
+            'build_image': 'buildroot:latest',
+            # 'build_imagestream': 'buildroot:name_label',
+            'build_type': BUILD_TYPE_WORKER,
+            'component': TEST_COMPONENT,
+            'compose_ids': [1, 2],
+            'filesystem_koji_task_id': TEST_FILESYSTEM_KOJI_TASK_ID,
+            'flatpak': False,
+            # 'flatpak_base_image': self.flatpak_base_image,  # not used with false flatpack
+            'git_branch': TEST_GIT_BRANCH,
+            'git_ref': TEST_GIT_REF,
+            'git_uri': TEST_GIT_URI,
+            'image_tag': 'user/None:none-0-0',
+            'imagestream_name': TEST_IMAGESTREAM,
+            'isolated': False,
+            'koji_parent_build': 'fedora-26-9',
+            'koji_target': 'tothepoint',
+            # 'name': self.name,  # calculated value
+            'platform': 'x86_64',
+            'platforms': ['x86_64', ],
+            'reactor_config_map': 'reactor-config-map',
+            'release': '29',
+            'scratch': False,
+            'signing_intent': False,
+            'task_id': TEST_KOJI_TASK_ID,
+            'trigger_imagestreamtag': 'base_image:latest',
+            'user': TEST_USER,
+            # 'yum_repourls': ,  # not used with compose_ids
+        }
+        # additional values that BuildUserParams requires but stores under different names
+        param_kwargs.update({
+            'additional_tag_data': {
+                'dir_path': '',
+                'file_name': '',
+                'tags': ('previous', 'next')
+            },
+            'name_label': 'name_label',
+        })
+        rand = '12345'
+        timestr = '20170731111111'
+        (flexmock(sys.modules['osbs.build.spec'])
+            .should_receive('utcnow').once()
+            .and_return(datetime.datetime.strptime(timestr, '%Y%m%d%H%M%S')))
+
+        (flexmock(random)
+            .should_receive('randrange').once()
+            .with_args(10**(len(rand) - 1), 10**len(rand))
+            .and_return(int(rand)))
+
+        build_json_dir = 'inputs'
+        spec = BuildUserParams(build_json_dir)
+        spec.set_params(**param_kwargs)
+        expected_json = {
+            "additional_tags": ["next", "previous"],
+            "arrangement_version": REACTOR_CONFIG_ARRANGEMENT_VERSION,
+            "base_image": "buildroot:old",
+            "build_image": "buildroot:latest",
+            "build_json_dir": build_json_dir,
+            "build_type": "worker",
+            "component": TEST_COMPONENT,
+            "compose_ids": [1, 2],
+            "customize_conf": "prod_customize.json",
+            "filesystem_koji_task_id": TEST_FILESYSTEM_KOJI_TASK_ID,
+            "git_branch": TEST_GIT_BRANCH,
+            "git_ref": TEST_GIT_REF,
+            "git_uri": TEST_GIT_URI,
+            "image_tag": "{0}/{1}:tothepoint-{2}-{3}-x86_64".format(TEST_USER, TEST_COMPONENT,
+                                                                    rand, timestr),
+            "imagestream_name": "name_label",
+            "koji_parent_build": "fedora-26-9",
+            "koji_target": "tothepoint",
+            "name": "path-master-cd1e4",
+            "platform": "x86_64",
+            "platforms": ["x86_64"],
+            "reactor_config_map": "reactor-config-map",
+            "release": "29",
+            "trigger_imagestreamtag": "buildroot:old",
+            "user": TEST_USER
+        }
+        assert spec.to_json() == json.dumps(expected_json, sort_keys=True)
+
+        spec2 = BuildUserParams()
+        spec2.from_json(spec.to_json())
+        assert spec2.to_json() == json.dumps(expected_json, sort_keys=True)


### PR DESCRIPTION
As part of the move to arrangement 6, create PluginsConfiguration, BuildRequestV2 and the
underlying BuildUserParams.

(move from PR733 because github keeps stalling out on me).

Currently the templates are *_inner:7.json to avoid collisions with the DEFAULT_ARRANGEMENT_VERSION tests.

Please review.

Signed-off-by: Mark Langsdorf mlangsdo@redhat.com