### PR TITLE
don't remove reactor_config plugin if config_map is provided

### DIFF
--- a/osbs/build/build_request.py
+++ b/osbs/build/build_request.py
@@ -228,7 +228,9 @@ class BuildRequest(object):
         self.template['metadata']['labels'][name] = value
 
     def render_reactor_config(self):
-        if self.spec.reactor_config_secret.value is None:
+        if self.spec.reactor_config_secret.value is None and \
+                self.spec.reactor_config_map.value is None and \
+                self.spec.reactor_config_override.value is None:
             logger.debug("removing reactor_config plugin: no secret")
             self.dj.remove_plugin('prebuild_plugins', 'reactor_config')
 


### PR DESCRIPTION
Signed-off-by: Robert Cerven <rcerven@redhat.com>