### PR TITLE
Set architecture parameter for add_filesystem

### DIFF
--- a/osbs/build/build_request.py
+++ b/osbs/build/build_request.py
@@ -840,6 +840,10 @@ class BuildRequest(object):
                 self.dj.dock_json_set_arg(phase, plugin, 'architectures',
                                           self.spec.platforms.value)
 
+            if self.spec.platform.value:
+                self.dj.dock_json_set_arg(phase, plugin, 'architecture',
+                                          self.spec.platform.value)
+
             if self.spec.filesystem_koji_task_id.value:
                 self.dj.dock_json_set_arg(phase, plugin, 'from_task_id',
                                           self.spec.filesystem_koji_task_id.value)

--- a/tests/build_/test_arrangements.py
+++ b/tests/build_/test_arrangements.py
@@ -322,6 +322,7 @@ class TestArrangementV1(ArrangementBase):
             allowed_args = set([
                 'koji_hub',
                 'repos',
+                'architecture',
             ])
             assert set(args.keys()) <= allowed_args
             assert 'koji_hub' in args
@@ -480,6 +481,7 @@ class TestArrangementV2(TestArrangementV1):
                 'koji_hub',
                 'repos',
                 'from_task_id',
+                'architecture',
             ])
             assert set(args.keys()) <= allowed_args
             assert 'koji_hub' in args


### PR DESCRIPTION
This parameter is used by add_filesystem plugin to select the arch
specific filesystem tarball.

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>