### PR TITLE
fixes for arrangement 6

### DIFF
--- a/osbs/build/build_requestv2.py
+++ b/osbs/build/build_requestv2.py
@@ -56,6 +56,7 @@ class BuildRequestV2(BuildRequest):
         :param koji_target: str, koji tag with packages used to build the image
         :param koji_task_id: str, koji ID
         :param koji_parent_build: str,
+        :param koji_upload_dir: str, koji directory where the completed image will be uploaded
         :param flatpak: if we should build a Flatpak OCI Image
         :param flatpak_base_image: str, name of the Flatpack OCI Image
         :param reactor_config_map: str, name of the config map containing the reactor environment

--- a/osbs/build/plugins_configuration.py
+++ b/osbs/build/plugins_configuration.py
@@ -384,6 +384,7 @@ class PluginsConfiguration(object):
         def set_arg(arg, value):
             self.pt.set_plugin_arg(phase, name, arg, value)
 
+        set_arg('koji_upload_dir', self.user_params.koji_upload_dir.value)
         set_arg('build_json_dir', self.user_params.build_json_dir.value)
         set_arg('platform', self.user_params.platform.value)
         set_arg('report_multiple_digests', True)

--- a/osbs/build/plugins_configuration.py
+++ b/osbs/build/plugins_configuration.py
@@ -358,8 +358,6 @@ class PluginsConfiguration(object):
         elif self.pt.has_plugin_conf('exit_plugins', 'import_image'):
             self.pt.set_plugin_arg('exit_plugins', 'import_image', 'imagestream',
                                    self.user_params.imagestream_name.value)
-            self.pt.set_plugin_arg('exit_plugins', 'import_image', 'build_json_dir',
-                                   self.user_params.build_json_dir.value)
 
     def render_inject_parent_image(self):
         phase = 'prebuild_plugins'
@@ -385,7 +383,6 @@ class PluginsConfiguration(object):
             self.pt.set_plugin_arg(phase, name, arg, value)
 
         set_arg('koji_upload_dir', self.user_params.koji_upload_dir.value)
-        set_arg('build_json_dir', self.user_params.build_json_dir.value)
         set_arg('platform', self.user_params.platform.value)
         set_arg('report_multiple_digests', True)
 

--- a/osbs/build/user_params.py
+++ b/osbs/build/user_params.py
@@ -46,6 +46,7 @@ class BuildUserParams(BuildCommon):
         self.isolated = BuildParam('isolated', allow_none=True)
         self.koji_parent_build = BuildParam('koji_parent_build', allow_none=True)
         self.koji_task_id = BuildParam('koji_task_id', allow_none=True)
+        self.koji_upload_dir = BuildParam('koji_upload_dir', allow_none=True)
         self.name = BuildIDParam()
         self.platforms = BuildParam('platforms', allow_none=True)
         self.reactor_config_map = BuildParam("reactor_config_map", allow_none=True)
@@ -80,7 +81,7 @@ class BuildUserParams(BuildCommon):
                    build_image=None, build_imagestream=None, build_from=None,
                    platforms=None, platform=None, build_type=None,
                    koji_target=None, koji_task_id=None, filesystem_koji_task_id=None,
-                   koji_parent_build=None,
+                   koji_parent_build=None, koji_upload_dir=None,
                    flatpak=None, flatpak_base_image=None,
                    reactor_config_map=None, reactor_config_override=None,
                    yum_repourls=None, signing_intent=None, compose_ids=None,
@@ -125,6 +126,7 @@ class BuildUserParams(BuildCommon):
         self.koji_task_id.value = koji_task_id
         self.filesystem_koji_task_id.value = filesystem_koji_task_id
         self.koji_parent_build.value = koji_parent_build
+        self.koji_upload_dir.value = koji_upload_dir
         self.flatpak.value = flatpak
         self.flatpak_base_image.value = flatpak_base_image
         self.isolated.value = isolated

--- a/tests/build_/test_arrangements.py
+++ b/tests/build_/test_arrangements.py
@@ -1611,6 +1611,5 @@ class TestArrangementV6(ArrangementBase):
 
         match_args = {
             "imagestream": "fedora23-something",
-            "build_json_dir": "inputs",
         }
         assert match_args == args

--- a/tests/build_/test_plugins_configuration.py
+++ b/tests/build_/test_plugins_configuration.py
@@ -115,7 +115,6 @@ class TestPluginsConfiguration(object):
     def test_render_koji_upload(self, build_type):
         user_params = get_sample_user_params({'koji_upload_dir': 'test'},
                                              build_type=build_type)
-        user_params = get_sample_user_params(build_type=build_type)
         build_json = PluginsConfiguration(user_params).render()
         plugins = get_plugins_from_build_json(build_json)
         if build_type == BUILD_TYPE_WORKER:

--- a/tests/build_/test_plugins_configuration.py
+++ b/tests/build_/test_plugins_configuration.py
@@ -98,14 +98,6 @@ class TestPluginsConfiguration(object):
 
         assert plugin_args['imagestream'] == name_label.replace('/', '-')
 
-    def assert_koji_upload_plugin(self, plugins):
-        phase = 'postbuild_plugins'
-        name = 'koji_upload'
-
-        assert get_plugin(plugins, phase, name)
-        plugin_args = plugin_value_get(plugins, phase, name, 'args')
-        assert plugin_args.get('build_json_dir')
-
     def test_bad_customize_conf(self):
         user_params = BuildUserParams(INPUTS_PATH, customize_conf='invalid_dir')
         build_json = PluginsConfiguration(user_params)
@@ -121,11 +113,15 @@ class TestPluginsConfiguration(object):
 
     @pytest.mark.parametrize('build_type', (BUILD_TYPE_ORCHESTRATOR, BUILD_TYPE_WORKER))
     def test_render_koji_upload(self, build_type):
+        user_params = get_sample_user_params({'koji_upload_dir': 'test'},
+                                             build_type=build_type)
         user_params = get_sample_user_params(build_type=build_type)
         build_json = PluginsConfiguration(user_params).render()
         plugins = get_plugins_from_build_json(build_json)
         if build_type == BUILD_TYPE_WORKER:
-            self.assert_koji_upload_plugin(plugins)
+            assert get_plugin(plugins, 'postbuild_plugins', 'koji_upload')
+            plugin_args = plugin_value_get(plugins, 'postbuild_plugins', 'koji_upload', 'args')
+            assert plugin_args.get('koji_upload_dir') == 'test'
         else:
             with pytest.raises(NoSuchPluginException):
                 assert get_plugin(plugins, 'postbuild_plugins', 'koji_upload')


### PR DESCRIPTION
A handful of fixes for arrangement 6
* add koji_upload_dir to BuildUserParams and koji_upload's rendered args
* remove build_json_dir from the args of some plugins
* change the way that labels are passed to add_labels_in_df

works with https://github.com/projectatomic/atomic-reactor/pull/964