### PR TITLE
Don't pad short usernames (OSBS-5391)

### DIFF
--- a/osbs/build/spec.py
+++ b/osbs/build/spec.py
@@ -48,14 +48,6 @@ class UserParam(BuildParam):
     def __init__(self):
         super(UserParam, self).__init__(self.name)
 
-    @BuildParam.value.setter
-    def value(self, val):  # pylint: disable=W0221
-        try:
-            val = val.ljust(4, "_")  # py3
-        except TypeError:
-            val = val.ljust(4, b"_")  # py2
-        BuildParam.value.fset(self, val)
-
 
 class BuildIDParam(BuildParam):
     """ validate build ID """


### PR DESCRIPTION
Docker versions since 1.12 have not placed any minimum length requirement on the namespace portion of a repository name.

Reference: https://github.com/moby/moby/commit/6f0068f

Fixes #552.

Signed-off-by: Tim Waugh <twaugh@redhat.com>