### PR TITLE
Don't backup Build objects

### DIFF
--- a/osbs/constants.py
+++ b/osbs/constants.py
@@ -61,7 +61,7 @@ SERVICEACCOUNT_CACRT = "ca.crt"
 SECRETS_PATH = "/var/run/secrets/atomic-reactor"
 
 # Backup/restore
-BACKUP_RESOURCES = ('buildconfigs', 'imagestreams', 'builds',)
+BACKUP_RESOURCES = ('buildconfigs', 'imagestreams',)
 
 CLI_LIST_BUILDS_DEFAULT_COLS = ["name", "status", "image"]
 CLI_WATCH_BUILDS_DEFAULT_COLS = ["changetype", "status", "created", "name"]


### PR DESCRIPTION
The information required by OSBS is fully stored in BuildConfig and
ImageStream objects. Additionally, the Build objects are only restored
if they don't have a BuildConfig associated with them. Those are scratch
and isolated builds which we care very little about backing up in OSBS.

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>