### PR TITLE
Run check_and_set_rebuild plugin earlier

### DIFF
--- a/inputs/orchestrator_inner:6.json
+++ b/inputs/orchestrator_inner:6.json
@@ -4,6 +4,13 @@
       "name": "reactor_config"
     },
     {
+      "name": "check_and_set_rebuild",
+      "args": {
+        "label_key": "is_autorebuild",
+        "label_value": "true"
+      }
+    },
+    {
       "name": "check_and_set_platforms",
       "required": false
     },
@@ -33,13 +40,6 @@
     },
     {
       "name": "koji_parent"
-    },
-    {
-      "name": "check_and_set_rebuild",
-      "args": {
-        "label_key": "is_autorebuild",
-        "label_value": "true"
-      }
     },
     {
       "name": "resolve_composes"

--- a/tests/build_/test_arrangements.py
+++ b/tests/build_/test_arrangements.py
@@ -1388,6 +1388,7 @@ class TestArrangementV6(ArrangementBase):
         ORCHESTRATOR_INNER_TEMPLATE: {
             'prebuild_plugins': [
                 'reactor_config',
+                'check_and_set_rebuild',
                 'check_and_set_platforms',
                 'resolve_module_compose',
                 'flatpak_create_dockerfile',
@@ -1397,7 +1398,6 @@ class TestArrangementV6(ArrangementBase):
                 'bump_release',
                 'add_labels_in_dockerfile',
                 'koji_parent',
-                'check_and_set_rebuild',
                 'resolve_composes',
             ],
 


### PR DESCRIPTION
This allows check_and_set_rebuild plugin to modify the current git
commit before other plugins read from git clone.

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>