### PR TITLE
arrangement 6: add deprecation warnings to conf.get_*

### DIFF
--- a/osbs/conf.py
+++ b/osbs/conf.py
@@ -19,7 +19,7 @@ from six.moves.urllib.parse import urljoin
 
 from osbs.constants import (DEFAULT_CONFIGURATION_FILE, DEFAULT_CONFIGURATION_SECTION,
                             GENERAL_CONFIGURATION_SECTION, DEFAULT_NAMESPACE,
-                            DEFAULT_ARRANGEMENT_VERSION)
+                            DEFAULT_ARRANGEMENT_VERSION, REACTOR_CONFIG_ARRANGEMENT_VERSION)
 from osbs.exceptions import OsbsValidationException
 from osbs import utils
 
@@ -101,6 +101,12 @@ class Configuration(object):
                 return bool(int_val)
         else:
             return value
+
+    def _get_deprecated(self, args_key, conf_section, conf_key, default=None, is_bool_val=False):
+        logger.warning("user configuration %s in section %s is ignored in arrangement %s and later",
+                       args_key, conf_section, REACTOR_CONFIG_ARRANGEMENT_VERSION)
+        logger.warning("it has been deprecated in favor of the value in the reactor_config_map")
+        return self._get_value(args_key, conf_section, conf_key, default, is_bool_val)
 
     def get_openshift_required_version(self):
         """
@@ -202,50 +208,52 @@ class Configuration(object):
         return self._get_value("flatpak_base_image", self.conf_section, "flatpak_base_image")
 
     def get_odcs_url(self):
-        return self._get_value("odcs_url", self.conf_section, "odcs_url")
+        return self._get_deprecated("odcs_url", self.conf_section, "odcs_url")
 
     def get_odcs_insecure(self):
-        return self._get_value("odcs_insecure", self.conf_section, "odcs_insecure",
-                               default=False, is_bool_val=True)
+        return self._get_deprecated("odcs_insecure", self.conf_section, "odcs_insecure",
+                                    default=False, is_bool_val=True)
 
     def get_odcs_openidc_secret(self):
-        return self._get_value("odcs_openidc_secret", self.conf_section, "odcs_openidc_secret")
+        return self._get_deprecated("odcs_openidc_secret", self.conf_section,
+                                    "odcs_openidc_secret")
 
     def get_odcs_ssl_secret(self):
-        return self._get_value("odcs_ssl_secret", self.conf_section, "odcs_ssl_secret")
+        return self._get_deprecated("odcs_ssl_secret", self.conf_section, "odcs_ssl_secret")
 
     def get_pdc_url(self):
-        return self._get_value("pdc_url", self.conf_section, "pdc_url")
+        return self._get_deprecated("pdc_url", self.conf_section, "pdc_url")
 
     def get_pdc_insecure(self):
-        return self._get_value("pdc_insecure", self.conf_section, "pdc_insecure",
-                               default=False, is_bool_val=True)
+        return self._get_deprecated("pdc_insecure", self.conf_section, "pdc_insecure",
+                                    default=False, is_bool_val=True)
 
     def get_kojiroot(self):
-        return self._get_value("koji_root", self.conf_section, "koji_root")
+        return self._get_deprecated("koji_root", self.conf_section, "koji_root")
 
     def get_kojihub(self):
-        return self._get_value("koji_hub", self.conf_section, "koji_hub")
+        return self._get_deprecated("koji_hub", self.conf_section, "koji_hub")
 
     def get_koji_target(self):
         return self._get_value("target", self.conf_section, "target")
 
     def get_koji_certs_secret(self):
-        return self._get_value("koji_certs_secret", self.conf_section, "koji_certs_secret")
+        return self._get_deprecated("koji_certs_secret", self.conf_section, "koji_certs_secret")
 
     def get_koji_use_kerberos(self):
-        return self._get_value("koji_use_kerberos", self.conf_section, "koji_use_kerberos",
-                               is_bool_val=True)
+        return self._get_deprecated("koji_use_kerberos", self.conf_section, "koji_use_kerberos",
+                                    is_bool_val=True)
 
     def get_koji_kerberos_keytab(self):
-        return self._get_value("koji_kerberos_keytab", self.conf_section, "koji_kerberos_keytab")
+        return self._get_deprecated("koji_kerberos_keytab", self.conf_section,
+                                    "koji_kerberos_keytab")
 
     def get_koji_kerberos_principal(self):
-        return self._get_value("koji_kerberos_principal", self.conf_section,
-                               "koji_kerberos_principal")
+        return self._get_deprecated("koji_kerberos_principal", self.conf_section,
+                                    "koji_kerberos_principal")
 
     def get_sources_command(self):
-        return self._get_value("sources_command", self.conf_section, "sources_command")
+        return self._get_deprecated("sources_command", self.conf_section, "sources_command")
 
     def get_username(self):
         return self._get_value("username", self.conf_section, "username")
@@ -272,33 +280,29 @@ class Configuration(object):
         return self._get_value("kerberos_ccache", self.conf_section, "kerberos_ccache")
 
     def get_registry_uris(self):
-        value = self._get_value("registry_uri",
-                                self.conf_section,
-                                "registry_uri")
+        value = self._get_deprecated("registry_uri", self.conf_section, "registry_uri")
         if value:
             return [x.strip() for x in value.split(',')]
         else:
             return []
 
     def get_registry_secrets(self):
-        value = self._get_value("registry_secret", self.conf_section, "registry_secret")
+        value = self._get_deprecated("registry_secret", self.conf_section, "registry_secret")
         if value:
             return [x.strip() for x in value.split(',')]
         else:
             return []
 
     def get_registry_api_versions(self, platform=None):
-        value = self._get_value("registry_api_versions",
-                                self.conf_section,
-                                "registry_api_versions",
-                                default='v1,v2')
+        value = self._get_deprecated("registry_api_versions", self.conf_section,
+                                     "registry_api_versions", default='v1,v2')
         versions = [x.strip() for x in value.split(',')]
         if platform is None:
             return versions
 
         section = 'platform:{0}'.format(platform)
-        enable_v1 = self._get_value("enable_v1", section, "enable_v1",
-                                    default=False, is_bool_val=True)
+        enable_v1 = self._get_deprecated("enable_v1", section, "enable_v1",
+                                         default=False, is_bool_val=True)
         if enable_v1:
             return versions
         else:
@@ -308,18 +312,19 @@ class Configuration(object):
                 raise OsbsValidationException('v2 only platform in v1 only instance')
 
     def get_source_registry_uri(self):
-        return self._get_value("source_registry_uri", self.conf_section, "source_registry_uri")
+        return self._get_deprecated("source_registry_uri", self.conf_section,
+                                    "source_registry_uri")
 
     def get_pulp_registry(self):
-        return self._get_value("pulp_registry_name", self.conf_section, "pulp_registry_name")
+        return self._get_deprecated("pulp_registry_name", self.conf_section, "pulp_registry_name")
 
     def get_prefer_schema1_digest(self):
-        return self._get_value("prefer_schema1_digest", self.conf_section, "prefer_schema1_digest",
-                               is_bool_val=True)
+        return self._get_deprecated("prefer_schema1_digest", self.conf_section,
+                                    "prefer_schema1_digest", is_bool_val=True)
 
     def get_group_manifests(self):
-        return self._get_value("group_manifests", self.conf_section,
-                               "group_manifests", is_bool_val=True)
+        return self._get_deprecated("group_manifests", self.conf_section,
+                                    "group_manifests", is_bool_val=True)
 
     def get_build_json_store(self):
         return self._get_value("build_json_dir", GENERAL_CONFIGURATION_SECTION, "build_json_dir")
@@ -329,34 +334,33 @@ class Configuration(object):
                                default=True, is_bool_val=True)
 
     def get_vendor(self):
-        return self._get_value("vendor", self.conf_section, "vendor")
+        return self._get_deprecated("vendor", self.conf_section, "vendor")
 
     def get_build_host(self):
-        return self._get_value("build_host", self.conf_section, "build_host")
+        return self._get_deprecated("build_host", self.conf_section, "build_host")
 
     def get_authoritative_registry(self):
-        return self._get_value("authoritative_registry", self.conf_section,
-                               "authoritative_registry")
+        return self._get_deprecated("authoritative_registry", self.conf_section,
+                                    "authoritative_registry")
 
     def get_distribution_scope(self):
-        return self._get_value("distribution_scope", self.conf_section, "distribution_scope")
+        return self._get_deprecated("distribution_scope", self.conf_section, "distribution_scope")
 
     def get_architecture(self):
-        return self._get_value("arch", self.conf_section, "architecture")
+        return self._get_deprecated("arch", self.conf_section, "architecture")
 
     def get_use_auth(self):
         return self._get_value("use_auth", self.conf_section, "use_auth", is_bool_val=True)
 
     def get_builder_use_auth(self):
-        return self._get_value("builder_use_auth", self.conf_section,
-                               "builder_use_auth",
-                               default=self.get_use_auth(),
-                               is_bool_val=True)
+        return self._get_deprecated("builder_use_auth", self.conf_section,
+                                    "builder_use_auth", default=self.get_use_auth(),
+                                    is_bool_val=True)
 
     def get_builder_openshift_url(self):
         """ url of OpenShift where builder will connect """
         key = "builder_openshift_url"
-        url = self._get_value(key, self.conf_section, key)
+        url = self._get_deprecated(key, self.conf_section, key)
         if url is None:
             logger.warning("%r not found, falling back to get_openshift_base_uri()", key)
             url = self.get_openshift_base_uri()
@@ -364,16 +368,16 @@ class Configuration(object):
 
     def get_builder_build_json_store(self):
         key = "builder_build_json_dir"
-        builder_build_json_dir = self._get_value(key, self.conf_section, key)
+        builder_build_json_dir = self._get_deprecated(key, self.conf_section, key)
         if builder_build_json_dir is None:
             logger.warning("%r not found, falling back to build_json_dir", key)
             builder_build_json_dir = self.get_build_json_store()
         return builder_build_json_dir
 
     def get_pulp_secret(self):
-        secret = self._get_value("pulp_secret", self.conf_section, "pulp_secret")
+        secret = self._get_deprecated("pulp_secret", self.conf_section, "pulp_secret")
         if not secret:
-            secret = self._get_value("source_secret", self.conf_section, "pulp_secret")
+            secret = self._get_deprecated("source_secret", self.conf_section, "pulp_secret")
         return secret
 
     def get_source_secret(self):
@@ -383,14 +387,14 @@ class Configuration(object):
         return self.get_pulp_secret()
 
     def get_smtp_host(self):
-        return self._get_value("smtp_host", self.conf_section, "smtp_host")
+        return self._get_deprecated("smtp_host", self.conf_section, "smtp_host")
 
     def get_smtp_from(self):
-        return self._get_value("smtp_from", self.conf_section, "smtp_from")
+        return self._get_deprecated("smtp_from", self.conf_section, "smtp_from")
 
     def get_smtp_additional_addresses(self):
-        value = self._get_value("smtp_additional_addresses", self.conf_section,
-                                "smtp_additional_addresses")
+        value = self._get_deprecated("smtp_additional_addresses", self.conf_section,
+                                     "smtp_additional_addresses")
 
         if value:
             return [x.strip() for x in value.split(',')]
@@ -398,22 +402,23 @@ class Configuration(object):
             return []
 
     def get_smtp_error_addresses(self):
-        value = self._get_value("smtp_error_addresses", self.conf_section, "smtp_error_addresses")
+        value = self._get_deprecated("smtp_error_addresses", self.conf_section,
+                                     "smtp_error_addresses")
         if value:
             return [x.strip() for x in value.split(',')]
         else:
             return []
 
     def get_smtp_email_domain(self):
-        return self._get_value("smtp_email_domain", self.conf_section, "smtp_email_domain")
+        return self._get_deprecated("smtp_email_domain", self.conf_section, "smtp_email_domain")
 
     def get_smtp_to_submitter(self):
-        return self._get_value("smtp_to_submitter", self.conf_section, "smtp_to_submitter",
-                               is_bool_val=True)
+        return self._get_deprecated("smtp_to_submitter", self.conf_section, "smtp_to_submitter",
+                                    is_bool_val=True)
 
     def get_smtp_to_pkgowner(self):
-        return self._get_value("smtp_to_pkgowner", self.conf_section, "smtp_to_pkgowner",
-                               is_bool_val=True)
+        return self._get_deprecated("smtp_to_pkgowner", self.conf_section, "smtp_to_pkgowner",
+                                    is_bool_val=True)
 
     def get_cpu_limit(self):
         return self._get_value("cpu_limit", self.conf_section, "cpu_limit")
@@ -434,7 +439,7 @@ class Configuration(object):
         return self._get_value("build_from", self.conf_section, "build_from")
 
     def get_proxy(self):
-        return self._get_value("yum_proxy", self.conf_section, "yum_proxy")
+        return self._get_deprecated("yum_proxy", self.conf_section, "yum_proxy")
 
     def get_scratch(self, default_value):
         return self._get_value("scratch", self.conf_section, "scratch",
@@ -489,16 +494,15 @@ class Configuration(object):
         return value
 
     def get_reactor_config_secret(self):
-        return self._get_value("reactor_config_secret", self.conf_section,
-                               "reactor_config_secret")
+        return self._get_deprecated("reactor_config_secret", self.conf_section,
+                                    "reactor_config_secret")
 
     def get_client_config_secret(self):
-        return self._get_value("client_config_secret", self.conf_section,
-                               "client_config_secret")
+        return self._get_deprecated("client_config_secret", self.conf_section,
+                                    "client_config_secret")
 
     def get_token_secrets(self):
-        value = self._get_value("token_secrets", self.conf_section,
-                                "token_secrets")
+        value = self._get_deprecated("token_secrets", self.conf_section, "token_secrets")
         token_dict = {}
         will_raise = False
         if value:
@@ -533,12 +537,11 @@ class Configuration(object):
                                default=False, is_bool_val=True)
 
     def get_info_url_format(self):
-        return self._get_value("info_url_format", self.conf_section,
-                               "info_url_format")
+        return self._get_deprecated("info_url_format", self.conf_section, "info_url_format")
 
     def get_artifacts_allowed_domains(self):
-        value = self._get_value("artifacts_allowed_domains", self.conf_section,
-                                "artifacts_allowed_domains")
+        value = self._get_deprecated("artifacts_allowed_domains", self.conf_section,
+                                     "artifacts_allowed_domains")
         if value:
             return [x.strip() for x in value.split(',')]
         else:
@@ -546,8 +549,7 @@ class Configuration(object):
 
     def get_equal_labels(self):
         equal_labels = []
-        equal_labels_str = self._get_value("equal_labels", self.conf_section,
-                                           "equal_labels")
+        equal_labels_str = self._get_deprecated("equal_labels", self.conf_section, "equal_labels")
         if equal_labels_str:
             # must be in correct format
             # e.g. `name1:name2:name3, release1:release2, version1:version2`
@@ -621,6 +623,11 @@ class Configuration(object):
                 continue
             platform = section.split("platform:")[1]
             platform_descriptor = {}
+            logger.warning("user configuration platforms in section %s is ignored in ",
+                           "arrangement %s and later",
+                           section, REACTOR_CONFIG_ARRANGEMENT_VERSION)
+            logger.warning("it has been deprecated in favor of the value in the reactor_config_map")
+
             arch = self._get_value("architecture", section, "architecture") or platform
             enable_v1 = self._get_value("enable_v1", section, "enable_v1",
                                         default=False, is_bool_val=True)

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -16,6 +16,7 @@ from osbs.exceptions import OsbsValidationException
 from osbs.constants import DEFAULT_ARRANGEMENT_VERSION
 import pytest
 from tempfile import NamedTemporaryFile
+import logging
 
 
 class TestConfiguration(object):
@@ -520,3 +521,14 @@ class TestConfiguration(object):
         with self.config_file(myconfig) as config_file:
             conf = Configuration(conf_file=config_file)
             assert getattr(conf, "get_" + nodeselector_type)() == expected
+
+    def test_deprecated_warnings(self, caplog):  # noqa:F811
+        with caplog.atLevel(logging.WARNING):
+            self.test_arrangement_version({'default': {}}, DEFAULT_ARRANGEMENT_VERSION)
+            assert "it has been deprecated" not in caplog.text()
+            build_test_config = {
+                'default': {},
+                'general': {'build_json_dir': 'general'},
+            }
+            self.test_builder_build_json_dir(build_test_config, 'general')
+            assert "it has been deprecated" in caplog.text()


### PR DESCRIPTION
A lot of conf arguments have been deprecated and moved to reactor_config_map.
Replace _get_value with _get_deprecated and print a warning message for
all get_* functions in conf where the value is not in the accepted parameters
list for BuildRequestV2.

Signed-off-by: Mark Langsdorf <mlangsdo@redhat.com>