### PR TITLE
HttpStream: don't catch exceptions in iter_lines

### DIFF
--- a/osbs/http.py
+++ b/osbs/http.py
@@ -175,13 +175,9 @@ class HttpStream(object):
         }
         if requests.__version__.startswith('2.6.'):
             kwargs['chunk_size'] = 1
-        try:
-            for line in self.req.iter_lines(**kwargs):
-                yield line
-        except (requests.exceptions.ChunkedEncodingError,
-                requests.exceptions.ConnectionError,
-                http_client.IncompleteRead):
-            raise StopIteration
+        # if this fails for any reason, let someone else handle the exception
+        for line in self.req.iter_lines(**kwargs):
+            yield line
 
     def close(self):
         if not self.closed:


### PR DESCRIPTION
Remove the try/except sequence from iter_lines(), so that any exceptions
generated by the req.iter() will be propagatetd unchanged up the stack.

Add a test case to prove that an exception in HttpStream.iter_lines()
will move up the stack.

Signed-off-by: Mark Langsdorf <mlangsdo@redhat.com>