### PR TITLE
build response: better error messages

### DIFF
--- a/osbs/api.py
+++ b/osbs/api.py
@@ -135,7 +135,7 @@ class OSBS(object):
         serialized_response = response.json()
         build_list = []
         for build in serialized_response["items"]:
-            build_list.append(BuildResponse(build))
+            build_list.append(BuildResponse(build, self))
 
         return build_list
 
@@ -150,13 +150,13 @@ class OSBS(object):
     @osbsapi
     def get_build(self, build_id):
         response = self.os.get_build(build_id)
-        build_response = BuildResponse(response.json())
+        build_response = BuildResponse(response.json(), self)
         return build_response
 
     @osbsapi
     def cancel_build(self, build_id):
         response = self.os.cancel_build(build_id)
-        build_response = BuildResponse(response.json())
+        build_response = BuildResponse(response.json(), self)
         return build_response
 
     @osbsapi
@@ -228,14 +228,14 @@ class OSBS(object):
         build_request.set_openshift_required_version(self.os_conf.get_openshift_required_version())
         build = build_request.render()
         response = self.os.create_build(json.dumps(build))
-        build_response = BuildResponse(response.json())
+        build_response = BuildResponse(response.json(), self)
         return build_response
 
     def _get_running_builds_for_build_config(self, build_config_id):
         all_builds_for_bc = self.os.list_builds(build_config_id=build_config_id).json()['items']
         running = []
         for b in all_builds_for_bc:
-            br = BuildResponse(b)
+            br = BuildResponse(b, self)
             if br.is_pending() or br.is_running():
                 running.append(br)
         return running
@@ -367,7 +367,7 @@ class OSBS(object):
                 raise RuntimeError('Matching build(s) already running: {0}'
                                    .format(', '.join(x.get_build_name() for x in running_builds)))
 
-        return BuildResponse(self.os.create_build(build_json).json())
+        return BuildResponse(self.os.create_build(build_json).json(), self)
 
     def _get_image_stream_info_for_build_request(self, build_request):
         """Return ImageStream, and ImageStreamTag name for base_image of build_request
@@ -480,10 +480,10 @@ class OSBS(object):
             prev_version = existing_bc['status']['lastVersion']
             build_id = self.os.wait_for_new_build_config_instance(
                 build_config_name, prev_version)
-            build = BuildResponse(self.os.get_build(build_id).json())
+            build = BuildResponse(self.os.get_build(build_id).json(), self)
         else:
             response = self.os.start_build(build_config_name)
-            build = BuildResponse(response.json())
+            build = BuildResponse(response.json(), self)
 
         return build
 
@@ -909,13 +909,13 @@ class OSBS(object):
     @osbsapi
     def wait_for_build_to_finish(self, build_id):
         response = self.os.wait_for_build_to_finish(build_id)
-        build_response = BuildResponse(response)
+        build_response = BuildResponse(response, self)
         return build_response
 
     @osbsapi
     def wait_for_build_to_get_scheduled(self, build_id):
         response = self.os.wait_for_build_to_get_scheduled(build_id)
-        build_response = BuildResponse(response)
+        build_response = BuildResponse(response, self)
         return build_response
 
     @osbsapi

--- a/osbs/build/build_response.py
+++ b/osbs/build/build_response.py
@@ -14,6 +14,7 @@ from osbs.utils import graceful_chain_get, get_time_from_rfc3339
 from osbs.constants import BUILD_FINISHED_STATES, BUILD_RUNNING_STATES, \
     BUILD_SUCCEEDED_STATES, BUILD_FAILED_STATES, BUILD_PENDING_STATES, \
     BUILD_CANCELLED_STATE
+from osbs.exceptions import OsbsException
 
 
 logger = logging.getLogger(__name__)
@@ -22,13 +23,15 @@ logger = logging.getLogger(__name__)
 class BuildResponse(object):
     """ class which wraps json from http response from OpenShift """
 
-    def __init__(self, build_json):
+    def __init__(self, build_json, osbs=None):
         """
         :param build_json: dict from JSON of OpenShift Build object
+        :param osbs: object of the creater's OSBS instance
         """
         self.json = build_json
         self._status = None
         self._cancelled = None
+        self.osbs = osbs
 
     @property
     def status(self):

--- a/osbs/cli/main.py
+++ b/osbs/cli/main.py
@@ -105,7 +105,7 @@ def cmd_list_builds(args, osbs):
 
     if args.from_json:
         with open(args.from_json) as fp:
-            builds = [BuildResponse(build) for build in json.load(fp)]
+            builds = [BuildResponse(build, osbs) for build in json.load(fp)]
     else:
         builds = osbs.list_builds(**kwargs)
 


### PR DESCRIPTION
add a new function to BuildReponse that returns the error reason: either the error message
from the build metadata if that exists, or from the pod's failure reason if that exists.

this new function will also be called by atomic reactor's build_orcestrate_build plugin, to
replace the current code for getting failures from a worker build.

change get_error_message() to use this new function also.

Signed-off-by: Mark Langsdorf <mlangsdo@redhat.com>