### PR TITLE
Limit the number of automatic connection attempts

### DIFF
--- a/osbs/http.py
+++ b/osbs/http.py
@@ -98,6 +98,7 @@ class HttpStream(object):
 
         retry = Retry(
             total=HTTP_MAX_RETRIES,
+            connect=HTTP_MAX_RETRIES,
             backoff_factor=HTTP_BACKOFF_FACTOR,
             status_forcelist=HTTP_RETRIES_STATUS_FORCELIST,
             method_whitelist=HTTP_RETRIES_METHODS_WHITELIST


### PR DESCRIPTION
The Retry class retries connection failures forever by default.
Limit this the same way we limit other retryable errors.

Signed-off-by: Tim Waugh <twaugh@redhat.com>

Tested using:
```
$ cat osbs.conf 
[default]
openshift_url = http://localhost:9001/
$ osbs --conf osbs.conf --verbose watch-builds 
2018-06-14 10:39:08,763 - osbs - DEBUG - Logging level set to debug
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/urllib3/connection.py", line 142, in _new_conn
    (self.host, self.port), self.timeout, **extra_kw)
  File "/usr/lib/python3.6/site-packages/urllib3/util/connection.py", line 83, in create_connection
    raise err
  File "/usr/lib/python3.6/site-packages/urllib3/util/connection.py", line 73, in create_connection
    sock.connect(sa)
ConnectionRefusedError: [Errno 111] Connection refused

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/urllib3/connectionpool.py", line 601, in urlopen
    chunked=chunked)
  File "/usr/lib/python3.6/site-packages/urllib3/connectionpool.py", line 357, in _make_request
    conn.request(method, url, **httplib_request_kw)
  File "/usr/lib64/python3.6/http/client.py", line 1239, in request
    self._send_request(method, url, body, headers, encode_chunked)
  File "/usr/lib64/python3.6/http/client.py", line 1285, in _send_request
    self.endheaders(body, encode_chunked=encode_chunked)
  File "/usr/lib64/python3.6/http/client.py", line 1234, in endheaders
    self._send_output(message_body, encode_chunked=encode_chunked)
  File "/usr/lib64/python3.6/http/client.py", line 1026, in _send_output
    self.send(msg)
  File "/usr/lib64/python3.6/http/client.py", line 964, in send
    self.connect()
  File "/usr/lib/python3.6/site-packages/urllib3/connection.py", line 167, in connect
    conn = self._new_conn()
  File "/usr/lib/python3.6/site-packages/urllib3/connection.py", line 151, in _new_conn
    self, "Failed to establish a new connection: %s" % e)
urllib3.exceptions.NewConnectionError: <urllib3.connection.HTTPConnection object at 0x7f8dd96d4c50>: Failed to establish a new connection: [Errno 111] Connection refused

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/requests/adapters.py", line 440, in send
    timeout=timeout
  File "/usr/lib/python3.6/site-packages/urllib3/connectionpool.py", line 668, in urlopen
    **response_kw)
  File "/usr/lib/python3.6/site-packages/urllib3/connectionpool.py", line 668, in urlopen
    **response_kw)
  File "/usr/lib/python3.6/site-packages/urllib3/connectionpool.py", line 668, in urlopen
    **response_kw)
  [Previous line repeated 4 more times]
  File "/usr/lib/python3.6/site-packages/urllib3/connectionpool.py", line 639, in urlopen
    _stacktrace=sys.exc_info()[2])
  File "/usr/lib/python3.6/site-packages/urllib3/util/retry.py", line 388, in increment
    raise MaxRetryError(_pool, url, error or ResponseError(cause))
urllib3.exceptions.MaxRetryError: HTTPConnectionPool(host='localhost', port=9001): Max retries exceeded with url: /oapi/v1/watch/namespaces/default/builds/?fieldSelector=status%21%3DFailed%2Cstatus%21%3DComplete%2Cstatus%21%3DError%2Cstatus%21%3DCancelled (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7f8dd96d4c50>: Failed to establish a new connection: [Errno 111] Connection refused',))

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/osbs_client-0.48.dev0-py3.6.egg/osbs/http.py", line 59, in request
  File "/usr/local/lib/python3.6/site-packages/osbs_client-0.48.dev0-py3.6.egg/osbs/http.py", line 156, in __init__
  File "/usr/lib/python3.6/site-packages/requests/sessions.py", line 508, in request
    resp = self.send(prep, **send_kwargs)
  File "/usr/lib/python3.6/site-packages/requests/sessions.py", line 618, in send
    r = adapter.send(request, **kwargs)
  File "/usr/lib/python3.6/site-packages/requests/adapters.py", line 508, in send
    raise ConnectionError(e, request=request)
requests.exceptions.ConnectionError: HTTPConnectionPool(host='localhost', port=9001): Max retries exceeded with url: /oapi/v1/watch/namespaces/default/builds/?fieldSelector=status%21%3DFailed%2Cstatus%21%3DComplete%2Cstatus%21%3DError%2Cstatus%21%3DCancelled (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7f8dd96d4c50>: Failed to establish a new connection: [Errno 111] Connection refused',))

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/bin/osbs", line 11, in <module>
    load_entry_point('osbs-client==0.48.dev0', 'console_scripts', 'osbs')()
  File "/usr/local/lib/python3.6/site-packages/osbs_client-0.48.dev0-py3.6.egg/osbs/cli/main.py", line 854, in main
  File "/usr/local/lib/python3.6/site-packages/osbs_client-0.48.dev0-py3.6.egg/osbs/cli/main.py", line 67, in cmd_watch_builds
  File "/usr/local/lib/python3.6/site-packages/osbs_client-0.48.dev0-py3.6.egg/osbs/api.py", line 148, in watch_builds
  File "/usr/local/lib/python3.6/site-packages/osbs_client-0.48.dev0-py3.6.egg/osbs/core.py", line 604, in watch_resource
  File "/usr/local/lib/python3.6/site-packages/osbs_client-0.48.dev0-py3.6.egg/osbs/core.py", line 179, in _get
  File "/usr/local/lib/python3.6/site-packages/osbs_client-0.48.dev0-py3.6.egg/osbs/http.py", line 46, in get
  File "/usr/local/lib/python3.6/site-packages/osbs_client-0.48.dev0-py3.6.egg/osbs/http.py", line 74, in request
osbs.exceptions.OsbsException: ConnectionError(MaxRetryError("HTTPConnectionPool(host='localhost', port=9001): Max retries exceeded with url: /oapi/v1/watch/namespaces/default/builds/?fieldSelector=status%21%3DFailed%2Cstatus%21%3DComplete%2Cstatus%21%3DError%2Cstatus%21%3DCancelled (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7f8dd96d4c50>: Failed to establish a new connection: [Errno 111] Connection refused',))",),)
2018-06-14 10:47:09,255 - osbs.http - DEBUG - cleaning up
```