### PR TITLE
Do not load the flatpak_create_plugin if we are not building a flatpak

### DIFF
--- a/osbs/build/plugins_configuration.py
+++ b/osbs/build/plugins_configuration.py
@@ -280,6 +280,11 @@ class PluginsConfiguration(object):
         plugin = 'flatpak_create_dockerfile'
 
         if self.pt.has_plugin_conf(phase, plugin):
+
+            if not self.user_params.flatpak.value:
+                self.pt.remove_plugin(phase, plugin)
+                return
+
             if not self.pt.set_plugin_arg_valid(phase, plugin, 'base_image',
                                                 self.user_params.flatpak_base_image.value):
                 self.pt.remove_plugin(phase, plugin, 'unable to set flatpak base image')

--- a/osbs/build/user_params.py
+++ b/osbs/build/user_params.py
@@ -130,7 +130,10 @@ class BuildUserParams(BuildCommon):
         self.isolated.value = isolated
         self.scratch.value = scratch
 
-        if not flatpak:
+        if flatpak:
+            if not flatpak_base_image:
+                raise OsbsValidationException("faltpak_base_image must be provided")
+        else:
             if not base_image:
                 raise OsbsValidationException("base_image must be provided")
             self.trigger_imagestreamtag.value = get_imagestreamtag_from_image(base_image)


### PR DESCRIPTION
Without this we are trying to run the pre_flatpak_create_dockerfile plugin when trying to build normal containers.

Maybe @mlangsdorf could review this and make sure this is a sane change.

I ll be happy to work on some tests if I could get some pointers on which test to modify.

cc'ing @owtaylor 

Signed-off-by: Clement Verna <cverna@tutanota.com>