### PR TITLE
when deciding whether it is orchestrator or worker build, use build_t…

### DIFF
--- a/osbs/build/build_requestv2.py
+++ b/osbs/build/build_requestv2.py
@@ -259,7 +259,7 @@ class BuildRequestV2(BuildRequest):
         self.adjust_for_repo_info()
         self.adjust_for_scratch()
         self.adjust_for_isolated(self.user_params.release)
-        self.render_node_selectors(self.user_params.platforms.value)
+        self.render_node_selectors(self.user_params.build_type.value)
 
         # Set our environment variables
         custom_strategy['env'].append({

--- a/tests/build_/test_build_request.py
+++ b/tests/build_/test_build_request.py
@@ -1723,6 +1723,7 @@ class TestBuildRequest(object):
             'arrangement_version': arrangement_version,
             'osbs_api': MockOSBSApi(),
             'platform_descriptors': platform_descriptors,
+            'build_type': BUILD_TYPE_ORCHESTRATOR if platforms else BUILD_TYPE_WORKER,
         }
         if build_image:
             kwargs['build_image'] = build_image
@@ -1747,6 +1748,8 @@ class TestBuildRequest(object):
             return
         if openshift_req_version:
             build_request.set_openshift_required_version(parse_version(openshift_req_version))
+        repo_info = RepoInfo()
+        build_request.set_repo_info(repo_info)
         build_json = build_request.render()
         plugins = get_plugins_from_build_json(build_json)
 
@@ -2748,8 +2751,10 @@ class TestBuildRequest(object):
         kwargs = get_sample_prod_params()
         if platforms:
             kwargs['platforms'] = [platforms]
+            kwargs['build_type'] = BUILD_TYPE_ORCHESTRATOR
         else:
             kwargs['platforms'] = None
+            kwargs['build_type'] = BUILD_TYPE_WORKER
 
         if platform:
             kwargs['platform_node_selector'] = platform_nodeselectors[platform]
@@ -2767,6 +2772,7 @@ class TestBuildRequest(object):
         build_json = br.render()
 
         if expected:
+            print(build_json['spec']['nodeSelector'])
             assert build_json['spec']['nodeSelector'] == expected
         else:
             assert 'nodeSelector' not in build_json['spec']

--- a/tests/build_/test_build_requestv2.py
+++ b/tests/build_/test_build_requestv2.py
@@ -618,8 +618,10 @@ class TestBuildRequestV2(object):
         kwargs = get_sample_prod_params()
         if platforms:
             kwargs['platforms'] = [platforms]
+            kwargs['build_type'] = BUILD_TYPE_ORCHESTRATOR
         else:
             kwargs['platforms'] = None
+            kwargs['build_type'] = BUILD_TYPE_WORKER
 
         if platform:
             kwargs['platform_node_selector'] = platform_nodeselectors[platform]


### PR DESCRIPTION
…ype, instead of checking platforms

Signed-off-by: Robert Cerven <rcerven@redhat.com>