### PR TITLE
Fedora 26 is EOL, replace it by Fedora 28 in travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,16 +14,16 @@ env:
       OS_VERSION=7
       PYTHON_VERSION=2
     - OS=fedora
-      OS_VERSION=26
+      OS_VERSION=27
       PYTHON_VERSION=2
     - OS=fedora
-      OS_VERSION=26
+      OS_VERSION=27
       PYTHON_VERSION=3
     - OS=fedora
-      OS_VERSION=27
+      OS_VERSION=28
       PYTHON_VERSION=2
     - OS=fedora
-      OS_VERSION=27
+      OS_VERSION=28
       PYTHON_VERSION=3
 script:
  - pip install coveralls


### PR DESCRIPTION
Signed-off-by: Clement Verna <cverna@tutanota.com>