### PR TITLE
plugins_configuration: disable check_and_set_platforms for scratch bu…

### DIFF
--- a/osbs/build/plugins_configuration.py
+++ b/osbs/build/plugins_configuration.py
@@ -157,6 +157,7 @@ class PluginsConfiguration(object):
         if self.user_params.scratch.value:
             remove_plugins = [
                 ("prebuild_plugins", "koji_parent"),
+                ("prebuild_plugins", "check_and_set_platforms"),  # don't override arch_override
                 ("postbuild_plugins", "compress"),  # required only to make an archive for Koji
                 ("postbuild_plugins", "pulp_pull"),  # required only to make an archive for Koji
                 ("postbuild_plugins", "koji_upload"),

--- a/tests/build_/test_plugins_configuration.py
+++ b/tests/build_/test_plugins_configuration.py
@@ -766,3 +766,35 @@ class TestPluginsConfiguration(object):
                 get_plugin(plugins, plugin_type, plugin_name)
         else:
             assert get_plugin(plugins, plugin_type, plugin_name)
+
+    def test_render_scratch(self):
+        additional_params = {
+            'scratch': True
+        }
+
+        self.mock_repo_info()
+        user_params = get_sample_user_params(additional_params)
+        build_json = PluginsConfiguration(user_params).render()
+        plugins = get_plugins_from_build_json(build_json)
+
+        remove_plugins = [
+            ("prebuild_plugins", "koji_parent"),
+            ("prebuild_plugins", "check_and_set_platforms"),
+            ("postbuild_plugins", "compress"),
+            ("postbuild_plugins", "pulp_pull"),
+            ("postbuild_plugins", "koji_upload"),
+            ("postbuild_plugins", "fetch_worker_metadata"),
+            ("postbuild_plugins", "compare_components"),
+            ("postbuild_plugins", "import_image"),
+            ("exit_plugins", "koji_promote"),
+            ("exit_plugins", "koji_import"),
+            ("exit_plugins", "koji_tag_build"),
+            ("exit_plugins", "remove_worker_metadata"),
+            ("exit_plugins", "import_image"),
+            ("prebuild_plugins", "check_and_set_rebuild"),
+            ("prebuild_plugins", "stop_autorebuild_if_disabled")
+        ]
+
+        for (plugin_type, plugin) in remove_plugins:
+            with pytest.raises(NoSuchPluginException):
+                get_plugin(plugins, plugin_type, plugin)


### PR DESCRIPTION
…ilds

scratch builds may run on a subset of available architectures. don't run
check_and_set_platforms when running scratch builds, so that any arches
specified by the user are used instead of taking arches from koji.

Signed-off-by: Mark Langsdorf <mlangsdo@redhat.com>