### PR TITLE
plugins_configuration.py: Don't exclude the 'koji' plugin for Flatpaks

### DIFF
--- a/osbs/build/plugins_configuration.py
+++ b/osbs/build/plugins_configuration.py
@@ -301,8 +301,6 @@ class PluginsConfiguration(object):
 
         if self.user_params.yum_repourls.value:
             self.pt.remove_plugin(phase, plugin, 'there is a yum repo user parameter')
-        elif self.user_params.flatpak.value:
-            self.pt.remove_plugin(phase, plugin, 'flatpak build requested')
         elif not self.pt.set_plugin_arg_valid(phase, plugin, "target",
                                               self.user_params.koji_target.value):
             self.pt.remove_plugin(phase, plugin, 'no koji target supplied in user parameters')

--- a/tests/build_/test_plugins_configuration.py
+++ b/tests/build_/test_plugins_configuration.py
@@ -284,6 +284,12 @@ class TestPluginsConfiguration(object):
             with pytest.raises(NoSuchPluginException):
                 get_plugin(plugins, "prepublish_plugins", "flatpak_create_oci")
         else:
+            plugin = get_plugin(plugins, "prebuild_plugins", "koji")
+            assert plugin
+
+            args = plugin['args']
+            assert args['target'] == "koji-target"
+
             assert get_plugin(plugins, "prepublish_plugins", "flatpak_create_oci")
             with pytest.raises(NoSuchPluginException):
                 plugin = get_plugin(plugins, "prebuild_plugins", "bump_release")


### PR DESCRIPTION
This was implemented for build_request.py in 3c18d4bb44, but the change
never made its way into plugins_configuration.py.
