### PR TITLE
Don't include 'resolve_composes' for Flatpak builds

### DIFF
--- a/osbs/build/plugins_configuration.py
+++ b/osbs/build/plugins_configuration.py
@@ -435,6 +435,10 @@ class PluginsConfiguration(object):
         if not self.pt.has_plugin_conf(phase, plugin):
             return
 
+        if self.user_params.flatpak.value:
+            self.pt.remove_plugin(phase, plugin, 'flatpak build')
+            return
+
         if self.user_params.yum_repourls.value:
             self.pt.remove_plugin(phase, plugin, 'yum repourls specified in user parameters')
             return

--- a/tests/build_/test_plugins_configuration.py
+++ b/tests/build_/test_plugins_configuration.py
@@ -262,6 +262,9 @@ class TestPluginsConfiguration(object):
         plugin = get_plugin(plugins, "prebuild_plugins", "resolve_module_compose")
         assert plugin
 
+        with pytest.raises(NoSuchPluginException):
+            assert get_plugin(plugins, "prebuild_plugins", "resolve_composes")
+
         args = plugin['args']
         # compose_ids will always have a value of at least []
         if compose_ids is None:


### PR DESCRIPTION
For Flatpak builds, handling of composes is done in
resolve_module_compose, so the 'resolve_composes' plugin just duplicates
this and causes things to go wrong.