### PR TITLE
plugins_configuration: disable check_and_set_platforms for isolated b…

### DIFF
--- a/osbs/build/plugins_configuration.py
+++ b/osbs/build/plugins_configuration.py
@@ -186,6 +186,7 @@ class PluginsConfiguration(object):
         """
         if self.user_params.isolated.value:
             remove_plugins = [
+                ("prebuild_plugins", "check_and_set_platforms"),  # don't override arch_override
                 ("prebuild_plugins", "check_and_set_rebuild"),
                 ("prebuild_plugins", "stop_autorebuild_if_disabled")
             ]

--- a/tests/build_/test_plugins_configuration.py
+++ b/tests/build_/test_plugins_configuration.py
@@ -767,6 +767,26 @@ class TestPluginsConfiguration(object):
         else:
             assert get_plugin(plugins, plugin_type, plugin_name)
 
+    def test_render_isolated(self):
+        additional_params = {
+            'isolated': True
+        }
+
+        self.mock_repo_info()
+        user_params = get_sample_user_params(additional_params)
+        build_json = PluginsConfiguration(user_params).render()
+        plugins = get_plugins_from_build_json(build_json)
+
+        remove_plugins = [
+            ("prebuild_plugins", "check_and_set_platforms"),
+            ("prebuild_plugins", "check_and_set_rebuild"),
+            ("prebuild_plugins", "stop_autorebuild_if_disabled")
+        ]
+
+        for (plugin_type, plugin) in remove_plugins:
+            with pytest.raises(NoSuchPluginException):
+                get_plugin(plugins, plugin_type, plugin)
+
     def test_render_scratch(self):
         additional_params = {
             'scratch': True


### PR DESCRIPTION
…uilds

isolated builds may run on a subset of available architectures. don't run
check_and_set_platforms when running isolated builds, so that any arches
specified by the user are used instead of taking arches from koji.

Signed-off-by: Mark Langsdorf <mlangsdo@redhat.com>