### PR TITLE
Fix yaml exception wrapping

### DIFF
--- a/osbs/exceptions.py
+++ b/osbs/exceptions.py
@@ -31,7 +31,7 @@ class OsbsException(Exception):
             return ("%s\n\n" % self.message +
                     "Original traceback (most recent call last):\n" +
                     "".join(format_tb(self.traceback)) +
-                    "%r" % self.cause)
+                    "%s" % self.cause)
         else:
             return super(OsbsException, self).__str__()
 


### PR DESCRIPTION
Previously the traceback could look like this:
```
Traceback (most recent call last):
[...]
OsbsException: ScannerError()

Original traceback (most recent call last):
[...]
  File "/usr/lib64/python2.6/site-packages/yaml/scanner.py", line 289, in stale_possible_simple_keys
    "could not found expected ':'", self.get_mark())
ScannerError()
```

This is because repr() for a yaml exception only reveals 'ScannerError()'
whereas str() reveals the line and column.

Use str() on the underlying exception when str() is called on the
wrapping exception.

Signed-off-by: Tim Waugh <twaugh@redhat.com>