### PR TITLE
Always run check_and_set_platforms plugin

### DIFF
--- a/osbs/build/plugins_configuration.py
+++ b/osbs/build/plugins_configuration.py
@@ -157,7 +157,6 @@ class PluginsConfiguration(object):
         if self.user_params.scratch.value:
             remove_plugins = [
                 ("prebuild_plugins", "koji_parent"),
-                ("prebuild_plugins", "check_and_set_platforms"),  # don't override arch_override
                 ("postbuild_plugins", "compress"),  # required only to make an archive for Koji
                 ("postbuild_plugins", "pulp_pull"),  # required only to make an archive for Koji
                 ("postbuild_plugins", "koji_upload"),
@@ -186,7 +185,6 @@ class PluginsConfiguration(object):
         """
         if self.user_params.isolated.value:
             remove_plugins = [
-                ("prebuild_plugins", "check_and_set_platforms"),  # don't override arch_override
                 ("prebuild_plugins", "check_and_set_rebuild"),
                 ("prebuild_plugins", "stop_autorebuild_if_disabled")
             ]

--- a/tests/build_/test_plugins_configuration.py
+++ b/tests/build_/test_plugins_configuration.py
@@ -778,7 +778,6 @@ class TestPluginsConfiguration(object):
         plugins = get_plugins_from_build_json(build_json)
 
         remove_plugins = [
-            ("prebuild_plugins", "check_and_set_platforms"),
             ("prebuild_plugins", "check_and_set_rebuild"),
             ("prebuild_plugins", "stop_autorebuild_if_disabled")
         ]
@@ -799,7 +798,6 @@ class TestPluginsConfiguration(object):
 
         remove_plugins = [
             ("prebuild_plugins", "koji_parent"),
-            ("prebuild_plugins", "check_and_set_platforms"),
             ("postbuild_plugins", "compress"),
             ("postbuild_plugins", "pulp_pull"),
             ("postbuild_plugins", "koji_upload"),


### PR DESCRIPTION
Not running this plugin causes the following issues:

X pulp_pull will not work for builds without x86_64 because there won't
be enough information to set boolean self.expect_v2schema2list_only to
true. This breaks isolated and scratch builds for arm only builds.

X add_filesystem will not work for arrangement 6 because its
architectures parameter will be None. This breaks isolated and scratch
builds of base images.

X pull_base_image and resolve_composes won't apply platform restrictions
from container.yaml. This causes checks that ensure parent image was
built for all needed arches to not work properly if user has platform
restrictions in container.yaml for isolated and scratch builds.

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>