### PR TITLE
 Always include check_and_set_platforms for orchestrated builds

### DIFF
--- a/osbs/build/plugins_configuration.py
+++ b/osbs/build/plugins_configuration.py
@@ -337,9 +337,9 @@ class PluginsConfiguration(object):
         if not self.pt.has_plugin_conf(phase, plugin):
             return
 
-        if not self.pt.set_plugin_arg_valid(phase, plugin, "koji_target",
-                                            self.user_params.koji_target.value):
-            self.pt.remove_plugin(phase, plugin, 'no koji target supplied in user parameters')
+        if self.user_params.koji_target.value:
+            self.pt.set_plugin_arg(phase, plugin, "koji_target",
+                                   self.user_params.koji_target.value)
 
     def render_import_image(self, use_auth=None):
         """

--- a/tests/build_/test_plugins_configuration.py
+++ b/tests/build_/test_plugins_configuration.py
@@ -134,9 +134,7 @@ class TestPluginsConfiguration(object):
             with pytest.raises(NoSuchPluginException):
                 assert get_plugin(plugins, 'postbuild_plugins', 'koji_upload')
 
-    @pytest.mark.parametrize(('enabled'), (
-        (True, False),
-    ))
+    @pytest.mark.parametrize('enabled', (True, False))
     def test_render_check_and_set_platforms(self, enabled):
         plugin_type = 'prebuild_plugins'
         plugin_name = 'check_and_set_platforms'

--- a/tests/build_/test_plugins_configuration.py
+++ b/tests/build_/test_plugins_configuration.py
@@ -147,16 +147,14 @@ class TestPluginsConfiguration(object):
         build_json = PluginsConfiguration(user_params).render()
         plugins = get_plugins_from_build_json(build_json)
 
-        if not enabled:
-            with pytest.raises(NoSuchPluginException):
-                get_plugin(plugins, plugin_type, plugin_name)
-            return
-
         assert get_plugin(plugins, plugin_type, plugin_name)
 
         actual_plugin_args = plugin_value_get(plugins, plugin_type, plugin_name, 'args')
 
-        expected_plugin_args = {'koji_target': 'koji-target'}
+        if enabled:
+            expected_plugin_args = {'koji_target': 'koji-target'}
+        else:
+            expected_plugin_args = {}
 
         assert actual_plugin_args == expected_plugin_args
 


### PR DESCRIPTION
There was a lot of (barely used) complexity in atomic reactor to handle the check_and_set_platforms plugin being only run for builds with koji_target. Including it for all orchestrated builds allows us to simplify that logic. (This does introduce incompatibility with older atomic-reactor for the rarer case of builds missing koji_target.)

See https://github.com/projectatomic/atomic-reactor/pull/1046 for the atomic-reactor piece.

This PR also contains a patch to fix the parameterization of the check_and_set_platforms test.
 