### PR TITLE
BuildResponse: avoid traceback in get_error_reason

### DIFF
--- a/osbs/build/build_response.py
+++ b/osbs/build/build_response.py
@@ -123,19 +123,24 @@ class BuildResponse(object):
                 return "Error in plugin %s" % plugin
 
     def get_error_reason(self):
-        try:
-            str_metadata = graceful_chain_get(self.get_annotations_or_labels(), "plugins-metadata")
-            metadata_dict = json.loads(str_metadata)
-            plugin, error_message = list(metadata_dict['errors'].items())[0]
-            return {'plugin': [plugin, error_message]}
-        except (ValueError, AttributeError):
-            if not self.osbs:
-                return {'pod': 'OSBS unavailable; Pod related errors cannot be retrieved'}
+        str_metadata = graceful_chain_get(self.get_annotations(),
+                                          "plugins-metadata")
+        if str_metadata:
             try:
-                pod = self.osbs.get_pod_for_build(self.get_build_name())
-                return {'pod': pod.get_failure_reason()}
-            except OsbsException:
-                return None
+                metadata_dict = json.loads(str_metadata)
+                plugin, error_message = list(metadata_dict['errors'].items())[0]
+                return {'plugin': [plugin, error_message]}
+            except (ValueError, KeyError, IndexError):
+                pass
+
+        if not self.osbs:
+            return {'pod': 'OSBS unavailable; Pod related errors cannot be retrieved'}
+
+        try:
+            pod = self.osbs.get_pod_for_build(self.get_build_name())
+            return {'pod': pod.get_failure_reason()}
+        except OsbsException:
+            return None
 
     def get_commit_id(self):
         return graceful_chain_get(self.get_annotations_or_labels(), "commit_id")

--- a/tests/build_/test_build_response.py
+++ b/tests/build_/test_build_response.py
@@ -115,23 +115,30 @@ class TestBuildResponse(object):
                     return self.error
                 raise OsbsException
 
-        plugins_metadata = json.dumps({
-            'errors': {
-                plugin: message,
-            },
-        })
-        if not plugin:
-            plugins_metadata = ''
         if pod or osbs:
             mock_pod = MockOsbsPod(pod)
         else:
             mock_pod = None
-        build_response = BuildResponse({
-            'metadata': {
-                'annotations': {
-                    'plugins-metadata': plugins_metadata
-                }
+        if plugin:
+            plugins_metadata = json.dumps({
+                'errors': {
+                    plugin: message,
+                },
+            })
+            build = {
+                'metadata': {
+                    'annotations': {
+                        'plugins-metadata': plugins_metadata,
+                    },
+                },
             }
-        }, mock_pod)
+        else:
+            build = {
+                'metadata': {
+                    'annotations': {},
+                },
+            }
+
+        build_response = BuildResponse(build, mock_pod)
 
         assert build_response.get_error_message() == expected_error_message


### PR DESCRIPTION
A missing annotation would result in a traceback:
...
File /usr/lib/python2.6/site-packages/osbs/build/build_response.py, line 128, in get_error_reason
    metadata_dict = json.loads(str_metadata)
  File /usr/lib64/python2.6/json/__init__.py, line 307, in loads
    return _default_decoder.decode(s)
  File /usr/lib64/python2.6/json/decoder.py, line 319, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
TypeError: expected string or buffer

Signed-off-by: Tim Waugh <twaugh@redhat.com>