### PR TITLE
use build for koji id if already exists, fix use json method instead of attribute from get_build

### DIFF
--- a/osbs/api.py
+++ b/osbs/api.py
@@ -246,7 +246,7 @@ class OSBS(object):
         not_cancelled = []
 
         for b in all_builds_for_task:
-            br = BuildResponse(b)
+            br = BuildResponse(b, self)
             build_labels = br.get_labels()
             if not br.is_cancelled() and build_labels['is_autorebuild'] == "false":
                 not_cancelled.append(br)
@@ -703,7 +703,7 @@ class OSBS(object):
             logger.info("found running build for koji task: %s" %
                         builds_for_koji_task[0].get_build_name())
             response =\
-                BuildResponse(self.os.get_build(builds_for_koji_task[0].get_build_name()).json,
+                BuildResponse(self.os.get_build(builds_for_koji_task[0].get_build_name()).json(),
                               self)
         elif builds_count > 1:
             raise OsbsException("Multiple builds %s for koji task id %s" %

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2017,7 +2017,7 @@ class TestOSBS(object):
             (flexmock(osbs_obj)
                 .should_receive(delegate_method)
                 .once()
-                .and_return(flexmock(json=lambda: {'spam': 'maps'})))
+                .and_return(BuildResponse({'spam': 'maps'})))
 
         if exc:
             with pytest.raises(OsbsException) as exc_info:
@@ -2025,7 +2025,7 @@ class TestOSBS(object):
             assert "Multiple builds 2 for koji task id %s" % koji_task_id in exc_info.value.message
         else:
             build_response = osbs_obj.create_build(**kwargs)
-            assert build_response.json() == {'spam': 'maps'}
+            assert build_response.json == {'spam': 'maps'}
 
     def test_get_image_stream_tag(self):
         config = Configuration(conf_name=None)


### PR DESCRIPTION
Signed-off-by: Robert Cerven <rcerven@redhat.com>