### PR TITLE
Disable delete_from_registry plugin

### DIFF
--- a/inputs/orchestrator_inner:6.json
+++ b/inputs/orchestrator_inner:6.json
@@ -97,9 +97,6 @@
       "required": false
     },
     {
-      "name": "delete_from_registry"
-    },
-    {
       "name": "koji_import"
     },
     {

--- a/tests/build_/test_arrangements.py
+++ b/tests/build_/test_arrangements.py
@@ -1451,7 +1451,6 @@ class TestArrangementV6(ArrangementBase):
                 PLUGIN_PULP_PULL_KEY,
                 PLUGIN_VERIFY_MEDIA_KEY,
                 'import_image',
-                'delete_from_registry',
                 PLUGIN_KOJI_IMPORT_PLUGIN_KEY,
                 'koji_tag_build',
                 'store_metadata_in_osv3',


### PR DESCRIPTION
Deleting content from the registry after pulp finishes syncing is
convenient so the next pulp sync will not take longer (pulp iterates
over the repository tags fetching all referenced content). However,
removing content may confuse the docker distribution registry, which
leads to failing builds.

Signed-off-by: Athos Ribeiro <athos@redhat.com>