### PR TITLE
Prohibit isolated FROM scratch builds

### DIFF
--- a/osbs/api.py
+++ b/osbs/api.py
@@ -700,6 +700,12 @@ class OSBS(object):
         build_request.set_openshift_required_version(self.os_conf.get_openshift_required_version())
         build_request.set_repo_info(repo_info)
 
+        if isolated:
+            if build_request.is_custom_base_image():
+                raise ValueError('Base image build cannot be isolated')
+            if build_request.is_from_scratch_image():
+                raise ValueError('"FROM scratch" image build cannot be isolated')
+
         builds_for_koji_task = []
         if koji_task_id and build_type == BUILD_TYPE_ORCHESTRATOR:
             # try to find build for koji_task which isn't canceled and use that one

--- a/osbs/build/build_requestv2.py
+++ b/osbs/build/build_requestv2.py
@@ -267,7 +267,8 @@ class BuildRequestV2(BuildRequest):
         self.set_data_from_reactor_config()
 
         # Adjust triggers for custom base image
-        if self.template['spec'].get('triggers', []) and self.is_custom_base_image():
+        if (self.template['spec'].get('triggers', [])
+                and (self.is_custom_base_image() or self.is_from_scratch_image())):
             del self.template['spec']['triggers']
 
         self.adjust_for_repo_info()

--- a/tests/build_/test_build_requestv2.py
+++ b/tests/build_/test_build_requestv2.py
@@ -453,6 +453,24 @@ class TestBuildRequestV2(object):
         # Verify the triggers are now disabled
         assert "triggers" not in build_json["spec"]
 
+    @pytest.mark.parametrize('use_auth', (True, False, None))
+    def test_render_from_scratch_image_with_trigger(self, tmpdir,  use_auth):
+        self.create_image_change_trigger_json(str(tmpdir))
+        build_request = BuildRequestV2(str(tmpdir))
+
+        kwargs = get_sample_prod_params()
+        kwargs['base_image'] = 'scratch'
+        if use_auth is not None:
+            kwargs['use_auth'] = use_auth
+
+        build_request.set_params(**kwargs)
+        build_json = build_request.render()
+
+        assert build_request.is_from_scratch_image() is True
+
+        # Verify the triggers are now disabled
+        assert "triggers" not in build_json["spec"]
+
     @pytest.mark.parametrize(('extra_kwargs', 'expected_error'), (
         ({'isolated': True}, 'release parameter is required'),
         ({'isolated': True, 'release': '1'}, 'must be in the format'),


### PR DESCRIPTION
FROM scratch images cannot be built as isolated builts.

Signed-off-by: Martin Bašti <mbasti@redhat.com>


- [ ] Test for raising proper error msg