### PR TITLE
Remove delete_from_registry plugin checks

### DIFF
--- a/tests/build_/test_plugins_configuration.py
+++ b/tests/build_/test_plugins_configuration.py
@@ -252,7 +252,6 @@ class TestPluginsConfiguration(object):
         ("o", "postbuild_plugins", "pulp_sync"),
         ("o", "exit_plugins", "pulp_publish"),
         ("o", "exit_plugins", "pulp_pull"),
-        ("o", "exit_plugins", "delete_from_registry"),
         ("o", "exit_plugins", "import_image"),
     ]
 


### PR DESCRIPTION
This plugin has been deactivated in 9cb8b97 (PR #813), which was merged without a rebase for the PR #815 changes, causing the related test to fail.

This removes the deactivated plugin from the expected plugins list for non flatpack builds, which fixes the issue.

Signed-off-by: Athos Ribeiro <athos@redhat.com>