### PR TITLE
Comply to PEP 479 to support Python 3.7

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -36,6 +36,8 @@ disable=I,
         bad-whitespace,  # pep8, nice to have
         bare-except,
         broad-except,
+        comprehension-escape, # throws false positives on 1.9.0 (Fedora 29)
+        exception-escape, # throws false positives on 1.9.0 (Fedora 29)
         dangerous-default-value,  # should be enabled
         deprecated-method,  # should be enabled
         dict-keys-not-iterating,  # py2/3 compatibility

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,11 @@ env:
   matrix:
     - ACTION=pylint
       OS=fedora
-      OS_VERSION=28
+      OS_VERSION=29
       PYTHON_VERSION=2
     - ACTION=pylint
       OS=fedora
-      OS_VERSION=28
+      OS_VERSION=29
       PYTHON_VERSION=3
     - OS=centos
       OS_VERSION=6
@@ -22,16 +22,16 @@ env:
       OS_VERSION=7
       PYTHON_VERSION=2
     - OS=fedora
-      OS_VERSION=27
+      OS_VERSION=28
       PYTHON_VERSION=2
     - OS=fedora
-      OS_VERSION=27
+      OS_VERSION=28
       PYTHON_VERSION=3
     - OS=fedora
-      OS_VERSION=28
+      OS_VERSION=29
       PYTHON_VERSION=2
     - OS=fedora
-      OS_VERSION=28
+      OS_VERSION=29
       PYTHON_VERSION=3
 install:
   - pip install coveralls

--- a/osbs/api.py
+++ b/osbs/api.py
@@ -1322,10 +1322,8 @@ class OSBS(object):
         Raises exception on error
 
         :param name: str, name of configMap to delete from the server
-        :returns: True on success
         """
-        response = self.os.delete_config_map(name)
-        return response
+        self.os.delete_config_map(name)
 
     @contextmanager
     def retries_disabled(self):

--- a/osbs/core.py
+++ b/osbs/core.py
@@ -1021,6 +1021,7 @@ class Openshift(object):
         url = self._build_k8s_url("configmaps/%s" % config_name)
         response = self._delete(url, data='{}')
         check_response(response)
+        return response
 
 
 if __name__ == '__main__':

--- a/osbs/http.py
+++ b/osbs/http.py
@@ -184,7 +184,7 @@ class HttpStream(object):
                 yield line
         except (requests.exceptions.ChunkedEncodingError,
                 http_client.IncompleteRead):
-            raise StopIteration
+            return
 
     def close(self):
         if not self.closed:


### PR DESCRIPTION
Python 3.7 enables PEP 479, meaning that direct calls to StopIterator in
generators will raise RuntimeError exceptions. We deprecate the usage of
such calls in favor of calls to return, keeping the desired behavior and
complying to PEP 479.

* https://docs.python.org/3.7/whatsnew/3.7.htm
* https://www.python.org/dev/peps/pep-0479/

Signed-off-by: Athos Ribeiro <athos@redhat.com>