### PR TITLE
Use logger for warnings

### DIFF
--- a/osbs/api.py
+++ b/osbs/api.py
@@ -93,8 +93,8 @@ def validate_arrangement_version(arrangement_version):
 
     if arrangement_version <= 5:
         # TODO: raise as ValueError in release 0.54+
-        warnings.warn("arrangement_version <= 5 is deprecated and will be removed"
-                      " in release 0.54", DeprecationWarning)
+        logger.warning("arrangement_version <= 5 is deprecated and will be removed"
+                       " in release 0.54")
 
 
 class OSBS(object):
@@ -777,9 +777,9 @@ class OSBS(object):
         :param compose_ids: list<int>, ODCS composes used
         :return: BuildResponse instance
         """
-        warnings.warn("prod (all-in-one) builds are deprecated, "
-                      "please use create_orchestrator_build "
-                      "(support will be removed in version 0.54)")
+        logger.warning("prod (all-in-one) builds are deprecated, "
+                       "please use create_orchestrator_build "
+                       "(support will be removed in version 0.54)")
         return self._do_create_prod_build(*args, **kwargs)
 
     @osbsapi

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -118,7 +118,7 @@ class MockDfParserBaseImage(object):
     (5, "arrangement_version <= 5 is deprecated and will be removed in release 0.54", None),
     (6, None, None),
 ))
-def test_validate_arrangement_version(recwarn, version, warning, exception):
+def test_validate_arrangement_version(caplog, version, warning, exception):
     """Test deprecation mechanism of arrangement version"""
     if exception:
         with pytest.raises(exception):
@@ -127,7 +127,7 @@ def test_validate_arrangement_version(recwarn, version, warning, exception):
         validate_arrangement_version(version)
 
     if warning:
-        assert warning in str(recwarn.pop(DeprecationWarning))
+        assert warning in caplog.text()
 
 
 class TestOSBS(object):


### PR DESCRIPTION
Koji doesn't collect stderr/stdout only logger, so warning.warn() output
is not shown in collected logs.

Signed-off-by: Martin Bašti <mbasti@redhat.com>