### PR TITLE
docs: Update OpenShift references

### DIFF
--- a/docs/backups.md
+++ b/docs/backups.md
@@ -26,6 +26,8 @@ It is recommended to perform restore on freshly installed OpenShift with no data
 
 ## Manually
 
+Manual backup routines are performed with the OpenShift Client (through the `oc` command), available in Fedora in the `origin-clients` package.
+
 ### Creating Backups
 
 Creating OSBS backups is very simple. To backup all relevant data, one needs to backup data using following commands.

--- a/docs/development-setup.md
+++ b/docs/development-setup.md
@@ -7,9 +7,9 @@ For more options how to install and run OpenShift, please see [this page](https:
 
 We'll use the `oc cluster up` method, since it's very easy to use:
 
- 1. If you're on Fedora, you can install package origin:
+ 1. If you're on Fedora, you can install package origin-clients:
     ```
-    $ dnf install -y origin
+    $ dnf install -y origin-clients
     ```
     This package provides `oc` command.
 

--- a/docs/osbs_instance_setup.md
+++ b/docs/osbs_instance_setup.md
@@ -40,12 +40,9 @@ Both OpenShift Origin or OpenShift Enterprise can be used to host OSBS.
 See the [upstream documentation](https://docs.openshift.org/latest/welcome/index.html)
 for installation instructions.
 
-AFAIK Origin is not packaged for Fedora, you can use @mmilata's
-[copr](https://copr.fedoraproject.org/coprs/mmilata/openshift/) though the
-packages there will likely be outdated.
+Origin is available in Fedora, you can install it by running
 
 ```
-$ dnf copr enable mmilata/openshift
 $ dnf install origin-master origin-node
 ```
 
@@ -99,13 +96,19 @@ $ systemctl start origin-master origin-node
 
 ### Talking to OpenShift via command line
 
-All communication with OpenShift is performed via executable `oc`. The
-binary needs to authenticate, otherwise all the requests will be denied.
-Authentication is handled via configuration file for `oc`. You need to set an
-environment variable to point `oc` to the admin config:
+All communication with OpenShift is performed via executable `oc` (the
+OpenShift Client). The binary needs to authenticate, otherwise all the requests
+will be denied.  Authentication is handled via configuration file for `oc`. You
+need to set an environment variable to point `oc` to the admin config:
 
 ```
 $ export KUBECONFIG=/etc/origin/master/admin.kubeconfig
+```
+
+OpenShift client is available in Fedora through the `origin-clients` package.
+
+```
+$ dnf install origin-clients
 ```
 
 #### Useful Commands


### PR DESCRIPTION
Explicitly reference the oc client as the OpenShift Client with up to
date Fedora package references for both the `oc` binary and the
OpenShift Origin packages.

* Closes #569

Signed-off-by: Athos Ribeiro <athos@redhat.com>