### PR TITLE
Drop Python 2.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,6 @@ env:
       OS_VERSION=29
       PYTHON_VERSION=3
     - OS=centos
-      OS_VERSION=6
-      PYTHON_VERSION=2
-    - OS=centos
       OS_VERSION=7
       PYTHON_VERSION=2
     - OS=fedora

--- a/osbs-client.spec
+++ b/osbs-client.spec
@@ -1,10 +1,3 @@
-%if 0%{?rhel} && 0%{?rhel} <= 6
-%{!?__python2: %global __python2 /usr/bin/python2}
-%{!?python2_sitelib: %global python2_sitelib %(%{__python2} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")}
-%{!?python2_sitearch: %global python2_sitearch %(%{__python2} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(1))")}
-%{!?python2_version: %global python2_version %(%{__python2} -c "import sys; sys.stdout.write(sys.version[:3])")}
-%endif
-
 %if 0%{?rhel} && 0%{?rhel} <= 7
 %{!?py2_build: %global py2_build %{__python2} setup.py build}
 %{!?py2_install: %global py2_install %{__python2} setup.py install --skip-build --root %{buildroot}}
@@ -107,9 +100,6 @@ Requires:       python-setuptools
 Requires:       python-six
 Requires:       krb5-workstation
 Requires:       PyYAML
-%if 0%{?rhel} && 0%{?rhel} <= 6
-Requires:       python-argparse
-%endif
 
 Provides:       python-osbs = %{version}-%{release}
 Obsoletes:      python-osbs < %{osbs_obsolete_vr}
@@ -208,6 +198,9 @@ LANG=en_US.utf8 py.test-%{python2_version} -vv tests
 %endif # with_python3
 
 %changelog
+* Fri Nov 16 2018 Athos Ribeiro <athos@redhat.com>
+- drop Python 2.6 support
+
 * Wed Nov 14 2018 Robert Cerven <rcerven@redhat.com> - 0.52-1
 - new upstream release: 0.52
 

--- a/osbs/api.py
+++ b/osbs/api.py
@@ -385,7 +385,7 @@ class OSBS(object):
                 unique_labels[u] = build_json['metadata']['labels'][u]
             running_builds = self.list_builds(running=True, labels=unique_labels)
             if running_builds:
-                raise RuntimeError('Matching build(s) already running: {0}'
+                raise RuntimeError('Matching build(s) already running: {}'
                                    .format(', '.join(x.get_build_name() for x in running_builds)))
 
         return BuildResponse(self.os.create_build(build_json).json(), self)
@@ -1154,9 +1154,9 @@ class OSBS(object):
             s = repo_without_registry.split('/', 1)
 
             if len(s) == 2:
-                repo_without_registry = "{0}/{1}-{2}".format(organization, s[0], s[1])
+                repo_without_registry = "{}/{}-{}".format(organization, s[0], s[1])
             else:
-                repo_without_registry = "{0}/{1}".format(organization, s[0])
+                repo_without_registry = "{}/{}".format(organization, s[0])
 
         return registry + repo_without_registry
 

--- a/osbs/build/build_request.py
+++ b/osbs/build/build_request.py
@@ -310,7 +310,7 @@ class BuildRequest(object):
 
         # Remove empty values, and always convert to string for better interaction
         # with Configuration class and JSON encoding
-        config_kwargs = dict((k, str(v)) for k, v in config_kwargs.items() if v is not None)
+        config_kwargs = {k: str(v) for k, v in config_kwargs.items() if v is not None}
 
         if not self.spec.build_imagestream.value:
             config_kwargs['build_image'] = self.spec.build_image.value
@@ -633,7 +633,7 @@ class BuildRequest(object):
 
         if not ISOLATED_RELEASE_FORMAT.match(release.value):
             raise OsbsValidationException(
-                'For isolated builds, the release value must be in the format: {0}'
+                'For isolated builds, the release value must be in the format: {}'
                 .format(ISOLATED_RELEASE_FORMAT.pattern))
 
         self.set_label('isolated', 'true')
@@ -1343,7 +1343,7 @@ class BuildRequest(object):
             self.dj.dock_json_set_arg(phase, plugin, "command",
                                       self.spec.sources_command.value)
         else:
-            logger.info('removing {0}, no sources_command was provided'.format(plugin))
+            logger.info('removing {}, no sources_command was provided'.format(plugin))
             self.dj.remove_plugin(phase, plugin)
 
     def render_pull_base_image(self):
@@ -1389,7 +1389,7 @@ class BuildRequest(object):
                         plugin_dict['plugin_name']
                     )
                     logger.debug(
-                        "site-specific plugin disabled -> Type:{0} Name:{1}".format(
+                        "site-specific plugin disabled -> Type:{} Name:{}".format(
                             plugin_dict['plugin_type'],
                             plugin_dict['plugin_name']
                         )
@@ -1410,7 +1410,7 @@ class BuildRequest(object):
                         plugin_dict['plugin_args']
                     )
                     logger.debug(
-                        "site-specific plugin enabled -> Type:{0} Name:{1} Args: {2}".format(
+                        "site-specific plugin enabled -> Type:{} Name:{} Args: {}".format(
                             plugin_dict['plugin_type'],
                             plugin_dict['plugin_name'],
                             plugin_dict['plugin_args']
@@ -1430,16 +1430,16 @@ class BuildRequest(object):
             name = image_tag
             # Platform name may contain characters not allowed by OpenShift.
             if platform:
-                platform_suffix = '-{0}'.format(platform)
+                platform_suffix = '-{}'.format(platform)
                 if name.endswith(platform_suffix):
                     name = name[:-len(platform_suffix)]
 
             _, salt, timestamp = name.rsplit('-', 2)
 
             if self.scratch:
-                name = 'scratch-{0}-{1}'.format(salt, timestamp)
+                name = 'scratch-{}-{}'.format(salt, timestamp)
             elif self.isolated:
-                name = 'isolated-{0}-{1}'.format(salt, timestamp)
+                name = 'isolated-{}-{}'.format(salt, timestamp)
 
         # !IMPORTANT! can't be too long: https://github.com/openshift/origin/issues/733
         self.template['metadata']['name'] = name
@@ -1479,7 +1479,7 @@ class BuildRequest(object):
 
         if self.spec.registry_uris.value:
             primary_registry_uri = self.spec.registry_uris.value[0].docker_uri
-            tag_with_registry = '{0}/{1}'.format(primary_registry_uri,
+            tag_with_registry = '{}/{}'.format(primary_registry_uri,
                                                  self.spec.image_tag.value)
             self.template['spec']['output']['to']['name'] = tag_with_registry
         else:

--- a/osbs/build/plugins_configuration.py
+++ b/osbs/build/plugins_configuration.py
@@ -62,7 +62,7 @@ class PluginsTemplate(object):
             if p.get('name') == name:
                 self.template[phase].remove(p)
                 if reason:
-                    logger.info('Removing {0}:{1}, {2}'.format(phase, name, reason))
+                    logger.info('Removing {}:{}, {}'.format(phase, name, reason))
                 break
 
     def add_plugin(self, phase, name, args, reason=None):
@@ -79,7 +79,7 @@ class PluginsTemplate(object):
         if not plugin_modified:
             self.template[phase].append({"name": name, "args": args})
             if reason:
-                logger.info('{0}:{1} with args {2}, {3}'.format(phase, name, args, reason))
+                logger.info('{}:{} with args {}, {}'.format(phase, name, args, reason))
 
     def get_plugin_conf(self, phase, name):
         """
@@ -133,7 +133,7 @@ class PluginsConfiguration(object):
         #    <build_type>_inner:<arrangement_version>.json
         arrangement_version = self.user_params.arrangement_version.value
         build_type = self.user_params.build_type.value
-        pt_path = '{0}_inner:{1}.json'.format(build_type, arrangement_version)
+        pt_path = '{}_inner:{}.json'.format(build_type, arrangement_version)
         self.pt = PluginsTemplate(self.user_params.build_json_dir.value, pt_path,
                                   self.user_params.customize_conf_path.value)
 

--- a/osbs/build/pod_response.py
+++ b/osbs/build/pod_response.py
@@ -47,9 +47,8 @@ class PodResponse(object):
 
             return image_id
 
-        return dict([(status['image'], remove_prefix(status['imageID'],
-                                                     'docker://'))
-                     for status in statuses])
+        return {status['image']: remove_prefix(status['imageID'], 'docker://')
+                for status in statuses}
 
     def get_failure_reason(self):
         """

--- a/osbs/build/spec.py
+++ b/osbs/build/spec.py
@@ -137,7 +137,7 @@ class BuildCommon(object):
             tag_segments.append(self.platform.value)
 
         tag = '-'.join(tag_segments)
-        self.image_tag.value = '{0}/{1}:{2}'.format(self.user.value, self.component.value, tag)
+        self.image_tag.value = '{}/{}:{}'.format(self.user.value, self.component.value, tag)
 
     def validate(self):
         logger.info("Validating params of %s", self.__class__.__name__)

--- a/osbs/cli/capture.py
+++ b/osbs/cli/capture.py
@@ -71,7 +71,7 @@ class ResponseSaver(object):
 
         visit = self.visited.get(path, 0)
         self.visited[path] = visit + 1
-        path += "-{0:0>3}".format(visit)
+        path += "-{:0>3}".format(visit)
 
         if kwargs.get('stream', False):
             stream = self.fn(url, method, *args, **kwargs)

--- a/osbs/cli/main.py
+++ b/osbs/cli/main.py
@@ -363,7 +363,7 @@ def cmd_build(args, osbs):
 def _display_build_summary(build):
     output = [
         "",  # Empty line for cleaner display
-        "build {0} is {1}".format(build.get_build_name(), build.status),
+        "build {} is {}".format(build.get_build_name(), build.status),
     ]
 
     if build.is_succeeded():
@@ -460,7 +460,7 @@ def cmd_get_build_image_id(args, osbs):
 
 
 def cmd_backup(args, osbs):
-    dirname = time.strftime("osbs-backup-{0}-%Y-%m-%d-%H%M%S"
+    dirname = time.strftime("osbs-backup-{}-%Y-%m-%d-%H%M%S"
                             .format(args.instance))
     if args.filename == '-':
         outfile = sys.stdout.buffer if PY3 else sys.stdout  # pylint: disable=no-member

--- a/osbs/conf.py
+++ b/osbs/conf.py
@@ -302,7 +302,7 @@ class Configuration(object):
         if platform is None:
             return versions
 
-        section = 'platform:{0}'.format(platform)
+        section = 'platform:{}'.format(platform)
         enable_v1 = self._get_deprecated("enable_v1", section, "enable_v1",
                                          default=False, is_bool_val=True)
         if enable_v1:
@@ -632,7 +632,7 @@ class Configuration(object):
             platform_descriptors[platform] = platform_descriptor
 
         if len(has_v1) > 1:
-            msg = "multiple platforms enable API v1: {0}".format(has_v1)
+            msg = "multiple platforms enable API v1: {}".format(has_v1)
             raise OsbsValidationException(msg)
 
         return platform_descriptors

--- a/osbs/core.py
+++ b/osbs/core.py
@@ -712,7 +712,7 @@ class Openshift(object):
                 return build_response
             except OsbsWatchBuildNotFound:
                 continue
-            raise OsbsException('Failed to schedule a build in {0} attempts: {1}'.format(WAIT_RETRY,
+            raise OsbsException('Failed to schedule a build in {} attempts: {}'.format(WAIT_RETRY,
                                                                                          build_id))
 
     @staticmethod
@@ -814,7 +814,7 @@ class Openshift(object):
             if not repository:
                 repository = stream['spec']['dockerImageRepository']
 
-        tag_id = '{0}:{1}'.format(stream_id, tag_name)
+        tag_id = '{}:{}'.format(stream_id, tag_name)
 
         changed = False
         try:
@@ -829,7 +829,7 @@ class Openshift(object):
             tag = tag_template
             tag['metadata']['name'] = tag_id
             tag['tag']['name'] = tag_name
-            tag['tag']['from']['name'] = '{0}:{1}'.format(repository, tag_name)
+            tag['tag']['from']['name'] = '{}:{}'.format(repository, tag_name)
             changed = True
 
         if insecure != tag['tag']['importPolicy'].get('insecure', False):
@@ -966,7 +966,7 @@ class Openshift(object):
         for tag in tags_set:
             image_import = {
                 'from': {"kind": "DockerImage",
-                         "name": '{0}:{1}'.format(repository, tag)},
+                         "name": '{}:{}'.format(repository, tag)},
                 'to': {'name': tag},
                 'importPolicy': {'insecure': insecure},
                 # referencePolicy will default to "type: source"
@@ -1001,7 +1001,7 @@ class Openshift(object):
                 failed_images_server_error = True
 
         if failed_images:
-            error_msg = 'Failed to import {0} image(s)'.format(len(failed_images))
+            error_msg = 'Failed to import {} image(s)'.format(len(failed_images))
             logger.error(error_msg)
             if failed_images_server_error:
                 raise ImportImageFailedServerError(error_msg)

--- a/osbs/http.py
+++ b/osbs/http.py
@@ -218,7 +218,7 @@ class HttpResponse(object):
         try:
             return json.loads(text)
         except ValueError:
-            msg = '{0}Headers {1}\nContent {2}'.format('HtttpResponse has corrupt json:\n',
+            msg = '{}Headers {}\nContent {}'.format('HtttpResponse has corrupt json:\n',
                                                        self.headers, self.content)
             logger.exception(msg)
             raise OsbsResponseException(msg, self.status_code)

--- a/osbs/utils.py
+++ b/osbs/utils.py
@@ -433,7 +433,7 @@ def wrap_name_from_git(prefix, suffix, *args, **kwargs):
 
 def get_instance_token_file_name(instance):
     """Return the token file name for the given instance."""
-    return '{0}/.osbs/{1}.token'.format(os.path.expanduser('~'), instance)
+    return '{}/.osbs/{}.token'.format(os.path.expanduser('~'), instance)
 
 
 def run_command(*popenargs, **kwargs):
@@ -478,7 +478,7 @@ def sanitize_version(version):
         parts += [0] * (3 - len(parts))
 
     major, minor, micro = parts[:3]
-    cleaned_version = '{0}.{1}.{2}'.format(major, minor, micro)
+    cleaned_version = '{}.{}.{}'.format(major, minor, micro)
     return cleaned_version
 
 

--- a/test.sh
+++ b/test.sh
@@ -3,7 +3,7 @@ set -eux
 
 # Prepare env vars
 OS=${OS:="centos"}
-OS_VERSION=${OS_VERSION:="6"}
+OS_VERSION=${OS_VERSION:="7"}
 PYTHON_VERSION=${PYTHON_VERSION:="2"}
 ACTION=${ACTION:="test"}
 IMAGE="$OS:$OS_VERSION"
@@ -46,12 +46,7 @@ fi
 # Install dependencies
 $RUN $PKG install -y $PKG_EXTRA
 [[ ${PYTHON_VERSION} == '3' ]] && WITH_PY3=1 || WITH_PY3=0
-if [[ ${OS} == 'centos' && ${OS_VERSION} == 6 ]]; then
-  # yum doesnt support --define option in centos 6
-  $RUN $BUILDDEP -y osbs-client.spec
-else
-  $RUN $BUILDDEP --define "with_python3 ${WITH_PY3}" -y osbs-client.spec
-fi
+$RUN $BUILDDEP --define "with_python3 ${WITH_PY3}" -y osbs-client.spec
 if [[ $OS != "fedora" ]]; then
   # Install dependecies for test, as check is disabled for rhel
   $RUN yum install -y python-flexmock python-six python-dockerfile-parse python-requests python-requests-kerberos
@@ -65,23 +60,12 @@ if [[ $PYTHON_VERSION == 3 ]]; then
 fi
 $RUN $PYTHON setup.py install
 
-# py >= 1.6.0 (py is a pytest dependency) is incompatible with Python 2.6
-VERSIONED_PY=
-if [[ $OS != "fedora" && $OS_VERSION == '6' ]] ; then
-    VERSIONED_PY="py==1.5.4"
-fi
-
-$RUN $PIP install -r tests/requirements.txt $VERSIONED_PY
+# Install packages for tests
+$RUN $PIP install -r tests/requirements.txt
 
 # CentOS needs to have setuptools updates to make pytest-cov work
 if [[ $OS != "fedora" ]]; then
-  if [[ $OS_VERSION != '6' ]] ; then
-      $RUN $PIP install -U setuptools
-  else
-      # setuptools 40.0 is incompatible with Python 2.6 because of this change
-      # https://github.com/pypa/setuptools/commit/7392f0#diff-c6950cefad8b244938b76f24a0db9a6aR51
-      $RUN $PIP install -U setuptools==39.2.0
-  fi
+  $RUN $PIP install -U setuptools
 
   # Watch out for https://github.com/pypa/setuptools/issues/937
   $RUN curl -O https://bootstrap.pypa.io/2.6/get-pip.py

--- a/tests/build_/test_user_params.py
+++ b/tests/build_/test_user_params.py
@@ -92,7 +92,7 @@ class TestBuildUserParams(object):
         assert spec.to_json() == required_json
         spec.from_json("")
         assert spec.to_json() == required_json
-        assert '{0}'.format(spec)
+        assert '{}'.format(spec)
 
     @pytest.mark.parametrize(('missing_arg'), (
         'name_label',
@@ -222,7 +222,7 @@ class TestBuildUserParams(object):
             "git_branch": TEST_GIT_BRANCH,
             "git_ref": TEST_GIT_REF,
             "git_uri": TEST_GIT_URI,
-            "image_tag": "{0}/{1}:tothepoint-{2}-{3}-x86_64".format(TEST_USER, TEST_COMPONENT,
+            "image_tag": "{}/{}:tothepoint-{}-{}-x86_64".format(TEST_USER, TEST_COMPONENT,
                                                                     rand, timestr),
             "imagestream_name": "name_label",
             "koji_parent_build": "fedora-26-9",

--- a/tests/fake_api.py
+++ b/tests/fake_api.py
@@ -546,9 +546,9 @@ def osbs(openshift, kwargs=None, additional_config=None, platform_descriptors=No
             if not platform_info:
                 continue
 
-            config += '[platform:{0}]\n'.format(platform)
+            config += '[platform:{}]\n'.format(platform)
             for item, value in platform_info.items():
-                config += '{0} = {1}\n'.format(item, value)
+                config += '{} = {}\n'.format(item, value)
 
         fp.write(config.format(**kwargs))
         fp.flush()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -526,7 +526,7 @@ class TestOSBS(object):
             with pytest.raises(OsbsException) as ex:
                 osbs.render_plugins_configuration(json.dumps(user_params))
 
-            assert 'inner:{0}'.format(invalid_version) in ex.value.message
+            assert 'inner:{}'.format(invalid_version) in ex.value.message
 
     # osbs is a fixture here
     def test_create_worker_build_ioerror(self, osbs):  # noqa
@@ -687,7 +687,7 @@ class TestOSBS(object):
             with pytest.raises(OsbsException) as ex:
                 osbs.render_plugins_configuration(json.dumps(user_params))
 
-            assert 'inner:{0}'.format(invalid_version) in ex.value.message
+            assert 'inner:{}'.format(invalid_version) in ex.value.message
 
     # osbs is a fixture here
     def test_create_prod_build_missing_name_label(self, osbs):  # noqa

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -544,7 +544,7 @@ class TestOpenshift(object):
             stream['metadata']['annotations'] = s_annotations
 
         tag_name = 'maps'
-        tag_id = '{0}:{1}'.format(stream_name, tag_name)
+        tag_id = '{}:{}'.format(stream_name, tag_name)
 
         expected_url = openshift._build_url('imagestreamtags/' +
                                             tag_id)
@@ -562,7 +562,7 @@ class TestOpenshift(object):
                 assert data['metadata']['name'] == tag_id
                 assert data['tag']['name'] == tag_name
                 assert (data['tag']['from']['name'] ==
-                        '{0}:{1}'.format(stream_repo, tag_name))
+                        '{}:{}'.format(stream_repo, tag_name))
 
             return make_json_response({})
 
@@ -826,7 +826,7 @@ class TestOpenshift(object):
             for tag in set(tags):
                 image_import = {
                     'from': {"kind": "DockerImage",
-                             "name": '{0}:{1}'.format(source_repo, tag)},
+                             "name": '{}:{}'.format(source_repo, tag)},
                     'to': {'name': tag},
                     'importPolicy': {'insecure': insecure},
                 }

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -28,10 +28,6 @@ def s():
 def has_connection():
     # In case we run tests in an environment without internet connection.
 
-    if sys.version_info < (2, 7):
-        # py 2.6 doesn't have SNI support, required for httpbin, as it has SSLv3 certificates
-        return False
-
     try:
         HttpStream("https://httpbin.org/get", "get", retries_enabled=False)
         return True

--- a/tests/test_repo_utils.py
+++ b/tests/test_repo_utils.py
@@ -51,7 +51,7 @@ class TestRepoConfiguration(object):
             if config_value is not None:
                 f.write(dedent("""\
                     [autorebuild]
-                    enabled={0}
+                    enabled={}
                     """.format(config_value)))
 
         with open(os.path.join(str(tmpdir), REPO_CONTAINER_CONFIG), 'w') as f:

--- a/tests/test_retries.py
+++ b/tests/test_retries.py
@@ -33,10 +33,6 @@ def s():
 def has_connection():
     # In case we run tests in an environment without internet connection.
 
-    if sys.version_info < (2, 7):
-        # py 2.6 doesn't have SNI support, required for httpbin, as it has SSLv3 certificates
-        return False
-
     try:
         HttpStream("https://httpbin.org/get", "get", retries_enabled=False)
         return True

--- a/tests/throughput-test-harness.py
+++ b/tests/throughput-test-harness.py
@@ -32,7 +32,7 @@ def run(*args):
     if err:
         logging.info("stderr:\n%s", err.rstrip())
     if p.returncode != 0:
-        raise SubprocessError("Subprocess failed w/ return code {0}".format(p.returncode))
+        raise SubprocessError("Subprocess failed w/ return code {}".format(p.returncode))
 
     return out
 
@@ -48,7 +48,7 @@ def bump_release(df_path, branch):
         raise RuntimeError("Release does not end with number")
 
     num = int(m.group(2))
-    newrelease = "{0}{1:03d}".format(m.group(1), num+1)
+    newrelease = "{}{:03d}".format(m.group(1), num+1)
 
     parser.labels["Release"] = newrelease
     return newrelease
@@ -57,7 +57,7 @@ def bump_release(df_path, branch):
 def set_initial_release(df_path, branch):
     parser = DockerfileParser(df_path)
     oldrelease = parser.labels.get("Release", "1")
-    newrelease = "{0}.{1}.iteration001".format(oldrelease, branch)
+    newrelease = "{}.{}.iteration001".format(oldrelease, branch)
     parser.labels["Release"] = newrelease
     return newrelease
 
@@ -72,7 +72,7 @@ def get_branches(branch_prefix):
 
 
 def cmd_create_branches(args):
-    branches = ["{0}{1:03d}".format(args.branch_prefix, n+1) for n in range(args.number)]
+    branches = ["{}{:03d}".format(args.branch_prefix, n+1) for n in range(args.number)]
 
     logging.info("Creating branches from current branch")
     for b in branches:
@@ -142,7 +142,7 @@ def cmd_start_builds(args):
         if i >= DEFAULT_BRANCH_COUNT:
             break
         commit = run("git", "rev-parse", b).strip()
-        branch_url = "{0}#{1}".format(remote_url, commit)
+        branch_url = "{}#{}".format(remote_url, commit)
 
         try:
             if args.use_koji:


### PR DESCRIPTION
We are dropping Python 2.6 support. Note that when this gets merged, atomic-reactor test suite should also be changed not to run on python 2.6 environments.