### PR TITLE
Extend build_json with images digests data

### DIFF
--- a/osbs/api.py
+++ b/osbs/api.py
@@ -609,6 +609,7 @@ class OSBS(object):
                               signing_intent=None,
                               compose_ids=None,
                               reactor_config_override=None,
+                              parent_images_digests=None,
                               **kwargs):
 
         if flatpak:
@@ -713,7 +714,8 @@ class OSBS(object):
             prefer_schema1_digest=self.build_conf.get_prefer_schema1_digest(),
             signing_intent=signing_intent,
             compose_ids=compose_ids,
-            osbs_api=self
+            osbs_api=self,
+            parent_images_digests=parent_images_digests,
         )
         build_request.set_openshift_required_version(self.os_conf.get_openshift_required_version())
         build_request.set_repo_info(repo_info)

--- a/osbs/build/build_request.py
+++ b/osbs/build/build_request.py
@@ -99,6 +99,11 @@ class BuildRequest(object):
         :param auto_build_node_selector: dict, a nodeselector for auto builds
         :param isolated_build_node_selector: dict, a nodeselector for isolated builds
         :param is_auto: bool, indicates if build is auto build
+        :param parent_images_digests: dict, mapping image names with tags to platform specific
+                                      digests, example:
+                                      {'registry.fedorahosted.org/fedora:29': {
+                                          x86_64': 'registry.fedorahosted.org/fedora@sha256:....'}
+                                      }
         """
 
         # Here we cater to the koji "scratch" build type, this will disable

--- a/osbs/build/build_requestv2.py
+++ b/osbs/build/build_requestv2.py
@@ -77,6 +77,7 @@ class BuildRequestV2(BuildRequest):
         :param explicit_build_node_selector: dict, a nodeselector for explicit builds
         :param auto_build_node_selector: dict, a nodeselector for auto builds
         :param isolated_build_node_selector: dict, a nodeselector for isolated builds
+        :param parent_images_digests: dict, mapping image digests to names and platforms
         """
 
         # Here we cater to the koji "scratch" build type, this will disable

--- a/osbs/build/plugins_configuration.py
+++ b/osbs/build/plugins_configuration.py
@@ -507,6 +507,15 @@ class PluginsConfiguration(object):
 
         self.pt.set_plugin_arg(phase, plugin, 'tag_suffixes', tag_suffixes)
 
+    def render_pull_base_image(self):
+        """Configure pull_base_image"""
+        phase = 'prebuild_plugins'
+        plugin = 'pull_base_image'
+
+        if self.user_params.parent_images_digests.value:
+            self.pt.set_plugin_arg(phase, plugin, 'parent_images_digests',
+                                   self.user_params.parent_images_digests.value)
+
     def render(self):
         self.user_params.validate()
         # adjust for custom configuration first
@@ -531,6 +540,7 @@ class PluginsConfiguration(object):
         self.render_koji_tag_build()
         self.render_koji_upload()
         self.render_orchestrate_build()
+        self.render_pull_base_image()
         self.render_resolve_composes()
         self.render_resolve_module_compose()
         self.render_tag_from_config()

--- a/osbs/build/user_params.py
+++ b/osbs/build/user_params.py
@@ -45,6 +45,7 @@ class BuildUserParams(BuildCommon):
         self.koji_task_id = BuildParam('koji_task_id', allow_none=True)
         self.koji_upload_dir = BuildParam('koji_upload_dir', allow_none=True)
         self.name = BuildIDParam()
+        self.parent_images_digests = BuildParam('parent_images_digests', allow_none=True)
         self.platforms = BuildParam('platforms', allow_none=True)
         self.reactor_config_map = BuildParam("reactor_config_map", allow_none=True)
         self.reactor_config_override = BuildParam("reactor_config_override", allow_none=True)
@@ -79,7 +80,7 @@ class BuildUserParams(BuildCommon):
                    koji_parent_build=None, koji_upload_dir=None,
                    flatpak=None, reactor_config_map=None, reactor_config_override=None,
                    yum_repourls=None, signing_intent=None, compose_ids=None,
-                   isolated=None, scratch=None,
+                   isolated=None, scratch=None, parent_images_digests=None,
                    **kwargs):
         self.git_uri.value = git_uri
         self.git_ref.value = git_ref
@@ -114,6 +115,7 @@ class BuildUserParams(BuildCommon):
             else:
                 self.build_imagestream.value = source_value
 
+        self.parent_images_digests.value = parent_images_digests
         self.platforms.value = platforms
         self.platform.value = platform
         self.koji_target.value = koji_target

--- a/tests/build_/test_user_params.py
+++ b/tests/build_/test_user_params.py
@@ -178,6 +178,12 @@ class TestBuildUserParams(object):
             'isolated': False,
             'koji_parent_build': 'fedora-26-9',
             'koji_target': 'tothepoint',
+            'parent_images_digests': {
+                'registry.fedorahosted.org/fedora:29': {
+                    'x86_64': 'registry.fedorahosted.org/fedora@sha256:8b96f2f9f88179a065738b2b37'
+                              '35e386efb2534438c2a2f45b74358c0f344c81'
+                }
+            },
             # 'name': self.name,  # calculated value
             'platform': 'x86_64',
             'platforms': ['x86_64', ],
@@ -228,6 +234,12 @@ class TestBuildUserParams(object):
             "koji_parent_build": "fedora-26-9",
             "koji_target": "tothepoint",
             "name": "path-master-cd1e4",
+            'parent_images_digests': {
+                'registry.fedorahosted.org/fedora:29': {
+                    'x86_64': 'registry.fedorahosted.org/fedora@sha256:8b96f2f9f88179a065738b2b37'
+                              '35e386efb2534438c2a2f45b74358c0f344c81'
+                }
+            },
             "platform": "x86_64",
             "platforms": ["x86_64"],
             "reactor_config_map": "reactor-config-map",


### PR DESCRIPTION
Atomic-reactor will use digests instead of tags for builds to prevent
race conditions caused by floating tags of paretn images. For this
reason osbs-client must provide this information in request

Jira: OSBS-5674

Signed-off-by: Martin Bašti <mbasti@redhat.com>