### PR TITLE
Freeze requirements minor versions for RPM builds

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,3 @@
 flexmock
-pytest==4.0.*
-pytest-cov==2.6.*
+pytest==4.0.1
+pytest-cov==2.6.0


### PR DESCRIPTION
CentOS 7 setuptools version does not accept a list of requirements
containing wildcards. We do skip tests for rhel<=7 builds, but the
python2 build macro calls setuptools, which verifies the test
requirements listed in setup.py. Using wildcards in requirements will
break RPM builds for such systems.

**A similar change is not required in atomic reactor since the test requirements are not listed in setup.py for that project**