### PR TITLE
Remove support for v1-only registries

### DIFF
--- a/docs/configuration_file.md
+++ b/docs/configuration_file.md
@@ -89,9 +89,9 @@ Some options are also mandatory.
 
 * `kerberos_ccache` (*optional*, `string`) - location of credential cache to use when `kerberos_keytab` is set (please refer to [kerberos documentation](http://web.mit.edu/Kerberos/krb5-latest/doc/basic/ccache_def.html) for list of credential cache types)
 
-* `registry_uri` (*optional*, `string`) — docker registry URI to use for pulling and pushing images. More than one can be specified by separating them with commas, and the registry API version for each can be specified by affixing '/v1' or '/v2' onto the end of the registry URI
+* `registry_uri` (*optional*, `string`) — docker registry URI to use for pulling and pushing images. More than one can be specified by separating them with commas. While it is possible to affix '/v2' onto the end of the registry URI for historical reasons, the `/v1` suffix is not supported. `v2` is assumed if no version suffix is provided.
 
-* `registry_api_versions` (*optional*, `string`) — comma-separated list of docker registry HTTP API versions to support, defaults to `v1,v2`
+* `registry_api_versions` (*optional*, `string`) — comma-separated list of docker registry HTTP API versions to support, defaults to `v1,v2`. `v1` only registries are no longer supported, i.e., `v2` must be present if this option is declared
 
 * `source_registry_uri` (*optional*, `string`) — URI of docker registry from which image is pulled
 

--- a/osbs/conf.py
+++ b/osbs/conf.py
@@ -299,6 +299,10 @@ class Configuration(object):
         value = self._get_deprecated("registry_api_versions", self.conf_section,
                                      "registry_api_versions", default='v1,v2')
         versions = [x.strip() for x in value.split(',')]
+
+        if 'v2' not in versions:
+            raise OsbsValidationException('v2 must be present in registry_api_versions')
+
         if platform is None:
             return versions
 
@@ -308,10 +312,7 @@ class Configuration(object):
         if enable_v1:
             return versions
         else:
-            if 'v2' in versions:
-                return ['v2']
-            else:
-                raise OsbsValidationException('v2 only platform in v1 only instance')
+            return ['v2']
 
     def get_source_registry_uri(self):
         return self._get_deprecated("source_registry_uri", self.conf_section,

--- a/osbs/utils.py
+++ b/osbs/utils.py
@@ -42,7 +42,7 @@ except ImportError:
     from calendar import timegm
 
 from dockerfile_parse import DockerfileParser
-from osbs.exceptions import OsbsException, OsbsResponseException
+from osbs.exceptions import OsbsException, OsbsResponseException, OsbsValidationException
 
 logger = logging.getLogger(__name__)
 
@@ -58,8 +58,11 @@ class RegistryURI(object):
     def __init__(self, uri):
         groups = self.versionre.match(uri).groups()
         self.docker_uri = groups[2]
-        self.version = groups[4] or 'v1'
+        self.version = groups[4] or 'v2'
         self.scheme = groups[1] or ''
+
+        if self.version == 'v1':
+            raise OsbsValidationException('Invalid API version requested in {}'.format(uri))
 
     @property
     def uri(self):

--- a/tests/build_/test_spec.py
+++ b/tests/build_/test_spec.py
@@ -39,7 +39,7 @@ class TestRegistryURIsParam(object):
 
         assert p.value[0].uri == 'registry.example.com:5000'
         assert p.value[0].docker_uri == 'registry.example.com:5000'
-        assert p.value[0].version == 'v1'
+        assert p.value[0].version == 'v2'
 
     def test_registry_uris_param_v2(self):
         p = RegistryURIsParam()
@@ -48,6 +48,11 @@ class TestRegistryURIsParam(object):
         assert p.value[0].uri == 'registry.example.com:5000'
         assert p.value[0].docker_uri == 'registry.example.com:5000'
         assert p.value[0].version == 'v2'
+
+    def test_registry_uris_param_v1(self):
+        p = RegistryURIsParam()
+        with pytest.raises(OsbsValidationException):
+            p.value = ['registry.example.com:5000/v1']
 
 
 class TestBuildSpec(object):

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -476,7 +476,7 @@ class TestConfiguration(object):
 
     @pytest.mark.parametrize(('platform', 'config', 'expected', 'valid'), [
         (None, {}, ['v1', 'v2'], True),
-        (None, {'default': {'registry_api_versions': 'v1'}}, ['v1'], True),
+        (None, {'default': {'registry_api_versions': 'v1'}}, ['v1'], False),
         (None, {'default': {'registry_api_versions': 'v2'}}, ['v2'], True),
         (None, {'default': {'registry_api_versions': 'v1,v2'}}, ['v1', 'v2'], True),
         (None, {'default': {'registry_api_versions': '  v1,   v2  '}}, ['v1', 'v2'], True),


### PR DESCRIPTION
We no longer need to handle the case where we are not pushing to a v2
registry.