### PR TITLE
Handle null values for composes in container yaml

### DIFF
--- a/osbs/repo_utils.py
+++ b/osbs/repo_utils.py
@@ -60,7 +60,9 @@ class RepoConfiguration(object):
             with open(file_path) as f:
                 self.container = (yaml.load(f) or {})
 
-        modules = self.container.get('compose', {}).get('modules', [])
+        # container values may be set to None
+        container_compose = self.container.get('compose') or {}
+        modules = container_compose.get('modules') or []
 
         self.container_module_specs = []
         value_errors = []

--- a/tests/test_repo_utils.py
+++ b/tests/test_repo_utils.py
@@ -128,6 +128,27 @@ class TestRepoConfiguration(object):
                     assert spec.context == expected[3]
             assert spec.profile == expected[4]
 
+    def test_empty_yaml_compose(self, tmpdir):
+        with open(os.path.join(str(tmpdir), REPO_CONTAINER_CONFIG), 'w') as f:
+            f.write(dedent("""\
+                compose:
+                """))
+
+        conf = RepoConfiguration(dir_path=str(tmpdir))
+        assert conf.container['compose'] is None
+        assert conf.container_module_specs == []
+
+    def test_empty_yaml_modules(self, tmpdir):
+        with open(os.path.join(str(tmpdir), REPO_CONTAINER_CONFIG), 'w') as f:
+            f.write(dedent("""\
+                compose:
+                    modules:
+                """))
+
+        conf = RepoConfiguration(dir_path=str(tmpdir))
+        assert conf.container['compose'] == {'modules': None}
+        assert conf.container_module_specs == []
+
 
 class TestModuleSpec(object):
     @pytest.mark.parametrize(('as_str', 'as_str_no_profile'), [


### PR DESCRIPTION
Container yaml file can may contain empty keys. We must handle them on
when fetching values from the file.

Also adding a couple tests to cover this case.