### PR TITLE
Retry git clone operations

### DIFF
--- a/osbs-client.spec
+++ b/osbs-client.spec
@@ -53,6 +53,7 @@ Requires:       python3-osbs-client = %{version}-%{release}
 Requires:       python-osbs-client = %{version}-%{release}
 %endif
 
+BuildRequires:  git-core
 BuildRequires:  python2-devel
 BuildRequires:  python-setuptools
 %if 0%{?with_check}
@@ -98,6 +99,7 @@ Requires:       python-setuptools
 Requires:       python-six
 Requires:       krb5-workstation
 Requires:       PyYAML
+Requires:       git-core
 
 Provides:       python-osbs = %{version}-%{release}
 Obsoletes:      python-osbs < %{osbs_obsolete_vr}
@@ -121,6 +123,7 @@ Requires:       python3-setuptools
 Requires:       python3-six
 Requires:       krb5-workstation
 Requires:       python3-PyYAML
+Requires:       git-core
 
 Provides:       python3-osbs = %{version}-%{release}
 Obsoletes:      python3-osbs < %{osbs_obsolete_vr}
@@ -196,6 +199,9 @@ LANG=en_US.utf8 py.test-%{python2_version} -vv tests
 %endif # with_python3
 
 %changelog
+* Tue Dec 11 2018 Athos Ribeiro <athos@redhat.com>
+- Add git-core dependency
+
 * Tue Nov 27 2018 Athos Ribeiro <athos@redhat.com>
 - remove pytest-capturelog dependency
 

--- a/osbs/cli/render.py
+++ b/osbs/cli/render.py
@@ -9,9 +9,7 @@ from __future__ import print_function, absolute_import, unicode_literals
 
 import sys
 import logging
-
-from osbs.exceptions import OsbsException
-from osbs.utils import run_command
+import subprocess
 
 
 logger = logging.getLogger(__name__)
@@ -24,8 +22,8 @@ def get_terminal_size():
     :return: tuple, (int, int)
     """
     try:
-        rows, columns = run_command(['stty', 'size']).split()
-    except OsbsException:
+        rows, columns = subprocess.check_output(['stty', 'size']).split()
+    except subprocess.CalledProcessError:
         # not attached to terminal
         logger.info("not attached to terminal")
         return 0, 0

--- a/osbs/constants.py
+++ b/osbs/constants.py
@@ -112,3 +112,9 @@ ANNOTATION_INSECURE_REPO = 'openshift.io/image.insecureRepository'
 
 # optional key path for filtering existing build config results
 FILTER_KEY = 'spec.source.git.uri'
+
+# number of retries for git clone operations
+GIT_MAX_RETRIES = 3
+
+# backoff factor for git clone operations - exponential backoff in seconds
+GIT_BACKOFF_FACTOR = 60

--- a/osbs/utils.py
+++ b/osbs/utils.py
@@ -200,17 +200,17 @@ def checkout_git_repo(git_uri, git_ref, git_branch=None):
                 args += ['-b', git_branch]
 
             args.append(repo_path)
-            run_command(args)
-        except OsbsException as ex:
+            subprocess.check_output(args)
+        except subprocess.CalledProcessError as ex:
             raise OsbsException("Unable to clone git repo '%s' "
                                 "branch '%s'" % (git_uri, git_branch),
                                 cause=ex, traceback=sys.exc_info()[2])
 
         # Find the specific ref we want
         try:
-            run_command(['git', 'reset', '--hard'], cwd=repo_path)
-            run_command(['git', 'checkout', git_ref], cwd=repo_path)
-        except OsbsException as ex:
+            subprocess.check_output(['git', 'reset', '--hard'], cwd=repo_path)
+            subprocess.check_output(['git', 'checkout', git_ref], cwd=repo_path)
+        except subprocess.CalledProcessError as ex:
             raise OsbsException("Unable to reset branch to '%s'" % git_ref,
                                 cause=ex, traceback=sys.exc_info()[2])
 
@@ -437,26 +437,6 @@ def wrap_name_from_git(prefix, suffix, *args, **kwargs):
 def get_instance_token_file_name(instance):
     """Return the token file name for the given instance."""
     return '{}/.osbs/{}.token'.format(os.path.expanduser('~'), instance)
-
-
-def run_command(*popenargs, **kwargs):
-    """
-    Run command with arguments and return its output as a byte string.
-
-    This is originally taken from subprocess.py of python 2.7
-    """
-    process = subprocess.Popen(stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
-                               *popenargs, **kwargs)
-    output, _ = process.communicate()
-    retcode = process.poll()
-    if retcode:
-        cmd = kwargs.get("args")
-        if cmd is None:
-            cmd = popenargs[0]
-        raise OsbsException(
-            message="Command %s returned %s\n\n%s" % (cmd, retcode, output)
-        )
-    return output
 
 
 def sanitize_version(version):


### PR DESCRIPTION
The retry code is based on atomic-reactor's backoff and retry operations [1]. A next step would be to reuse osbs git checkout function in atomic-reactor.

[1] https://github.com/projectatomic/atomic-reactor/blob/e8294b8df36660097db463060fe9610ddf7f7cbb/atomic_reactor/util.py#L305 (the ref points to master's HEAD on the day this PR was open)