### PR TITLE
Capture and re-raise DockerfileParser IOError

### DIFF
--- a/osbs/api.py
+++ b/osbs/api.py
@@ -516,7 +516,12 @@ class OSBS(object):
 
     def _check_labels(self, repo_info):
         df_parser = repo_info.dockerfile_parser
-        labels = utils.Labels(df_parser.labels)
+        # DockerfileParse does not ensure a Dockerfile exists during initialization
+        try:
+            labels = utils.Labels(df_parser.labels)
+        except IOError as e:
+            raise RuntimeError('Could not parse Dockerfile in {}: {}'
+                               .format(df_parser.dockerfile_path, e))
 
         required_missing = False
         req_labels = {}


### PR DESCRIPTION
If osbs-client fails when a Dockerfile cannot be parsed, it fails with

`osbs - ERROR - Exception caught: OsbsException: IOError(2, 'No such file or directory') (from IOError(2, 'No such file or directory'))`

This commit captures a possible IOError when DockerfileParser tries to
read a Dockerfile and re-raise it with a friendly error message.