### PR TITLE
minimize the work of git clone

### DIFF
--- a/osbs/api.py
+++ b/osbs/api.py
@@ -719,6 +719,8 @@ class OSBS(object):
             compose_ids=compose_ids,
             osbs_api=self,
             parent_images_digests=parent_images_digests,
+            tags_from_yaml=repo_info.additional_tags.from_container_yaml,
+            additional_tags=repo_info.additional_tags.tags,
         )
         build_request.set_openshift_required_version(self.os_conf.get_openshift_required_version())
         build_request.set_repo_info(repo_info)

--- a/osbs/api.py
+++ b/osbs/api.py
@@ -613,6 +613,7 @@ class OSBS(object):
                               compose_ids=None,
                               reactor_config_override=None,
                               parent_images_digests=None,
+                              git_commit_depth=None,
                               **kwargs):
 
         if flatpak:
@@ -623,7 +624,8 @@ class OSBS(object):
                 # fix for module requires will have to be determined from experience.
                 raise ValueError("Flatpak build cannot be isolated")
 
-        repo_info = utils.get_repo_info(git_uri, git_ref, git_branch=git_branch)
+        repo_info = utils.get_repo_info(git_uri, git_ref, git_branch=git_branch,
+                                        depth=git_commit_depth)
         build_request = self.get_build_request(inner_template=inner_template,
                                                outer_template=outer_template,
                                                customize_conf=customize_conf,
@@ -721,6 +723,7 @@ class OSBS(object):
             parent_images_digests=parent_images_digests,
             tags_from_yaml=repo_info.additional_tags.from_container_yaml,
             additional_tags=repo_info.additional_tags.tags,
+            git_commit_depth=repo_info.configuration.depth,
         )
         build_request.set_openshift_required_version(self.os_conf.get_openshift_required_version())
         build_request.set_repo_info(repo_info)

--- a/osbs/build/plugins_configuration.py
+++ b/osbs/build/plugins_configuration.py
@@ -13,7 +13,6 @@ import json
 
 from osbs.constants import BUILD_TYPE_ORCHESTRATOR
 from osbs.exceptions import OsbsException
-from osbs import utils
 
 logger = logging.getLogger(__name__)
 
@@ -455,24 +454,22 @@ class PluginsConfiguration(object):
         if not self.has_tag_suffixes_placeholder():
             return
 
-        repo_info = utils.get_repo_info(self.user_params.git_uri.value,
-                                        self.user_params.git_ref.value,
-                                        git_branch=self.user_params.git_branch.value)
-
         unique_tag = self.user_params.image_tag.value.split(':')[-1]
         tag_suffixes = {'unique': [unique_tag], 'primary': []}
 
         if self.user_params.build_type.value == BUILD_TYPE_ORCHESTRATOR:
+            additional_tags = self.user_params.additional_tags.value or set()
+
             if self.user_params.scratch.value:
                 pass
             elif self.user_params.isolated.value:
                 tag_suffixes['primary'].extend(['{version}-{release}'])
-            elif repo_info.additional_tags.from_container_yaml:
+            elif self.user_params.tags_from_yaml.value:
                 tag_suffixes['primary'].extend(['{version}-{release}'])
-                tag_suffixes['primary'].extend(repo_info.additional_tags.tags)
+                tag_suffixes['primary'].extend(additional_tags)
             else:
                 tag_suffixes['primary'].extend(['latest', '{version}', '{version}-{release}'])
-                tag_suffixes['primary'].extend(repo_info.additional_tags.tags)
+                tag_suffixes['primary'].extend(additional_tags)
 
         self.pt.set_plugin_arg(phase, plugin, 'tag_suffixes', tag_suffixes)
 

--- a/osbs/build/plugins_configuration.py
+++ b/osbs/build/plugins_configuration.py
@@ -392,7 +392,7 @@ class PluginsConfiguration(object):
             'component', 'git_branch', 'git_ref', 'git_uri', 'koji_task_id',
             'filesystem_koji_task_id', 'scratch', 'koji_target', 'user', 'yum_repourls',
             'arrangement_version', 'koji_parent_build', 'isolated', 'reactor_config_map',
-            'reactor_config_override'
+            'reactor_config_override', 'git_commit_depth',
         ]
 
         build_kwargs = self.user_params.to_dict(worker_params)

--- a/osbs/build/user_params.py
+++ b/osbs/build/user_params.py
@@ -55,6 +55,7 @@ class BuildUserParams(BuildCommon):
         self.yum_repourls = BuildParam("yum_repourls")
         self.tags_from_yaml = BuildParam('tags_from_yaml', allow_none=True)
         self.additional_tags = BuildParam('additional_tags', allow_none=True)
+        self.git_commit_depth = BuildParam('git_commit_depth', allow_none=True)
 
         self.required_params = [
             self.build_json_dir,
@@ -84,10 +85,12 @@ class BuildUserParams(BuildCommon):
                    yum_repourls=None, signing_intent=None, compose_ids=None,
                    isolated=None, scratch=None, parent_images_digests=None,
                    tags_from_yaml=None, additional_tags=None,
+                   git_commit_depth=None,
                    **kwargs):
         self.git_uri.value = git_uri
         self.git_ref.value = git_ref
         self.git_branch.value = git_branch
+        self.git_commit_depth.value = git_commit_depth
         self.tags_from_yaml.value = tags_from_yaml
         self.additional_tags.value = additional_tags or set()
 

--- a/osbs/build/user_params.py
+++ b/osbs/build/user_params.py
@@ -157,7 +157,11 @@ class BuildUserParams(BuildCommon):
     def from_json(self, user_params_json):
         if not user_params_json:
             return
-        json_dict = json.loads(user_params_json)
+        try:
+            json_dict = json.loads(user_params_json)
+        except ValueError:
+            logger.debug('failed to convert %s', user_params_json)
+            raise
         for key, value in json_dict.items():
             try:
                 self.convert_dict[key].value = value

--- a/osbs/build/user_params.py
+++ b/osbs/build/user_params.py
@@ -53,6 +53,9 @@ class BuildUserParams(BuildCommon):
         self.signing_intent = BuildParam('signing_intent', allow_none=True)
         self.trigger_imagestreamtag = BuildParam('trigger_imagestreamtag')
         self.yum_repourls = BuildParam("yum_repourls")
+        self.tags_from_yaml = BuildParam('tags_from_yaml', allow_none=True)
+        self.additional_tags = BuildParam('additional_tags', allow_none=True)
+
         self.required_params = [
             self.build_json_dir,
             self.build_type,
@@ -80,10 +83,14 @@ class BuildUserParams(BuildCommon):
                    flatpak=None, reactor_config_map=None, reactor_config_override=None,
                    yum_repourls=None, signing_intent=None, compose_ids=None,
                    isolated=None, scratch=None, parent_images_digests=None,
+                   tags_from_yaml=None, additional_tags=None,
                    **kwargs):
         self.git_uri.value = git_uri
         self.git_ref.value = git_ref
         self.git_branch.value = git_branch
+        self.tags_from_yaml.value = tags_from_yaml
+        self.additional_tags.value = additional_tags or set()
+
         self.user.value = user
         self.component.value = component
         self.release.value = release

--- a/osbs/utils.py
+++ b/osbs/utils.py
@@ -279,12 +279,12 @@ def reset_git_repo(target_dir, git_reference, retry_depth=None):
     :return: str and int, commit ID of HEAD and commit depth of git_reference
     """
     deepen = retry_depth or 0
-    commit_depth = None
+    base_commit_depth = 0
     for _ in range(GIT_FETCH_RETRY):
         try:
             if not deepen:
                 cmd = ['git', 'rev-list', '--count', git_reference]
-                commit_depth = int(subprocess.check_output(cmd, cwd=target_dir))
+                base_commit_depth = int(subprocess.check_output(cmd, cwd=target_dir)) - 1
             cmd = ["git", "reset", "--hard", git_reference]
             logger.debug("Resetting current HEAD: '%s'", cmd)
             subprocess.check_call(cmd, cwd=target_dir)
@@ -307,7 +307,12 @@ def reset_git_repo(target_dir, git_reference, retry_depth=None):
     commit_id = commit_id.strip()
     logger.info("commit ID = %s", commit_id)
 
-    return commit_id, commit_depth
+    final_commit_depth = None
+    if not deepen:
+        cmd = ['git', 'rev-list', '--count', 'HEAD']
+        final_commit_depth = int(subprocess.check_output(cmd, cwd=target_dir)) - base_commit_depth
+
+    return commit_id, final_commit_depth
 
 
 @contextlib.contextmanager

--- a/tests/build_/test_arrangements.py
+++ b/tests/build_/test_arrangements.py
@@ -103,7 +103,7 @@ class ArrangementBase(object):
 
         (flexmock(utils)
             .should_receive('get_repo_info')
-            .with_args(TEST_GIT_URI, TEST_GIT_REF, git_branch=TEST_GIT_BRANCH)
+            .with_args(TEST_GIT_URI, TEST_GIT_REF, git_branch=TEST_GIT_BRANCH, depth=None)
             .and_return(RepoInfo(MockParser(), MockConfiguration())))
 
         # Trick create_orchestrator_build into return the *request* JSON

--- a/tests/build_/test_user_params.py
+++ b/tests/build_/test_user_params.py
@@ -253,3 +253,9 @@ class TestBuildUserParams(object):
         spec2 = BuildUserParams()
         spec2.from_json(spec.to_json())
         assert spec2.to_json() == json.dumps(expected_json, sort_keys=True)
+
+    def test_from_json_failure(self, caplog):
+        spec = BuildUserParams()
+        with pytest.raises(ValueError):
+            spec.from_json('{"this is not valid json": }')
+        assert 'failed to convert {"this is not valid json": }' in caplog.text

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -198,7 +198,7 @@ class TestOSBS(object):
     def test_create_build_with_deprecated_params(self, osbs):  # noqa
         (flexmock(utils)
             .should_receive('get_repo_info')
-            .with_args(TEST_GIT_URI, TEST_GIT_REF, git_branch=TEST_GIT_BRANCH)
+            .with_args(TEST_GIT_URI, TEST_GIT_REF, git_branch=TEST_GIT_BRANCH, depth=None)
             .and_return(self.mock_repo_info()))
 
         kwargs = {
@@ -233,7 +233,7 @@ class TestOSBS(object):
             baseimage = 'fedora23/python'
         (flexmock(utils)
             .should_receive('get_repo_info')
-            .with_args(TEST_GIT_URI, TEST_GIT_REF, git_branch=TEST_GIT_BRANCH)
+            .with_args(TEST_GIT_URI, TEST_GIT_REF, git_branch=TEST_GIT_BRANCH, depth=None)
             .and_return(self.mock_repo_info()))
         response = osbs.create_prod_build(TEST_GIT_URI, TEST_GIT_REF,
                                           TEST_GIT_BRANCH, TEST_USER,
@@ -252,7 +252,7 @@ class TestOSBS(object):
                                              outer_template, customize_conf, version):
         (flexmock(utils)
             .should_receive('get_repo_info')
-            .with_args(TEST_GIT_URI, TEST_GIT_REF, git_branch=TEST_GIT_BRANCH)
+            .with_args(TEST_GIT_URI, TEST_GIT_REF, git_branch=TEST_GIT_BRANCH, depth=None)
             .and_return(self.mock_repo_info()))
 
         (flexmock(osbs)
@@ -322,7 +322,7 @@ class TestOSBS(object):
 
         (flexmock(utils)
             .should_receive('get_repo_info')
-            .with_args(TEST_GIT_URI, TEST_GIT_REF, git_branch=TEST_GIT_BRANCH)
+            .with_args(TEST_GIT_URI, TEST_GIT_REF, git_branch=TEST_GIT_BRANCH, depth=None)
             .and_return(self.mock_repo_info()))
 
         (flexmock(osbs_obj.os)
@@ -365,7 +365,7 @@ class TestOSBS(object):
                                                raises_exception):
         (flexmock(utils)
             .should_receive('get_repo_info')
-            .with_args(TEST_GIT_URI, TEST_GIT_REF, git_branch=TEST_GIT_BRANCH)
+            .with_args(TEST_GIT_URI, TEST_GIT_REF, git_branch=TEST_GIT_BRANCH, depth=None)
             .and_return(self.mock_repo_info()))
 
         kwargs = {
@@ -508,7 +508,7 @@ class TestOSBS(object):
         """
         (flexmock(utils)
             .should_receive('get_repo_info')
-            .with_args(TEST_GIT_URI, TEST_GIT_REF, git_branch=TEST_GIT_BRANCH)
+            .with_args(TEST_GIT_URI, TEST_GIT_REF, git_branch=TEST_GIT_BRANCH, depth=None)
             .and_return(self.mock_repo_info()))
 
         invalid_version = INVALID_ARRANGEMENT_VERSION
@@ -548,7 +548,7 @@ class TestOSBS(object):
         """
         (flexmock(utils)
             .should_receive('get_repo_info')
-            .with_args(TEST_GIT_URI, TEST_GIT_REF, git_branch=TEST_GIT_BRANCH)
+            .with_args(TEST_GIT_URI, TEST_GIT_REF, git_branch=TEST_GIT_BRANCH, depth=None)
             .and_raise(IOError))
 
         with pytest.raises(OsbsException) as ex:
@@ -647,7 +647,7 @@ class TestOSBS(object):
         """
         (flexmock(utils)
             .should_receive('get_repo_info')
-            .with_args(TEST_GIT_URI, TEST_GIT_REF, git_branch=TEST_GIT_BRANCH)
+            .with_args(TEST_GIT_URI, TEST_GIT_REF, git_branch=TEST_GIT_BRANCH, depth=None)
             .and_return(self.mock_repo_info()))
 
         with pytest.raises(OsbsOrchestratorNotEnabled) as ex:
@@ -669,7 +669,7 @@ class TestOSBS(object):
         """
         (flexmock(utils)
             .should_receive('get_repo_info')
-            .with_args(TEST_GIT_URI, TEST_GIT_REF, git_branch=TEST_GIT_BRANCH)
+            .with_args(TEST_GIT_URI, TEST_GIT_REF, git_branch=TEST_GIT_BRANCH, depth=None)
             .and_return(self.mock_repo_info()))
 
         invalid_version = INVALID_ARRANGEMENT_VERSION
@@ -708,7 +708,7 @@ class TestOSBS(object):
             baseimage = 'fedora23/python'
         (flexmock(utils)
             .should_receive('get_repo_info')
-            .with_args(TEST_GIT_URI, TEST_GIT_REF, git_branch=TEST_GIT_BRANCH)
+            .with_args(TEST_GIT_URI, TEST_GIT_REF, git_branch=TEST_GIT_BRANCH, depth=None)
             .and_return(self.mock_repo_info(MockParser())))
         with pytest.raises(OsbsValidationException):
             osbs.create_prod_build(TEST_GIT_URI, TEST_GIT_REF,
@@ -728,7 +728,7 @@ class TestOSBS(object):
             baseimage = 'fedora23/python'
         (flexmock(utils)
             .should_receive('get_repo_info')
-            .with_args(TEST_GIT_URI, TEST_GIT_REF, git_branch=TEST_GIT_BRANCH)
+            .with_args(TEST_GIT_URI, TEST_GIT_REF, git_branch=TEST_GIT_BRANCH, depth=None)
             .and_return(self.mock_repo_info(MockParser())))
         with pytest.raises(OsbsValidationException):
             osbs.create_prod_build(TEST_GIT_URI, TEST_GIT_REF,
@@ -754,7 +754,7 @@ class TestOSBS(object):
             baseimage = 'fedora:25'
         (flexmock(utils)
             .should_receive('get_repo_info')
-            .with_args(TEST_GIT_URI, TEST_GIT_REF, git_branch=TEST_GIT_BRANCH)
+            .with_args(TEST_GIT_URI, TEST_GIT_REF, git_branch=TEST_GIT_BRANCH, depth=None)
             .and_return(self.mock_repo_info(MockParser())))
         create_build_args = {
             'git_uri': TEST_GIT_URI,
@@ -796,7 +796,7 @@ class TestOSBS(object):
             baseimage = 'fedora23/python'
         (flexmock(utils)
             .should_receive('get_repo_info')
-            .with_args(TEST_GIT_URI, TEST_GIT_REF, git_branch=TEST_GIT_BRANCH)
+            .with_args(TEST_GIT_URI, TEST_GIT_REF, git_branch=TEST_GIT_BRANCH, depth=None)
             .and_return(self.mock_repo_info()))
         flexmock(OSBS, _create_build_config_and_build=request_as_response)
         req = osbs.create_prod_build(TEST_GIT_URI, TEST_GIT_REF,
@@ -809,7 +809,7 @@ class TestOSBS(object):
     def test_missing_component_argument_doesnt_break_build(self, osbs):  # noqa
         (flexmock(utils)
             .should_receive('get_repo_info')
-            .with_args(TEST_GIT_URI, TEST_GIT_REF, git_branch=TEST_GIT_BRANCH)
+            .with_args(TEST_GIT_URI, TEST_GIT_REF, git_branch=TEST_GIT_BRANCH, depth=None)
             .and_return(self.mock_repo_info()))
         response = osbs.create_prod_build(TEST_GIT_URI, TEST_GIT_REF,
                                           TEST_GIT_BRANCH, TEST_USER)
@@ -819,7 +819,7 @@ class TestOSBS(object):
     def test_create_prod_build_set_required_version(self, osbs106):  # noqa
         (flexmock(utils)
             .should_receive('get_repo_info')
-            .with_args(TEST_GIT_URI, TEST_GIT_REF, git_branch=TEST_GIT_BRANCH)
+            .with_args(TEST_GIT_URI, TEST_GIT_REF, git_branch=TEST_GIT_BRANCH, depth=None)
             .and_return(self.mock_repo_info()))
         (flexmock(BuildRequest)
             .should_receive('set_openshift_required_version')
@@ -1210,7 +1210,7 @@ class TestOSBS(object):
 
         (flexmock(utils)
             .should_receive('get_repo_info')
-            .with_args(TEST_GIT_URI, TEST_GIT_REF, git_branch=TEST_GIT_BRANCH)
+            .with_args(TEST_GIT_URI, TEST_GIT_REF, git_branch=TEST_GIT_BRANCH, depth=None)
             .and_return(self.mock_repo_info()))
 
         flexmock(OSBS, _create_build_config_and_build=request_as_response)
@@ -1278,7 +1278,7 @@ class TestOSBS(object):
 
         (flexmock(utils)
             .should_receive('get_repo_info')
-            .with_args(TEST_GIT_URI, TEST_GIT_REF, git_branch=TEST_GIT_BRANCH)
+            .with_args(TEST_GIT_URI, TEST_GIT_REF, git_branch=TEST_GIT_BRANCH, depth=None)
             .and_return(self.mock_repo_info()))
 
         flexmock(OSBS, _create_build_config_and_build=request_as_response)
@@ -1841,7 +1841,7 @@ class TestOSBS(object):
     def test_create_build_flatpak(self, osbs, modules):
         (flexmock(utils)
             .should_receive('get_repo_info')
-            .with_args(TEST_GIT_URI, TEST_GIT_REF, git_branch=TEST_GIT_BRANCH)
+            .with_args(TEST_GIT_URI, TEST_GIT_REF, git_branch=TEST_GIT_BRANCH, depth=None)
             .and_return(self.mock_repo_info(mock_config=MockConfiguration(modules))))
 
         kwargs = {
@@ -2013,7 +2013,7 @@ class TestOSBS(object):
 
         (flexmock(utils)
             .should_receive('get_repo_info')
-            .with_args(TEST_GIT_URI, TEST_GIT_REF, git_branch=TEST_GIT_BRANCH)
+            .with_args(TEST_GIT_URI, TEST_GIT_REF, git_branch=TEST_GIT_BRANCH, depth=None)
             .and_return(self.mock_repo_info()))
 
         (flexmock(osbs_obj)
@@ -2065,7 +2065,7 @@ class TestOSBS(object):
 
         (flexmock(utils)
             .should_receive('get_repo_info')
-            .with_args(TEST_GIT_URI, TEST_GIT_REF, git_branch=TEST_GIT_BRANCH)
+            .with_args(TEST_GIT_URI, TEST_GIT_REF, git_branch=TEST_GIT_BRANCH, depth=None)
             .and_return(self.mock_repo_info()))
 
         if use_build:
@@ -2287,7 +2287,7 @@ class TestOSBS(object):
 
         (flexmock(utils)
             .should_receive('get_repo_info')
-            .with_args(TEST_GIT_URI, TEST_GIT_REF, git_branch=TEST_GIT_BRANCH)
+            .with_args(TEST_GIT_URI, TEST_GIT_REF, git_branch=TEST_GIT_BRANCH, depth=None)
             .and_return(self.mock_repo_info()))
 
         flexmock(OSBS, _create_build_config_and_build=request_as_response)
@@ -2452,7 +2452,7 @@ class TestOSBS(object):
 
         (flexmock(utils)
             .should_receive('get_repo_info')
-            .with_args(TEST_GIT_URI, TEST_GIT_REF, git_branch=TEST_GIT_BRANCH)
+            .with_args(TEST_GIT_URI, TEST_GIT_REF, git_branch=TEST_GIT_BRANCH, depth=None)
             .and_return(self.mock_repo_info(mock_config=MockConfiguration())))
 
         args = MockArgs(isolated)
@@ -2486,7 +2486,7 @@ class TestOSBS(object):
     def test_do_create_prod_build_branch_required(self, osbs, branch_name):
         (flexmock(utils)
             .should_receive('get_repo_info')
-            .with_args(TEST_GIT_URI, TEST_GIT_REF, git_branch=branch_name)
+            .with_args(TEST_GIT_URI, TEST_GIT_REF, git_branch=branch_name, depth=None)
             .and_return(self.mock_repo_info()))
 
         inner_template = DEFAULT_INNER_TEMPLATE
@@ -2870,7 +2870,7 @@ class TestOSBS(object):
 
         (flexmock(utils)
             .should_receive('get_repo_info')
-            .with_args(TEST_GIT_URI, TEST_GIT_REF, git_branch=TEST_GIT_BRANCH)
+            .with_args(TEST_GIT_URI, TEST_GIT_REF, git_branch=TEST_GIT_BRANCH, depth=None)
             .and_return(self.mock_repo_info(mock_df_parser=mocked_df_parser)))
 
         flexmock(OSBS, _create_build_config_and_build=request_as_response)
@@ -2890,7 +2890,7 @@ class TestOSBS(object):
     def test_do_create_prod_build_isolated_from_scratch(self, osbs):  # noqa
         (flexmock(utils)
          .should_receive('get_repo_info')
-         .with_args(TEST_GIT_URI, TEST_GIT_REF, git_branch=TEST_GIT_BRANCH)
+         .with_args(TEST_GIT_URI, TEST_GIT_REF, git_branch=TEST_GIT_BRANCH, depth=None)
          .and_return(self.mock_repo_info(mock_df_parser=MockDfParserFromScratch())))
 
         inner_template = DEFAULT_INNER_TEMPLATE
@@ -2925,7 +2925,7 @@ class TestOSBS(object):
 
         (flexmock(utils)
          .should_receive('get_repo_info')
-         .with_args(TEST_GIT_URI, TEST_GIT_REF, git_branch=TEST_GIT_BRANCH)
+         .with_args(TEST_GIT_URI, TEST_GIT_REF, git_branch=TEST_GIT_BRANCH, depth=None)
          .and_return(self.mock_repo_info(mock_df_parser=MockDfParserNoDf(),
                                          mock_config=MockConfiguration())))
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -552,6 +552,16 @@ def test_clone_git_repo(tmpdir, commit, branch, depth):
     assert os.path.isdir(os.path.join(tmpdir_path, '.git'))
 
 
+@requires_internet
+def test_calc_depth_git_repo(tmpdir):
+    tmpdir_path = str(tmpdir.realpath())
+    repo_data = clone_git_repo(TEST_DOCKERFILE_GIT, tmpdir_path, commit='HEAD',
+                               branch='master', depth=None)
+    assert repo_data.commit_id is not None
+    assert tmpdir_path == repo_data.repo_path
+    assert repo_data.commit_depth == 1
+
+
 @pytest.mark.parametrize(('commit', 'branch', 'depth'), [
     ("bad", None, None),
     ("bad", TEST_DOCKERFILE_BRANCH, 1),


### PR DESCRIPTION
Reduce the amount of load on the git servers:
* Pass the git repo configuration information (container.yaml, additional tags, and such) to atomic reactor as part of the user parameters of the build JSON, so that atomic reactor doesn't need to reclone the repo to get that information.
* Refactor plugins configuration slightly so that the additional tags for `tag_from_config` are taken from the build configuration, instead of recloning the git repo
* Calculate the depth of the commit when cloning the repo for the first time, and pass that information to as part of the git repo configuration information.  Subsequent clones of the repo clone (for worker builds, etc) clone using --depth, dramatically reducing the amount of data that needs to be transferred.

Atomic reactor will need changes to take advantage of this work.