### PR TITLE
utils: refactor git clone operations to share code with atomic-reactor

### DIFF
--- a/osbs/constants.py
+++ b/osbs/constants.py
@@ -118,3 +118,7 @@ GIT_MAX_RETRIES = 3
 
 # backoff factor for git clone operations - exponential backoff in seconds
 GIT_BACKOFF_FACTOR = 60
+
+# number of deepen operations to attempt if a requested commit is not
+# in the shallow depth of the original clone
+GIT_FETCH_RETRY = 9

--- a/osbs/repo_utils.py
+++ b/osbs/repo_utils.py
@@ -43,10 +43,11 @@ class RepoConfiguration(object):
         enabled = false
         """)
 
-    def __init__(self, dir_path='', file_name=REPO_CONFIG_FILE):
+    def __init__(self, dir_path='', file_name=REPO_CONFIG_FILE, depth=None):
 
         self._config_parser = ConfigParser()
         self.container = {}
+        self.depth = depth or 0
 
         # Set default options
         self._config_parser.readfp(StringIO(self.DEFAULT_CONFIG))

--- a/tests/build_/test_arrangements.py
+++ b/tests/build_/test_arrangements.py
@@ -96,6 +96,7 @@ class ArrangementBase(object):
 
             module = container['compose']['modules'][0]
             container_module_specs = [ModuleSpec.from_str(module)]
+            depth = 0
 
             def is_autorebuild_enabled(self):
                 return False

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -37,6 +37,10 @@ TEST_LABEL = "test-label"
 TEST_LABEL_VALUE = "sample-value"
 TEST_KOJI_TASK_ID = 12345
 TEST_FILESYSTEM_KOJI_TASK_ID = 67890
+TEST_DOCKERFILE_GIT = "https://github.com/TomasTomecek/docker-hello-world.git"
+TEST_DOCKERFILE_SHA1 = "6e592f1420efcd331cd28b360a7e02f669caf540"
+TEST_DOCKERFILE_INIT_SHA1 = "04523782eeb1e6c960b12f2f6fc887aa7cf76290"
+TEST_DOCKERFILE_BRANCH = "error-build"
 
 TEST_FLATPAK_BASE_IMAGE = 'registry.fedoraproject.org/fedora:latest'
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -119,6 +119,7 @@ class MockConfiguration(object):
         self.container = {'compose': {'modules': modules}}
         safe_modules = modules or []
         self.container_module_specs = [ModuleSpec.from_str(module) for module in safe_modules]
+        self.depth = 0
 
     def is_autorebuild_enabled(self):
         return False
@@ -144,7 +145,8 @@ class TestOSBS(object):
 
     def mock_repo_info(self, mock_df_parser=None, mock_config=None):
         mock_df_parser = mock_df_parser or MockDfParser()
-        return RepoInfo(mock_df_parser, mock_config)
+        config = mock_config or MockConfiguration()
+        return RepoInfo(mock_df_parser, config)
 
     def test_osbsapi_wrapper(self):
         """


### PR DESCRIPTION
merge the logic of atomic-reactor's clone_git_repo with osbs-client's
checkout_git_repo while adding support for passing depth values to
both and performing shallow clone operations if possible.

Signed-off-by: Mark Langsdorf <mlangsdo@redhat.com>