### PR TITLE
run remove_worker_metadata for scratch, so it cleans config-maps from…

### DIFF
--- a/osbs/build/plugins_configuration.py
+++ b/osbs/build/plugins_configuration.py
@@ -161,7 +161,6 @@ class PluginsConfiguration(object):
                 ("postbuild_plugins", "import_image"),
                 ("exit_plugins", "koji_promote"),
                 ("exit_plugins", "koji_tag_build"),
-                ("exit_plugins", "remove_worker_metadata"),
                 ("exit_plugins", "import_image"),
                 ("prebuild_plugins", "check_and_set_rebuild"),
                 ("prebuild_plugins", "stop_autorebuild_if_disabled")

--- a/tests/build_/test_plugins_configuration.py
+++ b/tests/build_/test_plugins_configuration.py
@@ -817,7 +817,6 @@ class TestPluginsConfiguration(object):
             ("postbuild_plugins", "import_image"),
             ("exit_plugins", "koji_promote"),
             ("exit_plugins", "koji_tag_build"),
-            ("exit_plugins", "remove_worker_metadata"),
             ("exit_plugins", "import_image"),
             ("prebuild_plugins", "check_and_set_rebuild"),
             ("prebuild_plugins", "stop_autorebuild_if_disabled")


### PR DESCRIPTION
… workers

* OSBS-7243

Signed-off-by: Robert Cerven <rcerven@redhat.com>