### PR TITLE
Fix py2/3 compatibility issues

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -39,12 +39,8 @@ disable=I,
         exception-escape, # throws false positives on 1.9.0 (Fedora 29)
         dangerous-default-value,  # should be enabled
         deprecated-method,  # should be enabled
-        dict-keys-not-iterating,  # py2/3 compatibility
-        eq-without-hash,  # py2/3 compatibility
         empty-docstring,  # should be enabled
-        exception-message-attribute,  # py2/3 compatibility
         fixme,
-        input-builtin,  # py2/3 compatibility
         invalid-name,
         keyword-arg-before-vararg,  # nice to have
         len-as-condition,  # nice to have
@@ -53,18 +49,10 @@ disable=I,
         logging-not-lazy,  # should be enabled
         missing-docstring,
         misplaced-comparison-constant,
-        next-method-called,  # py2/3 compatibility
-        next-method-defined,  # py2/3 compatibility
-        no-absolute-import,  # py2/3 compatibility
         no-init,
-        old-division,  # py2/3 compatibility
-        old-style-class,  # py2/3 compatibility
         pointless-statement,  # should be enabled
-        print-statement,  # py2/3 compatibility
         protected-access,
         raising-format-tuple,  # should be enabled
-        range-builtin-not-iterating,  # py2/3 compatibility
-        raw_input-builtin,  # py2/3 compatibility
         redefined-builtin,  # should be enabled
         redefined-outer-name,  # nice to have
         relative-import,  # nice to have

--- a/osbs/api.py
+++ b/osbs/api.py
@@ -43,7 +43,7 @@ from osbs import utils
 from osbs.utils import (retry_on_conflict, graceful_chain_get, RegistryURI,
                         strip_registry_and_tag_from_image)
 
-from six.moves import http_client
+from six.moves import http_client, input
 
 
 # Decorator for API methods.
@@ -1068,10 +1068,7 @@ class OSBS(object):
             if username:
                 self.os.username = username
             else:
-                try:
-                    self.os.username = raw_input("Username: ")
-                except NameError:
-                    self.os.username = input("Username: ")
+                self.os.username = input("Username: ")
 
             if password:
                 self.os.password = password

--- a/osbs/build/user_params.py
+++ b/osbs/build/user_params.py
@@ -189,5 +189,5 @@ class BuildUserParams(BuildCommon):
         return retdict
 
     def to_json(self):
-        json_dict = self.to_dict(self.convert_dict.keys())
+        json_dict = self.to_dict(list(self.convert_dict))
         return json.dumps(json_dict, sort_keys=True)

--- a/osbs/cli/main.py
+++ b/osbs/cli/main.py
@@ -867,14 +867,13 @@ def main():
             raise
         else:
             logger.error("Network error at %s (%d): %s",
-                         ex.url, ex.status_code, ex.message)
+                         ex.url, ex.status_code, ex)
             return -1
     except OsbsAuthException as ex:
         if is_verbose:
             raise
         else:
-            logger.error("Authentication failure: %s",
-                         ex.message)
+            logger.error("Authentication failure: %s", ex)
             return -1
     except OsbsResponseException as ex:
         if is_verbose:
@@ -883,7 +882,7 @@ def main():
             if isinstance(ex.json, dict) and 'message' in ex.json:
                 msg = ex.json['message']
             else:
-                msg = ex.message
+                msg = str(ex)
             logger.error("Server returned error %s: %s", ex.status_code, msg)
             return -1
     except Exception as ex:  # pylint: disable=broad-except

--- a/osbs/core.py
+++ b/osbs/core.py
@@ -5,7 +5,7 @@ All rights reserved.
 This software may be modified and distributed under the terms
 of the BSD license. See the LICENSE file for details.
 """
-from __future__ import print_function, unicode_literals, absolute_import
+from __future__ import print_function, unicode_literals, absolute_import, division
 import json
 import os
 import numbers
@@ -40,10 +40,10 @@ logger = logging.getLogger(__name__)
 # Retry each connection attempt after 30 seconds, for a maximum of 10 times
 WATCH_RETRY_SECS = 30
 WATCH_RETRY = 10
-MAX_BAD_RESPONSES = int(WATCH_RETRY / 3)
+MAX_BAD_RESPONSES = WATCH_RETRY // 3
 # Give up after 12 hours
 WAIT_RETRY_HOURS = 12
-WAIT_RETRY = int(WAIT_RETRY_HOURS * 3600 / (WATCH_RETRY_SECS * WATCH_RETRY))
+WAIT_RETRY = WAIT_RETRY_HOURS * 3600 // (WATCH_RETRY_SECS * WATCH_RETRY)
 
 
 def check_response(response, log_level=logging.ERROR):

--- a/osbs/repo_utils.py
+++ b/osbs/repo_utils.py
@@ -115,6 +115,8 @@ class ModuleSpec(object):
     def __eq__(self, other):
         return self.__dict__ == other.__dict__
 
+    __hash__ = None     # py2 compatibility
+
     @classmethod
     def from_str(cls, text):
         profile = None

--- a/osbs/repo_utils.py
+++ b/osbs/repo_utils.py
@@ -7,6 +7,8 @@ of the BSD license. See the LICENSE file for details.
 """
 
 
+from __future__ import absolute_import
+
 from osbs.constants import REPO_CONFIG_FILE, ADDITIONAL_TAGS_FILE, REPO_CONTAINER_CONFIG
 from six import StringIO
 from six.moves.configparser import ConfigParser

--- a/osbs/utils.py
+++ b/osbs/utils.py
@@ -115,16 +115,15 @@ class TarReader(object):
         return self
 
     def __next__(self):
-        return self.next()
-
-    def next(self):
-        ti = self.tarfile.next()
+        ti = self.tarfile.next()    # pylint: disable=next-method-called
 
         if ti is None:
             self.close()
             raise StopIteration()
 
         return self.TarFile(ti.name, self.tarfile.extractfile(ti))
+
+    next = __next__     # py2 compatibility
 
     def close(self):
         self.tarfile.close()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,6 +5,8 @@ All rights reserved.
 This software may be modified and distributed under the terms
 of the BSD license. See the LICENSE file for details.
 """
+from __future__ import absolute_import
+
 import logging
 from osbs import set_logging
 set_logging(name="osbs.tests", level=logging.DEBUG)

--- a/tests/build_/test_arrangements.py
+++ b/tests/build_/test_arrangements.py
@@ -6,7 +6,7 @@ This software may be modified and distributed under the terms
 of the BSD license. See the LICENSE file for details.
 """
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, absolute_import
 import shutil
 import os
 import json

--- a/tests/build_/test_build_request.py
+++ b/tests/build_/test_build_request.py
@@ -5,7 +5,7 @@ All rights reserved.
 This software may be modified and distributed under the terms
 of the BSD license. See the LICENSE file for details.
 """
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 
 import copy
 import glob

--- a/tests/build_/test_build_request.py
+++ b/tests/build_/test_build_request.py
@@ -966,7 +966,8 @@ class TestBuildRequest(object):
         ['v2'],
     ])
     @pytest.mark.parametrize('platform', [None, 'x86_64'])
-    @pytest.mark.parametrize('arrangement_version', range(3, TEST_ARRANGEMENT_VERSION + 1))
+    @pytest.mark.parametrize('arrangement_version',
+                             list(range(3, TEST_ARRANGEMENT_VERSION + 1)))
     @pytest.mark.parametrize('scratch', [False, True])
     def test_render_prod_request_v1_v2(self, registry_api_versions, platform, arrangement_version,
                                        scratch):
@@ -1628,7 +1629,7 @@ class TestBuildRequest(object):
         (None, None, True),
     ))
     @pytest.mark.parametrize('arrangement_version',
-                             range(3, TEST_ARRANGEMENT_VERSION + 1))
+                             list(range(3, TEST_ARRANGEMENT_VERSION + 1)))
     @pytest.mark.parametrize(('build_from', 'build_image', 'build_imagestream',
                               'worker_build_image', 'valid'), (
 

--- a/tests/build_/test_build_request.py
+++ b/tests/build_/test_build_request.py
@@ -5,6 +5,8 @@ All rights reserved.
 This software may be modified and distributed under the terms
 of the BSD license. See the LICENSE file for details.
 """
+from __future__ import absolute_import
+
 import copy
 import glob
 import json

--- a/tests/build_/test_build_requestv2.py
+++ b/tests/build_/test_build_requestv2.py
@@ -5,6 +5,8 @@ All rights reserved.
 This software may be modified and distributed under the terms
 of the BSD license. See the LICENSE file for details.
 """
+from __future__ import absolute_import
+
 import copy
 import glob
 import json

--- a/tests/build_/test_build_response.py
+++ b/tests/build_/test_build_response.py
@@ -5,6 +5,8 @@ All rights reserved.
 This software may be modified and distributed under the terms
 of the BSD license. See the LICENSE file for details.
 """
+from __future__ import absolute_import
+
 import json
 import pytest
 from osbs.build.build_response import BuildResponse

--- a/tests/build_/test_build_response.py
+++ b/tests/build_/test_build_response.py
@@ -105,7 +105,7 @@ class TestBuildResponse(object):
          "Error in pod: OSBS unavailable; Pod related errors cannot be retrieved"),
     ])
     def test_error_message(self, osbs, pod, plugin, message, expected_error_message):
-        class MockOsbsPod:
+        class MockOsbsPod(object):
             def __init__(self, error):
                 self.error = error
 

--- a/tests/build_/test_manipulate.py
+++ b/tests/build_/test_manipulate.py
@@ -5,6 +5,8 @@ All rights reserved.
 This software may be modified and distributed under the terms
 of the BSD license. See the LICENSE file for details.
 """
+from __future__ import absolute_import
+
 import copy
 import json
 

--- a/tests/build_/test_plugins_configuration.py
+++ b/tests/build_/test_plugins_configuration.py
@@ -5,6 +5,8 @@ All rights reserved.
 This software may be modified and distributed under the terms
 of the BSD license. See the LICENSE file for details.
 """
+from __future__ import absolute_import
+
 import json
 from flexmock import flexmock
 

--- a/tests/build_/test_pod_response.py
+++ b/tests/build_/test_pod_response.py
@@ -6,7 +6,7 @@ This software may be modified and distributed under the terms
 of the BSD license. See the LICENSE file for details.
 """
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, absolute_import
 
 from copy import deepcopy
 import pytest

--- a/tests/build_/test_spec.py
+++ b/tests/build_/test_spec.py
@@ -5,6 +5,8 @@ All rights reserved.
 This software may be modified and distributed under the terms
 of the BSD license. See the LICENSE file for details.
 """
+from __future__ import absolute_import
+
 import pytest
 import datetime
 import random

--- a/tests/build_/test_user_params.py
+++ b/tests/build_/test_user_params.py
@@ -5,6 +5,8 @@ All rights reserved.
 This software may be modified and distributed under the terms
 of the BSD license. See the LICENSE file for details.
 """
+from __future__ import absolute_import
+
 import pytest
 from flexmock import flexmock
 

--- a/tests/cli/test_capture.py
+++ b/tests/cli/test_capture.py
@@ -6,6 +6,8 @@ This software may be modified and distributed under the terms
 of the BSD license. See the LICENSE file for details.
 """
 
+from __future__ import absolute_import
+
 import json
 import os
 import pytest

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -300,7 +300,7 @@ class TestOSBS(object):
         def inspect_build_request(name, br):
             assert 'koji-task-id' not in json.loads(br)['metadata']['labels']
 
-            class Response:
+            class Response(object):
                 def __init__(self, br):
                     self.br = br
 
@@ -311,7 +311,7 @@ class TestOSBS(object):
 
         def mock_start_build(name):
 
-            class Response:
+            class Response(object):
                 def json(self):
                     return ''
 
@@ -969,7 +969,7 @@ class TestOSBS(object):
             .with_args(osbs.os_conf.conf_section)
             .and_return(token_file_path))
 
-        class TestResponse:
+        class TestResponse(object):
             status_code = http_client.UNAUTHORIZED
 
         if not token:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -6,6 +6,8 @@ All rights reserved.
 This software may be modified and distributed under the terms
 of the BSD license. See the LICENSE file for details.
 """
+from __future__ import absolute_import
+
 from types import GeneratorType
 
 from flexmock import flexmock, MethodCallError

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -55,6 +55,8 @@ from tests.constants import (TEST_ARCH, TEST_BUILD, TEST_COMPONENT, TEST_GIT_BRA
                              TEST_KOJI_TASK_ID, TEST_FILESYSTEM_KOJI_TASK_ID, TEST_VERSION,
                              TEST_ORCHESTRATOR_BUILD)
 from osbs.core import Openshift
+# needed for mocking input() (because it is imported from six)
+from osbs import api as _osbs_api
 # These are used as fixtures
 from tests.fake_api import openshift, osbs, osbs106, osbs_cant_orchestrate  # noqa
 from six.moves import http_client
@@ -983,15 +985,8 @@ class TestOSBS(object):
                     .once()
                     .and_return("password"))
             if not username:
-                if six.PY2:
-                    builtin = '__builtin__'
-                    input_str = 'raw_input'
-                else:
-                    builtin = 'builtins'
-                    input_str = 'input'
-
-                (flexmock(sys.modules[builtin])
-                    .should_receive(input_str)
+                (flexmock(_osbs_api)
+                    .should_receive('input')
                     .once()
                     .and_return('username'))
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,8 @@ All rights reserved.
 This software may be modified and distributed under the terms
 of the BSD license. See the LICENSE file for details.
 """
+from __future__ import absolute_import
+
 import pytest
 import sys
 

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -6,6 +6,8 @@ This software may be modified and distributed under the terms
 of the BSD license. See the LICENSE file for details.
 """
 
+from __future__ import absolute_import
+
 from contextlib import contextmanager
 from flexmock import flexmock
 import argparse

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6,6 +6,8 @@ All rights reserved.
 This software may be modified and distributed under the terms
 of the BSD license. See the LICENSE file for details.
 """
+from __future__ import absolute_import
+
 from copy import deepcopy
 from flexmock import flexmock
 from textwrap import dedent

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -5,6 +5,8 @@ All rights reserved.
 This software may be modified and distributed under the terms
 of the BSD license. See the LICENSE file for details.
 """
+from __future__ import absolute_import
+
 import logging
 
 from flexmock import flexmock

--- a/tests/test_osbs.py
+++ b/tests/test_osbs.py
@@ -5,7 +5,7 @@ All rights reserved.
 This software may be modified and distributed under the terms
 of the BSD license. See the LICENSE file for details.
 """
-from __future__ import print_function, unicode_literals
+from __future__ import print_function, unicode_literals, absolute_import
 
 import os
 import re

--- a/tests/test_repo_utils.py
+++ b/tests/test_repo_utils.py
@@ -6,6 +6,8 @@ This software may be modified and distributed under the terms
 of the BSD license. See the LICENSE file for details.
 """
 
+from __future__ import absolute_import
+
 from flexmock import flexmock
 from osbs.constants import REPO_CONFIG_FILE, ADDITIONAL_TAGS_FILE, REPO_CONTAINER_CONFIG
 from osbs.repo_utils import RepoInfo, RepoConfiguration, AdditionalTagsConfig, ModuleSpec

--- a/tests/test_retries.py
+++ b/tests/test_retries.py
@@ -8,6 +8,8 @@ of the BSD license. See the LICENSE file for details.
 
 These tests are moved to a separate file due to https://github.com/bkabrda/flexmock/issues/13
 """
+from __future__ import absolute_import
+
 import logging
 
 from flexmock import flexmock

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,6 +5,8 @@ All rights reserved.
 This software may be modified and distributed under the terms
 of the BSD license. See the LICENSE file for details.
 """
+from __future__ import absolute_import
+
 from flexmock import flexmock
 import os
 import os.path

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -630,3 +630,5 @@ class JsonMatcher(object):
         # Assert to provide a more meaningful error
         assert self.expected == json.loads(json_str)
         return self.expected == json.loads(json_str)
+
+    __hash__ = None     # py2 compatibility

--- a/tests/throughput-test-harness.py
+++ b/tests/throughput-test-harness.py
@@ -1,5 +1,7 @@
 #!/usr/bin/python
 
+from __future__ import absolute_import
+
 import re
 import sys
 import time


### PR DESCRIPTION
You don't want to know how long it took me to figure out why `from six.moves import input` broke tests.