### PR TITLE
schemas/container.json: add a new compose: module_resolve_tags key

### DIFF
--- a/osbs/schemas/container.json
+++ b/osbs/schemas/container.json
@@ -159,6 +159,17 @@
               ]
           }
         },
+        "module_resolve_tags": {
+          "description": "Koji tags to use to resolve partially specified modules from the modules list. If True is used, tag from koji target will be used",
+          "type": ["array", "null", "boolean"],
+          "items": {
+              "type": "string",
+              "examples": [
+                "f30-modules",
+                "rhel-8.2.1-modules"
+              ]
+          }
+        },
         "build_only_content_sets": {
           "desription": "Content sets used only for building content, not for distribution",
           "type": ["object", "null"],


### PR DESCRIPTION
The module_resolve_tags key specifies that modules that are incompletely
specified (name:stream, not name:stream:version:context) are looked up
in the given set of Koji tags, rather than using the latest built
version in MBS.

* CLOUDBLD-4225

Signed-off-by: Owen W. Taylor <otaylor@fishsoup.net>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
