### PR TITLE
PyYAML 6.0 doesn't support py2

### DIFF
--- a/requirements-py2.txt
+++ b/requirements-py2.txt
@@ -3,4 +3,4 @@ jsonschema==2.3.0  # to match available in RHEL/CentOS 7
 requests
 requests-kerberos
 six
-PyYAML
+PyYAML<6


### PR DESCRIPTION
Freeze to PyYAML<6

Signed-off-by: Martin Basti <mbasti@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
