### PR TITLE
fix: fetch final_platfrom from multiple tasks

### DIFF
--- a/osbs/tekton.py
+++ b/osbs/tekton.py
@@ -570,12 +570,17 @@ class PipelineRun():
 
         task_results = self.get_task_results()
 
-        if 'binary-container-prebuild' not in task_results:
-            return None
+        if 'binary-container-prebuild' in task_results:
+            if 'platforms_result' in task_results['binary-container-prebuild']:
+                platforms = json.loads(
+                    task_results['binary-container-prebuild']['platforms_result'])
+                return platforms['platforms']
 
-        if 'platforms_result' in task_results['binary-container-prebuild']:
-            platforms = json.loads(task_results['binary-container-prebuild']['platforms_result'])
-            return platforms['platforms']
+        if 'binary-container-init' in task_results:
+            if 'platforms_result' in task_results['binary-container-init']:
+                platforms = json.loads(
+                    task_results['binary-container-init']['platforms_result'])
+                return platforms['platforms']
 
         return None
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1066,7 +1066,11 @@ class TestOSBS(object):
     @pytest.mark.parametrize('platforms_result', [
         '{"platforms": ["x86_64", "ppc64le"]}',
     ])
-    def test_get_final_platforms(self, osbs_binary, platforms_result):
+    @pytest.mark.parametrize('task', [
+        'binary-container-prebuild',
+        'binary-container-init',
+    ])
+    def test_get_final_platforms(self, osbs_binary, platforms_result, task):
         taskstatus = {'conditions': [{'reason': 'Succeeded'}],
                       'taskResults': [{'name': 'platforms_result',
                                        'value': platforms_result}],
@@ -1074,7 +1078,7 @@ class TestOSBS(object):
         childrefs = [{'name': 'task_run_name', 'kind': 'TaskRun'}]
 
         resp1 = {'metadata': {'name': 'run_name'}, 'status': {'childReferences': childrefs}}
-        resp2 = {'metadata': {'labels': {'tekton.dev/pipelineTask': 'binary-container-prebuild'}},
+        resp2 = {'metadata': {'labels': {'tekton.dev/pipelineTask': task}},
                  'status': taskstatus}
 
         flexmock(PipelineRun).should_receive('get_info').and_return(resp1)


### PR DESCRIPTION
With Hemeto introduction to OSBS, flatforms are provided by binary-container-init task

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
